### PR TITLE
feat(phase-3): Plan 3.1 — Fact Tables for analytics layer

### DIFF
--- a/apps/flink-jobs/build.gradle.kts
+++ b/apps/flink-jobs/build.gradle.kts
@@ -32,7 +32,9 @@ dependencies {
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.assertj.core)
     testImplementation(libs.mockito.core)
 }

--- a/apps/flink-jobs/build.gradle.kts
+++ b/apps/flink-jobs/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(libs.flink.avro)
     implementation(libs.flink.avro.confluent.registry)
     implementation(libs.flink.table.common)
+    implementation(libs.flink.table.api.bridge)
+    compileOnly(libs.flink.table.planner)
     implementation(libs.iceberg.flink.runtime)
     implementation(libs.opensearch.java)
     implementation(libs.httpclient5)
@@ -39,5 +41,6 @@ tasks.shadowJar {
     archiveBaseName.set("stablepay-flink-jobs")
     archiveClassifier.set("")
     archiveVersion.set("")
+    isZip64 = true
     mergeServiceFiles()
 }

--- a/apps/flink-jobs/build.gradle.kts
+++ b/apps/flink-jobs/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.flink.avro.confluent.registry)
     implementation(libs.flink.table.common)
     implementation(libs.flink.table.api.bridge)
-    compileOnly(libs.flink.table.planner)
+    runtimeOnly(libs.flink.table.planner)
     implementation(libs.iceberg.flink.runtime)
     implementation(libs.opensearch.java)
     implementation(libs.httpclient5)

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
@@ -1,7 +1,6 @@
 package io.stablepay.flink;
 
-import java.util.Map;
-
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
@@ -14,6 +13,7 @@ public class FactFlowsMergeJob {
 
     public static void main(String[] args) throws Exception {
         var env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         var tableEnv = StreamTableEnvironment.create(env);
 
         var factSinkFactory = new FactTableSinkFactory();
@@ -21,155 +21,164 @@ public class FactFlowsMergeJob {
 
         registerIcebergCatalog(tableEnv);
 
-        log.info("Executing MERGE INTO facts.fact_flows from raw tables");
-        tableEnv.executeSql(buildMergeSql());
-        log.info("MERGE INTO facts.fact_flows completed");
+        log.info("Executing INSERT OVERWRITE facts.fact_flows from raw tables");
+        tableEnv.executeSql(buildInsertOverwriteSql());
+        log.info("INSERT OVERWRITE facts.fact_flows completed");
     }
 
     private static void registerIcebergCatalog(StreamTableEnvironment tableEnv) {
         var props = IcebergCatalogConfig.catalogProperties();
-        tableEnv.executeSql(String.format(
-                "CREATE CATALOG %s WITH ("
+        var sql = "CREATE CATALOG " + IcebergCatalogConfig.CATALOG_NAME + " WITH ("
                 + "'type'='iceberg',"
                 + "'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',"
-                + "'uri'='%s',"
-                + "'jdbc.user'='%s',"
-                + "'jdbc.password'='%s',"
-                + "'warehouse'='%s',"
-                + "'io-impl'='%s',"
-                + "'s3.endpoint'='%s',"
-                + "'s3.access-key-id'='%s',"
-                + "'s3.secret-access-key'='%s',"
+                + "'uri'='" + escapeSql(props.get("uri")) + "',"
+                + "'jdbc.user'='" + escapeSql(props.get("jdbc.user")) + "',"
+                + "'jdbc.password'='" + escapeSql(props.get("jdbc.password")) + "',"
+                + "'warehouse'='" + escapeSql(props.get("warehouse")) + "',"
+                + "'io-impl'='" + escapeSql(props.get("io-impl")) + "',"
+                + "'s3.endpoint'='" + escapeSql(props.get("s3.endpoint")) + "',"
+                + "'s3.access-key-id'='" + escapeSql(props.get("s3.access-key-id")) + "',"
+                + "'s3.secret-access-key'='" + escapeSql(props.get("s3.secret-access-key")) + "',"
                 + "'s3.path-style-access'='true'"
-                + ")",
-                IcebergCatalogConfig.CATALOG_NAME,
-                props.get("uri"),
-                props.get("jdbc.user"),
-                props.get("jdbc.password"),
-                props.get("warehouse"),
-                props.get("io-impl"),
-                props.get("s3.endpoint"),
-                props.get("s3.access-key-id"),
-                props.get("s3.secret-access-key")));
+                + ")";
 
+        tableEnv.executeSql(sql);
         tableEnv.executeSql("USE CATALOG " + IcebergCatalogConfig.CATALOG_NAME);
     }
 
-    private static String buildMergeSql() {
+    static String escapeSql(String value) {
+        return value != null ? value.replace("'", "''") : "";
+    }
+
+    static String buildInsertOverwriteSql() {
         return """
-                MERGE INTO facts.fact_flows AS t
-                USING (
+                INSERT OVERWRITE facts.fact_flows
+                SELECT
+                    f.flow_id,
+                    f.customer_id,
+                    f.flow_type,
+                    f.flow_status,
+                    aggs.initiated_at,
+                    aggs.completed_at,
+                    aggs.last_updated_at,
+                    pi.payin_status,
+                    pi.payin_amount_micros,
+                    pi.payin_currency,
+                    pi.payin_reference,
+                    tr.trade_status,
+                    tr.trade_amount_micros,
+                    tr.trade_currency,
+                    po.payout_status,
+                    po.payout_amount_micros,
+                    po.payout_currency,
+                    po.payout_reference,
+                    CASE WHEN aggs.completed_at IS NOT NULL
+                         THEN TIMESTAMPDIFF(SECOND, aggs.initiated_at, aggs.completed_at) * 1000
+                         ELSE NULL END,
+                    f.leg_count
+                FROM (
+                    SELECT flow_id, customer_id, flow_type, flow_status, leg_count
+                    FROM (
+                        SELECT
+                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                            JSON_VALUE(payload_json, '$.customer_id') AS customer_id,
+                            JSON_VALUE(payload_json, '$.flow_type') AS flow_type,
+                            JSON_VALUE(payload_json, '$.flow_status') AS flow_status,
+                            CAST(JSON_VALUE(payload_json, '$.leg_count') AS INT) AS leg_count,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY JSON_VALUE(payload_json, '$.flow_id')
+                                ORDER BY event_time DESC
+                            ) AS rn
+                        FROM raw.raw_payment_flow
+                    ) WHERE rn = 1
+                ) f
+                JOIN (
                     SELECT
-                        f.flow_id,
-                        f.customer_id,
-                        f.flow_type,
-                        f.flow_status,
-                        f.initiated_at,
-                        f.completed_at,
-                        f.last_updated_at,
-                        pi.payin_status,
-                        pi.payin_amount_micros,
-                        pi.payin_currency,
-                        pi.payin_reference,
-                        tr.trade_status,
-                        tr.trade_amount_micros,
-                        tr.trade_currency,
-                        po.payout_status,
-                        po.payout_amount_micros,
-                        po.payout_currency,
-                        po.payout_reference,
-                        CASE WHEN f.completed_at IS NOT NULL AND f.initiated_at IS NOT NULL
-                             THEN TIMESTAMPDIFF(SECOND, f.initiated_at, f.completed_at) * 1000
-                             ELSE NULL END AS total_duration_ms,
-                        f.leg_count
+                        JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                        MIN(event_time) AS initiated_at,
+                        MAX(CASE WHEN JSON_VALUE(payload_json, '$.flow_status') = 'COMPLETED'
+                                 THEN event_time END) AS completed_at,
+                        MAX(event_time) AS last_updated_at
+                    FROM raw.raw_payment_flow
+                    GROUP BY JSON_VALUE(payload_json, '$.flow_id')
+                ) aggs ON f.flow_id = aggs.flow_id
+                LEFT JOIN (
+                    SELECT flow_id, payin_status, payin_amount_micros, payin_currency, payin_reference
                     FROM (
                         SELECT
                             flow_id,
-                            LAST_VALUE(customer_id) AS customer_id,
-                            LAST_VALUE(flow_type) AS flow_type,
-                            LAST_VALUE(flow_status) AS flow_status,
-                            MIN(event_time) AS initiated_at,
-                            MAX(CASE WHEN flow_status = 'COMPLETED' THEN event_time ELSE NULL END) AS completed_at,
-                            MAX(event_time) AS last_updated_at,
-                            LAST_VALUE(leg_count) AS leg_count
+                            internal_status AS payin_status,
+                            amount_micros AS payin_amount_micros,
+                            currency_code AS payin_currency,
+                            payin_reference,
+                            ROW_NUMBER() OVER (PARTITION BY flow_id ORDER BY event_time DESC) AS rn
                         FROM (
                             SELECT
                                 JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
-                                JSON_VALUE(payload_json, '$.customer_id') AS customer_id,
-                                JSON_VALUE(payload_json, '$.flow_type') AS flow_type,
-                                JSON_VALUE(payload_json, '$.flow_status') AS flow_status,
-                                event_time,
-                                CAST(JSON_VALUE(payload_json, '$.leg_count') AS INT) AS leg_count
-                            FROM raw.raw_payment_flow
+                                JSON_VALUE(payload_json, '$.internal_status') AS internal_status,
+                                CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT) AS amount_micros,
+                                JSON_VALUE(payload_json, '$.amount.currency_code') AS currency_code,
+                                JSON_VALUE(payload_json, '$.payin_reference') AS payin_reference,
+                                event_time
+                            FROM raw.raw_payment_payin_fiat
+                            UNION ALL
+                            SELECT
+                                JSON_VALUE(payload_json, '$.flow_id'),
+                                JSON_VALUE(payload_json, '$.internal_status'),
+                                CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT),
+                                JSON_VALUE(payload_json, '$.amount.currency_code'),
+                                JSON_VALUE(payload_json, '$.payin_reference'),
+                                event_time
+                            FROM raw.raw_payment_payin_crypto
                         )
-                        GROUP BY flow_id
-                    ) f
-                    LEFT JOIN (
+                    ) WHERE rn = 1
+                ) pi ON f.flow_id = pi.flow_id
+                LEFT JOIN (
+                    SELECT flow_id, trade_status, trade_amount_micros, trade_currency
+                    FROM (
                         SELECT
                             JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS payin_status,
-                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS payin_amount_micros,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS payin_currency,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.payin_reference')) AS payin_reference
-                        FROM raw.raw_payment_payin_fiat
-                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
-                    ) pi ON f.flow_id = pi.flow_id
-                    LEFT JOIN (
-                        SELECT
-                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS trade_status,
-                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS trade_amount_micros,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS trade_currency
+                            JSON_VALUE(payload_json, '$.internal_status') AS trade_status,
+                            CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT) AS trade_amount_micros,
+                            JSON_VALUE(payload_json, '$.amount.currency_code') AS trade_currency,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY JSON_VALUE(payload_json, '$.flow_id')
+                                ORDER BY event_time DESC
+                            ) AS rn
                         FROM raw.raw_chain_transaction
-                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
-                    ) tr ON f.flow_id = tr.flow_id
-                    LEFT JOIN (
+                    ) WHERE rn = 1
+                ) tr ON f.flow_id = tr.flow_id
+                LEFT JOIN (
+                    SELECT flow_id, payout_status, payout_amount_micros, payout_currency, payout_reference
+                    FROM (
                         SELECT
-                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS payout_status,
-                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS payout_amount_micros,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS payout_currency,
-                            LAST_VALUE(JSON_VALUE(payload_json, '$.payout_reference')) AS payout_reference
-                        FROM raw.raw_payment_payout_fiat
-                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
-                    ) po ON f.flow_id = po.flow_id
-                ) AS s
-                ON t.flow_id = s.flow_id
-                WHEN MATCHED THEN UPDATE SET
-                    customer_id = s.customer_id,
-                    flow_type = s.flow_type,
-                    flow_status = s.flow_status,
-                    initiated_at = s.initiated_at,
-                    completed_at = s.completed_at,
-                    last_updated_at = s.last_updated_at,
-                    payin_status = s.payin_status,
-                    payin_amount_micros = s.payin_amount_micros,
-                    payin_currency = s.payin_currency,
-                    payin_reference = s.payin_reference,
-                    trade_status = s.trade_status,
-                    trade_amount_micros = s.trade_amount_micros,
-                    trade_currency = s.trade_currency,
-                    payout_status = s.payout_status,
-                    payout_amount_micros = s.payout_amount_micros,
-                    payout_currency = s.payout_currency,
-                    payout_reference = s.payout_reference,
-                    total_duration_ms = s.total_duration_ms,
-                    leg_count = s.leg_count
-                WHEN NOT MATCHED THEN INSERT (
-                    flow_id, customer_id, flow_type, flow_status,
-                    initiated_at, completed_at, last_updated_at,
-                    payin_status, payin_amount_micros, payin_currency, payin_reference,
-                    trade_status, trade_amount_micros, trade_currency,
-                    payout_status, payout_amount_micros, payout_currency, payout_reference,
-                    total_duration_ms, leg_count
-                ) VALUES (
-                    s.flow_id, s.customer_id, s.flow_type, s.flow_status,
-                    s.initiated_at, s.completed_at, s.last_updated_at,
-                    s.payin_status, s.payin_amount_micros, s.payin_currency, s.payin_reference,
-                    s.trade_status, s.trade_amount_micros, s.trade_currency,
-                    s.payout_status, s.payout_amount_micros, s.payout_currency, s.payout_reference,
-                    s.total_duration_ms, s.leg_count
-                )
+                            flow_id,
+                            internal_status AS payout_status,
+                            amount_micros AS payout_amount_micros,
+                            currency_code AS payout_currency,
+                            payout_reference,
+                            ROW_NUMBER() OVER (PARTITION BY flow_id ORDER BY event_time DESC) AS rn
+                        FROM (
+                            SELECT
+                                JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                                JSON_VALUE(payload_json, '$.internal_status') AS internal_status,
+                                CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT) AS amount_micros,
+                                JSON_VALUE(payload_json, '$.amount.currency_code') AS currency_code,
+                                JSON_VALUE(payload_json, '$.payout_reference') AS payout_reference,
+                                event_time
+                            FROM raw.raw_payment_payout_fiat
+                            UNION ALL
+                            SELECT
+                                JSON_VALUE(payload_json, '$.flow_id'),
+                                JSON_VALUE(payload_json, '$.internal_status'),
+                                CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT),
+                                JSON_VALUE(payload_json, '$.amount.currency_code'),
+                                JSON_VALUE(payload_json, '$.payout_reference'),
+                                event_time
+                            FROM raw.raw_payment_payout_crypto
+                        )
+                    ) WHERE rn = 1
+                ) po ON f.flow_id = po.flow_id
                 """;
     }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
@@ -1,0 +1,175 @@
+package io.stablepay.flink;
+
+import java.util.Map;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
+import io.stablepay.flink.sink.FactTableSinkFactory;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FactFlowsMergeJob {
+
+    public static void main(String[] args) throws Exception {
+        var env = StreamExecutionEnvironment.getExecutionEnvironment();
+        var tableEnv = StreamTableEnvironment.create(env);
+
+        var factSinkFactory = new FactTableSinkFactory();
+        factSinkFactory.ensureFactTablesExist();
+
+        registerIcebergCatalog(tableEnv);
+
+        log.info("Executing MERGE INTO facts.fact_flows from raw tables");
+        tableEnv.executeSql(buildMergeSql());
+        log.info("MERGE INTO facts.fact_flows completed");
+    }
+
+    private static void registerIcebergCatalog(StreamTableEnvironment tableEnv) {
+        var props = IcebergCatalogConfig.catalogProperties();
+        tableEnv.executeSql(String.format(
+                "CREATE CATALOG %s WITH ("
+                + "'type'='iceberg',"
+                + "'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',"
+                + "'uri'='%s',"
+                + "'jdbc.user'='%s',"
+                + "'jdbc.password'='%s',"
+                + "'warehouse'='%s',"
+                + "'io-impl'='%s',"
+                + "'s3.endpoint'='%s',"
+                + "'s3.access-key-id'='%s',"
+                + "'s3.secret-access-key'='%s',"
+                + "'s3.path-style-access'='true'"
+                + ")",
+                IcebergCatalogConfig.CATALOG_NAME,
+                props.get("uri"),
+                props.get("jdbc.user"),
+                props.get("jdbc.password"),
+                props.get("warehouse"),
+                props.get("io-impl"),
+                props.get("s3.endpoint"),
+                props.get("s3.access-key-id"),
+                props.get("s3.secret-access-key")));
+
+        tableEnv.executeSql("USE CATALOG " + IcebergCatalogConfig.CATALOG_NAME);
+    }
+
+    private static String buildMergeSql() {
+        return """
+                MERGE INTO facts.fact_flows AS t
+                USING (
+                    SELECT
+                        f.flow_id,
+                        f.customer_id,
+                        f.flow_type,
+                        f.flow_status,
+                        f.initiated_at,
+                        f.completed_at,
+                        f.last_updated_at,
+                        pi.payin_status,
+                        pi.payin_amount_micros,
+                        pi.payin_currency,
+                        pi.payin_reference,
+                        tr.trade_status,
+                        tr.trade_amount_micros,
+                        tr.trade_currency,
+                        po.payout_status,
+                        po.payout_amount_micros,
+                        po.payout_currency,
+                        po.payout_reference,
+                        CASE WHEN f.completed_at IS NOT NULL AND f.initiated_at IS NOT NULL
+                             THEN TIMESTAMPDIFF(SECOND, f.initiated_at, f.completed_at) * 1000
+                             ELSE NULL END AS total_duration_ms,
+                        f.leg_count
+                    FROM (
+                        SELECT
+                            flow_id,
+                            LAST_VALUE(customer_id) AS customer_id,
+                            LAST_VALUE(flow_type) AS flow_type,
+                            LAST_VALUE(flow_status) AS flow_status,
+                            MIN(event_time) AS initiated_at,
+                            MAX(CASE WHEN flow_status = 'COMPLETED' THEN event_time ELSE NULL END) AS completed_at,
+                            MAX(event_time) AS last_updated_at,
+                            LAST_VALUE(leg_count) AS leg_count
+                        FROM (
+                            SELECT
+                                JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                                JSON_VALUE(payload_json, '$.customer_id') AS customer_id,
+                                JSON_VALUE(payload_json, '$.flow_type') AS flow_type,
+                                JSON_VALUE(payload_json, '$.flow_status') AS flow_status,
+                                event_time,
+                                CAST(JSON_VALUE(payload_json, '$.leg_count') AS INT) AS leg_count
+                            FROM raw.raw_payment_flow
+                        )
+                        GROUP BY flow_id
+                    ) f
+                    LEFT JOIN (
+                        SELECT
+                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS payin_status,
+                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS payin_amount_micros,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS payin_currency,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.payin_reference')) AS payin_reference
+                        FROM raw.raw_payment_payin_fiat
+                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
+                    ) pi ON f.flow_id = pi.flow_id
+                    LEFT JOIN (
+                        SELECT
+                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS trade_status,
+                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS trade_amount_micros,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS trade_currency
+                        FROM raw.raw_chain_transaction
+                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
+                    ) tr ON f.flow_id = tr.flow_id
+                    LEFT JOIN (
+                        SELECT
+                            JSON_VALUE(payload_json, '$.flow_id') AS flow_id,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.internal_status')) AS payout_status,
+                            LAST_VALUE(CAST(JSON_VALUE(payload_json, '$.amount.amount_micros') AS BIGINT)) AS payout_amount_micros,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.amount.currency_code')) AS payout_currency,
+                            LAST_VALUE(JSON_VALUE(payload_json, '$.payout_reference')) AS payout_reference
+                        FROM raw.raw_payment_payout_fiat
+                        GROUP BY JSON_VALUE(payload_json, '$.flow_id')
+                    ) po ON f.flow_id = po.flow_id
+                ) AS s
+                ON t.flow_id = s.flow_id
+                WHEN MATCHED THEN UPDATE SET
+                    customer_id = s.customer_id,
+                    flow_type = s.flow_type,
+                    flow_status = s.flow_status,
+                    initiated_at = s.initiated_at,
+                    completed_at = s.completed_at,
+                    last_updated_at = s.last_updated_at,
+                    payin_status = s.payin_status,
+                    payin_amount_micros = s.payin_amount_micros,
+                    payin_currency = s.payin_currency,
+                    payin_reference = s.payin_reference,
+                    trade_status = s.trade_status,
+                    trade_amount_micros = s.trade_amount_micros,
+                    trade_currency = s.trade_currency,
+                    payout_status = s.payout_status,
+                    payout_amount_micros = s.payout_amount_micros,
+                    payout_currency = s.payout_currency,
+                    payout_reference = s.payout_reference,
+                    total_duration_ms = s.total_duration_ms,
+                    leg_count = s.leg_count
+                WHEN NOT MATCHED THEN INSERT (
+                    flow_id, customer_id, flow_type, flow_status,
+                    initiated_at, completed_at, last_updated_at,
+                    payin_status, payin_amount_micros, payin_currency, payin_reference,
+                    trade_status, trade_amount_micros, trade_currency,
+                    payout_status, payout_amount_micros, payout_currency, payout_reference,
+                    total_duration_ms, leg_count
+                ) VALUES (
+                    s.flow_id, s.customer_id, s.flow_type, s.flow_status,
+                    s.initiated_at, s.completed_at, s.last_updated_at,
+                    s.payin_status, s.payin_amount_micros, s.payin_currency, s.payin_reference,
+                    s.trade_status, s.trade_amount_micros, s.trade_currency,
+                    s.payout_status, s.payout_amount_micros, s.payout_currency, s.payout_reference,
+                    s.total_duration_ms, s.leg_count
+                )
+                """;
+    }
+}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/IngestJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/IngestJob.java
@@ -19,11 +19,14 @@ import io.stablepay.flink.config.FlinkConfig;
 import io.stablepay.flink.deser.AvroEnvelopeDeserializer;
 import io.stablepay.flink.dlq.DlqKafkaSinkFactory;
 import io.stablepay.flink.dlq.DlqOutputTags;
+import io.stablepay.flink.mapper.EventToFactScreeningMapper;
+import io.stablepay.flink.mapper.EventToFactTransactionMapper;
 import io.stablepay.flink.mapper.EventToIcebergRowMapper;
 import io.stablepay.flink.model.DlqEnvelope;
 import io.stablepay.flink.model.ValidatedEvent;
 import io.stablepay.flink.model.ValidationResult;
 import io.stablepay.flink.process.ValidateAndRouteFunction;
+import io.stablepay.flink.sink.FactTableSinkFactory;
 import io.stablepay.flink.sink.IcebergSinkFactory;
 import io.stablepay.flink.sink.OpenSearchAsyncSink;
 import io.stablepay.flink.watermark.EnvelopeTimestampAssigner;
@@ -103,6 +106,22 @@ public class IngestJob {
         routedStream
                 .sinkTo(new OpenSearchAsyncSink(FlinkConfig.opensearchUrl()))
                 .name("opensearch-transactions-sink");
+
+        // --- Fact table sinks (independent branches) ---
+        var factSinkFactory = new FactTableSinkFactory();
+        factSinkFactory.ensureFactTablesExist();
+
+        var factTxStream = routedStream
+                .filter(e -> FlinkConfig.FACT_TX_TOPICS.contains(e.topic()))
+                .map(EventToFactTransactionMapper::toRowData)
+                .name("fact-transactions-map");
+        factSinkFactory.addSink(factTxStream, "fact_transactions");
+
+        var factScreeningStream = routedStream
+                .filter(e -> "screening.result.v1".equals(e.topic()))
+                .map(EventToFactScreeningMapper::toRowData)
+                .name("fact-screening-map");
+        factSinkFactory.addSink(factScreeningStream, "fact_screening_outcomes");
 
         env.execute("stablepay-ingest-job");
     }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/catalog/IcebergCatalogConfig.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/catalog/IcebergCatalogConfig.java
@@ -10,6 +10,11 @@ public final class IcebergCatalogConfig {
 
     public static final String CATALOG_NAME = "iceberg_catalog";
     public static final String RAW_NAMESPACE = "raw";
+    public static final String FACTS_NAMESPACE = "facts";
+    public static final String DLQ_NAMESPACE = "dlq";
+
+    public static final List<String> FACT_TABLES = List.of(
+            "fact_transactions", "fact_flows", "fact_screening_outcomes");
 
     public static final List<String> RAW_TABLES = List.of(
             "raw_payment_payout_fiat",

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/config/FlinkConfig.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/config/FlinkConfig.java
@@ -1,10 +1,18 @@
 package io.stablepay.flink.config;
 
 import java.util.List;
+import java.util.Set;
 
 public final class FlinkConfig {
 
     private FlinkConfig() {}
+
+    public static final Set<String> FACT_TX_TOPICS = Set.of(
+            "payment.payout.fiat.v1",
+            "payment.payout.crypto.v1",
+            "payment.payin.fiat.v1",
+            "payment.payin.crypto.v1",
+            "chain.transaction.v1");
 
     public static final List<String> INPUT_TOPICS = List.of(
             "payment.payout.fiat.v1",

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
@@ -1,0 +1,54 @@
+package io.stablepay.flink.mapper;
+
+import java.time.Instant;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+
+import io.stablepay.flink.model.ValidatedEvent;
+
+public final class EventToFactScreeningMapper {
+
+    private EventToFactScreeningMapper() {}
+
+    public static RowData toRowData(ValidatedEvent event) {
+        var record = event.toRecord();
+        var row = new GenericRowData(10);
+
+        row.setField(0, StringData.fromString(event.eventId()));
+        row.setField(1, stringDataOrNull(stringVal(record.get("screening_id"))));
+        row.setField(2, stringDataOrNull(stringVal(record.get("customer_id"))));
+        row.setField(3, stringDataOrNull(extractTransactionReference(record)));
+        row.setField(4, stringDataOrNull(stringVal(record.get("outcome"))));
+        row.setField(5, stringDataOrNull(stringVal(record.get("provider"))));
+        row.setField(6, stringDataOrNull(stringVal(record.get("rule_triggered"))));
+
+        var score = record.get("score");
+        row.setField(7, score instanceof Number n ? n.doubleValue() : null);
+
+        row.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
+
+        var durationMs = record.get("duration_ms");
+        row.setField(9, durationMs instanceof Number n ? n.longValue() : null);
+
+        return row;
+    }
+
+    private static String extractTransactionReference(GenericRecord record) {
+        var ref = record.get("transaction_reference");
+        if (ref != null) return ref.toString();
+        var payoutRef = record.get("payout_reference");
+        return payoutRef != null ? payoutRef.toString() : null;
+    }
+
+    private static StringData stringDataOrNull(String value) {
+        return value != null ? StringData.fromString(value) : null;
+    }
+
+    private static String stringVal(Object value) {
+        return value != null ? value.toString() : null;
+    }
+}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
@@ -20,7 +20,7 @@ public final class EventToFactScreeningMapper {
 
         row.setField(0, StringData.fromString(event.eventId()));
         row.setField(1, stringDataOrNull(stringVal(record.get("screening_id"))));
-        row.setField(2, stringDataOrNull(PiiMasker.mask(stringVal(record.get("customer_id")))));
+        row.setField(2, stringDataOrNull(stringVal(record.get("customer_id"))));
         row.setField(3, stringDataOrNull(extractTransactionReference(record)));
         row.setField(4, stringDataOrNull(stringVal(record.get("outcome"))));
         row.setField(5, stringDataOrNull(stringVal(record.get("provider"))));

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
@@ -20,7 +20,7 @@ public final class EventToFactScreeningMapper {
 
         row.setField(0, StringData.fromString(event.eventId()));
         row.setField(1, stringDataOrNull(stringVal(record.get("screening_id"))));
-        row.setField(2, stringDataOrNull(stringVal(record.get("customer_id"))));
+        row.setField(2, stringDataOrNull(PiiMasker.mask(stringVal(record.get("customer_id")))));
         row.setField(3, stringDataOrNull(extractTransactionReference(record)));
         row.setField(4, stringDataOrNull(stringVal(record.get("outcome"))));
         row.setField(5, stringDataOrNull(stringVal(record.get("provider"))));

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
@@ -39,8 +39,8 @@ public final class EventToFactTransactionMapper {
         row.setField(9, isCrypto(topic));
         row.setField(10, extractBoolean(record, "is_user_facing"));
         row.setField(11, stringDataOrNull(extractTransactionReference(record, topic)));
-        row.setField(12, stringDataOrNull(PiiMasker.mask(stringVal(record.get("customer_id")))));
-        row.setField(13, stringDataOrNull(PiiMasker.mask(stringVal(record.get("account_id")))));
+        row.setField(12, stringDataOrNull(stringVal(record.get("customer_id"))));
+        row.setField(13, stringDataOrNull(stringVal(record.get("account_id"))));
 
         extractMoneyField(record, "amount", row, 14, 15);
         extractMoneyField(record, "fee", row, 16, 17);
@@ -119,14 +119,6 @@ public final class EventToFactTransactionMapper {
     private static Boolean extractBoolean(GenericRecord record, String field) {
         var val = record.get(field);
         return val instanceof Boolean b ? b : null;
-    }
-
-    private static StringData extractNestedName(GenericRecord record, String field) {
-        var nested = record.get(field);
-        if (nested instanceof GenericRecord party) {
-            return stringDataOrNull(stringVal(party.get("name")));
-        }
-        return null;
     }
 
     private static StringData maskedNestedName(GenericRecord record, String field) {

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
@@ -1,0 +1,162 @@
+package io.stablepay.flink.mapper;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+
+import io.stablepay.flink.model.ValidatedEvent;
+
+public final class EventToFactTransactionMapper {
+
+    private EventToFactTransactionMapper() {}
+
+    private static final Map<String, String> TOPIC_TO_EVENT_TYPE = Map.of(
+            "payment.payout.fiat.v1", "PAYOUT_FIAT",
+            "payment.payout.crypto.v1", "PAYOUT_CRYPTO",
+            "payment.payin.fiat.v1", "PAYIN_FIAT",
+            "payment.payin.crypto.v1", "PAYIN_CRYPTO",
+            "chain.transaction.v1", "CHAIN_TRANSACTION");
+
+    public static RowData toRowData(ValidatedEvent event) {
+        var record = event.toRecord();
+        var topic = event.topic();
+        var row = new GenericRowData(41);
+
+        row.setField(0, StringData.fromString(event.eventId()));
+        row.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
+        row.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(extractIngestTime(record))));
+        row.setField(3, stringDataOrNull(event.flowId()));
+        row.setField(4, stringDataOrNull(extractEnvelopeField(record, "correlation_id")));
+        row.setField(5, stringDataOrNull(extractEnvelopeField(record, "trace_id")));
+        row.setField(6, StringData.fromString(TOPIC_TO_EVENT_TYPE.getOrDefault(topic, "UNKNOWN")));
+        row.setField(7, StringData.fromString(deriveFlowType(topic)));
+        row.setField(8, StringData.fromString(deriveDirection(topic)));
+        row.setField(9, isCrypto(topic));
+        row.setField(10, extractBoolean(record, "is_user_facing"));
+        row.setField(11, stringDataOrNull(extractTransactionReference(record, topic)));
+        row.setField(12, stringDataOrNull(stringVal(record.get("customer_id"))));
+        row.setField(13, stringDataOrNull(stringVal(record.get("account_id"))));
+
+        extractMoneyField(record, "amount", row, 14, 15);
+        extractMoneyField(record, "fee", row, 16, 17);
+        extractMoneyField(record, "source_amount", row, 18, 19);
+        extractMoneyField(record, "target_amount", row, 20, 21);
+
+        var fxRate = record.get("fx_rate");
+        row.setField(22, fxRate instanceof Number n ? n.doubleValue() : null);
+
+        row.setField(23, stringDataOrNull(stringVal(record.get("internal_status"))));
+        row.setField(24, stringDataOrNull(stringVal(record.get("customer_status"))));
+        row.setField(25, stringDataOrNull(stringVal(record.get("screening_outcome"))));
+        row.setField(26, stringDataOrNull(stringVal(record.get("chain"))));
+        row.setField(27, stringDataOrNull(stringVal(record.get("asset"))));
+        row.setField(28, stringDataOrNull(stringVal(record.get("source_address"))));
+        row.setField(29, stringDataOrNull(stringVal(record.get("destination_address"))));
+        row.setField(30, stringDataOrNull(stringVal(record.get("tx_hash"))));
+
+        var confirmations = record.get("confirmations");
+        row.setField(31, confirmations instanceof Number n ? n.intValue() : null);
+
+        var gasFee = record.get("gas_fee_micros");
+        row.setField(32, gasFee instanceof Number n ? n.longValue() : null);
+
+        var blockNumber = record.get("block_number");
+        row.setField(33, blockNumber instanceof Number n ? n.longValue() : null);
+
+        var blockTimestamp = record.get("block_timestamp");
+        row.setField(34, blockTimestamp instanceof Long ts
+                ? TimestampData.fromInstant(Instant.ofEpochMilli(ts)) : null);
+
+        row.setField(35, stringDataOrNull(stringVal(record.get("provider"))));
+        row.setField(36, stringDataOrNull(stringVal(record.get("route"))));
+
+        row.setField(37, extractNestedName(record, "beneficiary"));
+        row.setField(38, extractNestedName(record, "sender"));
+
+        row.setField(39, stringDataOrNull(stringVal(record.get("description"))));
+        row.setField(40, stringDataOrNull(stringVal(record.get("notes"))));
+
+        return row;
+    }
+
+    private static long extractIngestTime(GenericRecord record) {
+        var envelope = record.get("envelope");
+        if (envelope instanceof GenericRecord env) {
+            var ingestTime = env.get("ingest_time");
+            if (ingestTime instanceof Long l) return l;
+        }
+        return Instant.now().toEpochMilli();
+    }
+
+    private static String extractEnvelopeField(GenericRecord record, String field) {
+        var envelope = record.get("envelope");
+        if (envelope instanceof GenericRecord env) {
+            var val = env.get(field);
+            return val != null ? val.toString() : null;
+        }
+        return null;
+    }
+
+    private static void extractMoneyField(
+            GenericRecord record, String field, GenericRowData row,
+            int microsIndex, int currencyIndex) {
+        var money = record.get(field);
+        if (money instanceof GenericRecord moneyRecord) {
+            var micros = moneyRecord.get("amount_micros");
+            row.setField(microsIndex, micros instanceof Number n ? n.longValue() : null);
+            row.setField(currencyIndex, stringDataOrNull(stringVal(moneyRecord.get("currency_code"))));
+        } else {
+            row.setField(microsIndex, null);
+            row.setField(currencyIndex, null);
+        }
+    }
+
+    private static Boolean extractBoolean(GenericRecord record, String field) {
+        var val = record.get(field);
+        return val instanceof Boolean b ? b : null;
+    }
+
+    private static StringData extractNestedName(GenericRecord record, String field) {
+        var nested = record.get(field);
+        if (nested instanceof GenericRecord party) {
+            return stringDataOrNull(stringVal(party.get("name")));
+        }
+        return null;
+    }
+
+    private static String extractTransactionReference(GenericRecord record, String topic) {
+        if (topic.contains("payout")) return stringVal(record.get("payout_reference"));
+        if (topic.contains("payin")) return stringVal(record.get("payin_reference"));
+        if (topic.contains("chain.transaction")) return stringVal(record.get("tx_hash"));
+        return stringVal(record.get("flow_id"));
+    }
+
+    private static String deriveFlowType(String topic) {
+        if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
+        if (topic.contains("fiat")) return "FIAT";
+        return "MIXED";
+    }
+
+    private static String deriveDirection(String topic) {
+        if (topic.contains("payin")) return "INBOUND";
+        if (topic.contains("payout")) return "OUTBOUND";
+        return "INTERNAL";
+    }
+
+    private static boolean isCrypto(String topic) {
+        return topic.contains("crypto") || topic.contains("chain");
+    }
+
+    private static StringData stringDataOrNull(String value) {
+        return value != null ? StringData.fromString(value) : null;
+    }
+
+    private static String stringVal(Object value) {
+        return value != null ? value.toString() : null;
+    }
+}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
@@ -39,8 +39,8 @@ public final class EventToFactTransactionMapper {
         row.setField(9, isCrypto(topic));
         row.setField(10, extractBoolean(record, "is_user_facing"));
         row.setField(11, stringDataOrNull(extractTransactionReference(record, topic)));
-        row.setField(12, stringDataOrNull(stringVal(record.get("customer_id"))));
-        row.setField(13, stringDataOrNull(stringVal(record.get("account_id"))));
+        row.setField(12, stringDataOrNull(PiiMasker.mask(stringVal(record.get("customer_id")))));
+        row.setField(13, stringDataOrNull(PiiMasker.mask(stringVal(record.get("account_id")))));
 
         extractMoneyField(record, "amount", row, 14, 15);
         extractMoneyField(record, "fee", row, 16, 17);
@@ -55,8 +55,8 @@ public final class EventToFactTransactionMapper {
         row.setField(25, stringDataOrNull(stringVal(record.get("screening_outcome"))));
         row.setField(26, stringDataOrNull(stringVal(record.get("chain"))));
         row.setField(27, stringDataOrNull(stringVal(record.get("asset"))));
-        row.setField(28, stringDataOrNull(stringVal(record.get("source_address"))));
-        row.setField(29, stringDataOrNull(stringVal(record.get("destination_address"))));
+        row.setField(28, stringDataOrNull(PiiMasker.mask(stringVal(record.get("source_address")))));
+        row.setField(29, stringDataOrNull(PiiMasker.mask(stringVal(record.get("destination_address")))));
         row.setField(30, stringDataOrNull(stringVal(record.get("tx_hash"))));
 
         var confirmations = record.get("confirmations");
@@ -75,11 +75,11 @@ public final class EventToFactTransactionMapper {
         row.setField(35, stringDataOrNull(stringVal(record.get("provider"))));
         row.setField(36, stringDataOrNull(stringVal(record.get("route"))));
 
-        row.setField(37, extractNestedName(record, "beneficiary"));
-        row.setField(38, extractNestedName(record, "sender"));
+        row.setField(37, maskedNestedName(record, "beneficiary"));
+        row.setField(38, maskedNestedName(record, "sender"));
 
-        row.setField(39, stringDataOrNull(stringVal(record.get("description"))));
-        row.setField(40, stringDataOrNull(stringVal(record.get("notes"))));
+        row.setField(39, stringDataOrNull(PiiMasker.mask(stringVal(record.get("description")))));
+        row.setField(40, stringDataOrNull(PiiMasker.mask(stringVal(record.get("notes")))));
 
         return row;
     }
@@ -125,6 +125,14 @@ public final class EventToFactTransactionMapper {
         var nested = record.get(field);
         if (nested instanceof GenericRecord party) {
             return stringDataOrNull(stringVal(party.get("name")));
+        }
+        return null;
+    }
+
+    private static StringData maskedNestedName(GenericRecord record, String field) {
+        var nested = record.get(field);
+        if (nested instanceof GenericRecord party) {
+            return stringDataOrNull(PiiMasker.mask(stringVal(party.get("name"))));
         }
         return null;
     }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/PiiMasker.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/PiiMasker.java
@@ -1,0 +1,19 @@
+package io.stablepay.flink.mapper;
+
+public final class PiiMasker {
+
+    private static final int VISIBLE_PREFIX_LENGTH = 4;
+    private static final String MASK_CHAR = "*";
+
+    private PiiMasker() {}
+
+    public static String mask(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        if (value.length() <= VISIBLE_PREFIX_LENGTH) {
+            return MASK_CHAR.repeat(value.length());
+        }
+        return value.substring(0, VISIBLE_PREFIX_LENGTH) + MASK_CHAR.repeat(value.length() - VISIBLE_PREFIX_LENGTH);
+    }
+}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
@@ -1,5 +1,7 @@
 package io.stablepay.flink.sink;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -129,25 +131,35 @@ public class FactTableSinkFactory implements Serializable {
 
     public void ensureFactTablesExist() {
         var catalog = createCatalogLoader().loadCatalog();
-        var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
+        try {
+            var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
 
-        if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
-            nsCatalog.createNamespace(namespace);
-            log.info("Created Iceberg namespace: {}", namespace);
-        }
-
-        for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
-            var def = TABLE_DEFINITIONS.get(tableName);
-            if (def == null) {
-                throw new IllegalStateException(
-                        "No schema definition for fact table '" + tableName + "' — add it to TABLE_DEFINITIONS");
+            if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
+                nsCatalog.createNamespace(namespace);
+                log.info("Created Iceberg namespace: {}", namespace);
             }
-            var tableId = TableIdentifier.of(namespace, tableName);
-            if (!catalog.tableExists(tableId)) {
-                catalog.createTable(tableId, def.schema(), def.spec(), Map.of(
-                        "format-version", "2",
-                        "write.parquet.compression-codec", "zstd"));
-                log.info("Created Iceberg fact table: {}", tableId);
+
+            for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
+                var def = TABLE_DEFINITIONS.get(tableName);
+                if (def == null) {
+                    throw new IllegalStateException(
+                            "No schema definition for fact table '" + tableName + "' — add it to TABLE_DEFINITIONS");
+                }
+                var tableId = TableIdentifier.of(namespace, tableName);
+                if (!catalog.tableExists(tableId)) {
+                    catalog.createTable(tableId, def.schema(), def.spec(), Map.of(
+                            "format-version", "2",
+                            "write.parquet.compression-codec", "zstd"));
+                    log.info("Created Iceberg fact table: {}", tableId);
+                }
+            }
+        } finally {
+            if (catalog instanceof Closeable closeable) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    log.warn("Failed to close Iceberg catalog", e);
+                }
             }
         }
     }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
@@ -137,9 +137,13 @@ public class FactTableSinkFactory implements Serializable {
         }
 
         for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
+            var def = TABLE_DEFINITIONS.get(tableName);
+            if (def == null) {
+                throw new IllegalStateException(
+                        "No schema definition for fact table '" + tableName + "' — add it to TABLE_DEFINITIONS");
+            }
             var tableId = TableIdentifier.of(namespace, tableName);
             if (!catalog.tableExists(tableId)) {
-                var def = TABLE_DEFINITIONS.get(tableName);
                 catalog.createTable(tableId, def.schema(), def.spec(), Map.of(
                         "format-version", "2",
                         "write.parquet.compression-codec", "zstd"));

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
@@ -1,0 +1,156 @@
+package io.stablepay.flink.sink;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.FlinkSink;
+import org.apache.iceberg.types.Types;
+
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FactTableSinkFactory implements Serializable {
+
+    static final Schema FACT_TRANSACTIONS_SCHEMA = new Schema(
+            Types.NestedField.required(1, "event_id", Types.StringType.get()),
+            Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
+            Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
+            Types.NestedField.optional(4, "flow_id", Types.StringType.get()),
+            Types.NestedField.optional(5, "correlation_id", Types.StringType.get()),
+            Types.NestedField.optional(6, "trace_id", Types.StringType.get()),
+            Types.NestedField.required(7, "event_type", Types.StringType.get()),
+            Types.NestedField.required(8, "flow_type", Types.StringType.get()),
+            Types.NestedField.required(9, "direction", Types.StringType.get()),
+            Types.NestedField.required(10, "is_crypto", Types.BooleanType.get()),
+            Types.NestedField.optional(11, "is_user_facing", Types.BooleanType.get()),
+            Types.NestedField.optional(12, "transaction_reference", Types.StringType.get()),
+            Types.NestedField.optional(13, "customer_id", Types.StringType.get()),
+            Types.NestedField.optional(14, "account_id", Types.StringType.get()),
+            Types.NestedField.optional(15, "amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(16, "currency_code", Types.StringType.get()),
+            Types.NestedField.optional(17, "fee_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(18, "fee_currency_code", Types.StringType.get()),
+            Types.NestedField.optional(19, "source_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(20, "source_currency_code", Types.StringType.get()),
+            Types.NestedField.optional(21, "target_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(22, "target_currency_code", Types.StringType.get()),
+            Types.NestedField.optional(23, "fx_rate", Types.DoubleType.get()),
+            Types.NestedField.optional(24, "internal_status", Types.StringType.get()),
+            Types.NestedField.optional(25, "customer_status", Types.StringType.get()),
+            Types.NestedField.optional(26, "screening_outcome", Types.StringType.get()),
+            Types.NestedField.optional(27, "chain", Types.StringType.get()),
+            Types.NestedField.optional(28, "asset", Types.StringType.get()),
+            Types.NestedField.optional(29, "source_address", Types.StringType.get()),
+            Types.NestedField.optional(30, "destination_address", Types.StringType.get()),
+            Types.NestedField.optional(31, "tx_hash", Types.StringType.get()),
+            Types.NestedField.optional(32, "confirmations", Types.IntegerType.get()),
+            Types.NestedField.optional(33, "gas_fee_micros", Types.LongType.get()),
+            Types.NestedField.optional(34, "block_number", Types.LongType.get()),
+            Types.NestedField.optional(35, "block_timestamp", Types.TimestampType.withZone()),
+            Types.NestedField.optional(36, "provider", Types.StringType.get()),
+            Types.NestedField.optional(37, "route", Types.StringType.get()),
+            Types.NestedField.optional(38, "beneficiary_name", Types.StringType.get()),
+            Types.NestedField.optional(39, "sender_name", Types.StringType.get()),
+            Types.NestedField.optional(40, "description", Types.StringType.get()),
+            Types.NestedField.optional(41, "notes", Types.StringType.get()));
+
+    static final PartitionSpec FACT_TRANSACTIONS_PARTITION_SPEC =
+            PartitionSpec.builderFor(FACT_TRANSACTIONS_SCHEMA)
+                    .day("event_time")
+                    .bucket("customer_id", 16)
+                    .build();
+
+    static final Schema FACT_FLOWS_SCHEMA = new Schema(
+            Types.NestedField.required(1, "flow_id", Types.StringType.get()),
+            Types.NestedField.optional(2, "customer_id", Types.StringType.get()),
+            Types.NestedField.optional(3, "flow_type", Types.StringType.get()),
+            Types.NestedField.optional(4, "flow_status", Types.StringType.get()),
+            Types.NestedField.required(5, "initiated_at", Types.TimestampType.withZone()),
+            Types.NestedField.optional(6, "completed_at", Types.TimestampType.withZone()),
+            Types.NestedField.optional(7, "last_updated_at", Types.TimestampType.withZone()),
+            Types.NestedField.optional(8, "payin_status", Types.StringType.get()),
+            Types.NestedField.optional(9, "payin_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(10, "payin_currency", Types.StringType.get()),
+            Types.NestedField.optional(11, "payin_reference", Types.StringType.get()),
+            Types.NestedField.optional(12, "trade_status", Types.StringType.get()),
+            Types.NestedField.optional(13, "trade_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(14, "trade_currency", Types.StringType.get()),
+            Types.NestedField.optional(15, "payout_status", Types.StringType.get()),
+            Types.NestedField.optional(16, "payout_amount_micros", Types.LongType.get()),
+            Types.NestedField.optional(17, "payout_currency", Types.StringType.get()),
+            Types.NestedField.optional(18, "payout_reference", Types.StringType.get()),
+            Types.NestedField.optional(19, "total_duration_ms", Types.LongType.get()),
+            Types.NestedField.optional(20, "leg_count", Types.IntegerType.get()));
+
+    static final PartitionSpec FACT_FLOWS_PARTITION_SPEC =
+            PartitionSpec.builderFor(FACT_FLOWS_SCHEMA)
+                    .day("initiated_at")
+                    .build();
+
+    static final Schema FACT_SCREENING_SCHEMA = new Schema(
+            Types.NestedField.required(1, "event_id", Types.StringType.get()),
+            Types.NestedField.optional(2, "screening_id", Types.StringType.get()),
+            Types.NestedField.optional(3, "customer_id", Types.StringType.get()),
+            Types.NestedField.optional(4, "transaction_reference", Types.StringType.get()),
+            Types.NestedField.optional(5, "outcome", Types.StringType.get()),
+            Types.NestedField.optional(6, "provider", Types.StringType.get()),
+            Types.NestedField.optional(7, "rule_triggered", Types.StringType.get()),
+            Types.NestedField.optional(8, "score", Types.DoubleType.get()),
+            Types.NestedField.required(9, "event_time", Types.TimestampType.withZone()),
+            Types.NestedField.optional(10, "duration_ms", Types.LongType.get()));
+
+    static final PartitionSpec FACT_SCREENING_PARTITION_SPEC =
+            PartitionSpec.builderFor(FACT_SCREENING_SCHEMA)
+                    .day("event_time")
+                    .build();
+
+    private static final Map<String, SchemaAndSpec> TABLE_DEFINITIONS = Map.of(
+            "fact_transactions", new SchemaAndSpec(FACT_TRANSACTIONS_SCHEMA, FACT_TRANSACTIONS_PARTITION_SPEC),
+            "fact_flows", new SchemaAndSpec(FACT_FLOWS_SCHEMA, FACT_FLOWS_PARTITION_SPEC),
+            "fact_screening_outcomes", new SchemaAndSpec(FACT_SCREENING_SCHEMA, FACT_SCREENING_PARTITION_SPEC));
+
+    private CatalogLoader createCatalogLoader() {
+        return CatalogLoader.custom(
+                IcebergCatalogConfig.CATALOG_NAME,
+                IcebergCatalogConfig.catalogProperties(),
+                new org.apache.hadoop.conf.Configuration(),
+                "org.apache.iceberg.jdbc.JdbcCatalog");
+    }
+
+    public void ensureFactTablesExist() {
+        var catalog = createCatalogLoader().loadCatalog();
+        var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
+
+        for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
+            var tableId = TableIdentifier.of(namespace, tableName);
+            if (!catalog.tableExists(tableId)) {
+                var def = TABLE_DEFINITIONS.get(tableName);
+                catalog.createTable(tableId, def.schema(), def.spec(), Map.of(
+                        "format-version", "2",
+                        "write.parquet.compression-codec", "zstd"));
+                log.info("Created Iceberg fact table: {}", tableId);
+            }
+        }
+    }
+
+    public void addSink(DataStream<RowData> stream, String tableName) {
+        var tableId = TableIdentifier.of(
+                Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE), tableName);
+        var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
+
+        FlinkSink.forRowData(stream)
+                .tableLoader(tableLoader)
+                .append();
+    }
+
+    private record SchemaAndSpec(Schema schema, PartitionSpec spec) {}
+}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
@@ -8,6 +8,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.TableLoader;
@@ -129,6 +130,11 @@ public class FactTableSinkFactory implements Serializable {
     public void ensureFactTablesExist() {
         var catalog = createCatalogLoader().loadCatalog();
         var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
+
+        if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
+            nsCatalog.createNamespace(namespace);
+            log.info("Created Iceberg namespace: {}", namespace);
+        }
 
         for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
             var tableId = TableIdentifier.of(namespace, tableName);

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/FactFlowsMergeJobTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/FactFlowsMergeJobTest.java
@@ -1,0 +1,114 @@
+package io.stablepay.flink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FactFlowsMergeJobTest {
+
+    @Nested
+    class EscapeSql {
+
+        @Test
+        void shouldEscapeSingleQuotes() {
+            // when
+            var result = FactFlowsMergeJob.escapeSql("it's a test");
+
+            // then
+            assertThat(result).isEqualTo("it''s a test");
+        }
+
+        @Test
+        void shouldReturnEmptyStringForNull() {
+            // when
+            var result = FactFlowsMergeJob.escapeSql(null);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnValueUnchangedWhenNoQuotes() {
+            // when
+            var result = FactFlowsMergeJob.escapeSql("jdbc:postgresql://host:5432/db");
+
+            // then
+            assertThat(result).isEqualTo("jdbc:postgresql://host:5432/db");
+        }
+
+        @Test
+        void shouldEscapeMultipleSingleQuotes() {
+            // when
+            var result = FactFlowsMergeJob.escapeSql("a'b'c");
+
+            // then
+            assertThat(result).isEqualTo("a''b''c");
+        }
+    }
+
+    @Nested
+    class BuildInsertOverwriteSql {
+
+        @Test
+        void shouldTargetFactFlowsTable() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("INSERT OVERWRITE facts.fact_flows");
+        }
+
+        @Test
+        void shouldJoinOnFlowId() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("ON f.flow_id = aggs.flow_id");
+            assertThat(sql).contains("ON f.flow_id = pi.flow_id");
+            assertThat(sql).contains("ON f.flow_id = tr.flow_id");
+            assertThat(sql).contains("ON f.flow_id = po.flow_id");
+        }
+
+        @Test
+        void shouldIncludeBothFiatAndCryptoPayinSources() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("raw.raw_payment_payin_fiat");
+            assertThat(sql).contains("raw.raw_payment_payin_crypto");
+        }
+
+        @Test
+        void shouldIncludeBothFiatAndCryptoPayoutSources() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("raw.raw_payment_payout_fiat");
+            assertThat(sql).contains("raw.raw_payment_payout_crypto");
+        }
+
+        @Test
+        void shouldUseDeterministicRowNumberForLatestRow() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("ROW_NUMBER()");
+            assertThat(sql).contains("ORDER BY event_time DESC");
+            assertThat(sql).doesNotContain("LAST_VALUE");
+        }
+
+        @Test
+        void shouldComputeTotalDurationMs() {
+            // when
+            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+            // then
+            assertThat(sql).contains("TIMESTAMPDIFF(SECOND, aggs.initiated_at, aggs.completed_at)");
+        }
+    }
+}

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/FactFixtures.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/FactFixtures.java
@@ -1,0 +1,120 @@
+package io.stablepay.flink.fixtures;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import io.stablepay.flink.model.ValidatedEvent;
+
+public final class FactFixtures {
+
+    public static final long SOME_EVENT_TIME_MILLIS = 1_711_000_000_000L;
+    public static final long SOME_INGEST_TIME_MILLIS = 1_711_000_000_500L;
+    public static final String SOME_EVENT_ID = "evt-fact-001";
+    public static final String SOME_FLOW_ID = "flow-fact-001";
+    public static final String SOME_SCHEMA_VERSION = "1.0.0";
+    public static final String SOME_CUSTOMER_ID = "cust-a1b2c3d4-e5f6-7890";
+    public static final String SOME_ACCOUNT_ID = "acc-x1y2z3w4-5678-9012";
+    public static final String SOME_CORRELATION_ID = "corr-001";
+    public static final String SOME_TRACE_ID = "trace-001";
+
+    private static final Schema MONEY_SCHEMA = SchemaBuilder.money();
+    private static final Schema ENVELOPE_SCHEMA = SchemaBuilder.envelope();
+    private static final Schema PARTY_SCHEMA = SchemaBuilder.party();
+    private static final Schema PAYOUT_FIAT_SCHEMA =
+            SchemaBuilder.payoutFiat(ENVELOPE_SCHEMA, MONEY_SCHEMA, PARTY_SCHEMA);
+    private static final Schema SCREENING_SCHEMA =
+            SchemaBuilder.screeningResult(ENVELOPE_SCHEMA);
+
+    private FactFixtures() {}
+
+    public static ValidatedEvent fiatPayoutEvent(
+            long amountMicros, String currency, String internalStatus) {
+        var envelope = envelope(SOME_CORRELATION_ID, SOME_TRACE_ID);
+        var money = money(amountMicros, currency);
+        var beneficiary = party("Jane Beneficiary");
+        var sender = party("John Sender");
+
+        var record = new GenericRecordBuilder(PAYOUT_FIAT_SCHEMA)
+                .set("envelope", envelope)
+                .set("customer_id", SOME_CUSTOMER_ID)
+                .set("account_id", SOME_ACCOUNT_ID)
+                .set("amount", money)
+                .set("fee", null)
+                .set("source_amount", null)
+                .set("target_amount", null)
+                .set("fx_rate", null)
+                .set("internal_status", internalStatus)
+                .set("customer_status", "PROCESSING")
+                .set("screening_outcome", null)
+                .set("payout_reference", "PAY-REF-001")
+                .set("is_user_facing", null)
+                .set("chain", null)
+                .set("asset", null)
+                .set("source_address", null)
+                .set("destination_address", null)
+                .set("tx_hash", null)
+                .set("confirmations", null)
+                .set("gas_fee_micros", null)
+                .set("block_number", null)
+                .set("block_timestamp", null)
+                .set("provider", "provider-x")
+                .set("route", "route-1")
+                .set("beneficiary", beneficiary)
+                .set("sender", sender)
+                .set("description", "Payment to vendor")
+                .set("notes", "Monthly invoice")
+                .build();
+
+        return ValidatedEvent.fromRecord(
+                "payment.payout.fiat.v1", "key-1", record,
+                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
+    }
+
+    public static ValidatedEvent screeningEvent(
+            String screeningId, String customerId, String outcome,
+            String provider, double score, long durationMs) {
+        var envelope = envelope(null, null);
+        var record = new GenericRecordBuilder(SCREENING_SCHEMA)
+                .set("envelope", envelope)
+                .set("screening_id", screeningId)
+                .set("customer_id", customerId)
+                .set("transaction_reference", "TX-REF-001")
+                .set("outcome", outcome)
+                .set("provider", provider)
+                .set("rule_triggered", "RULE-01")
+                .set("score", score)
+                .set("duration_ms", durationMs)
+                .build();
+
+        return ValidatedEvent.fromRecord(
+                "screening.result.v1", "key-1", record,
+                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
+    }
+
+    private static GenericRecord envelope(String correlationId, String traceId) {
+        var rec = new GenericData.Record(ENVELOPE_SCHEMA);
+        rec.put("event_id", SOME_EVENT_ID);
+        rec.put("event_time", SOME_EVENT_TIME_MILLIS);
+        rec.put("ingest_time", SOME_INGEST_TIME_MILLIS);
+        rec.put("schema_version", SOME_SCHEMA_VERSION);
+        rec.put("flow_id", SOME_FLOW_ID);
+        rec.put("correlation_id", correlationId);
+        rec.put("trace_id", traceId);
+        return rec;
+    }
+
+    private static GenericRecord money(long amountMicros, String currency) {
+        return new GenericRecordBuilder(MONEY_SCHEMA)
+                .set("amount_micros", amountMicros)
+                .set("currency_code", currency)
+                .build();
+    }
+
+    private static GenericRecord party(String name) {
+        return new GenericRecordBuilder(PARTY_SCHEMA)
+                .set("name", name)
+                .build();
+    }
+}

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/SchemaBuilder.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/SchemaBuilder.java
@@ -1,0 +1,113 @@
+package io.stablepay.flink.fixtures;
+
+import java.util.List;
+
+import org.apache.avro.Schema;
+
+final class SchemaBuilder {
+
+    private SchemaBuilder() {}
+
+    static Schema money() {
+        return new Schema.Parser().parse("""
+                {
+                  "type": "record",
+                  "name": "Money",
+                  "namespace": "io.stablepay.events.common",
+                  "fields": [
+                    {"name": "amount_micros", "type": "long"},
+                    {"name": "currency_code", "type": "string"}
+                  ]
+                }
+                """);
+    }
+
+    static Schema envelope() {
+        return new Schema.Parser().parse("""
+                {
+                  "type": "record",
+                  "name": "EventEnvelope",
+                  "namespace": "io.stablepay.events.common",
+                  "fields": [
+                    {"name": "event_id", "type": "string"},
+                    {"name": "event_time", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+                    {"name": "ingest_time", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+                    {"name": "schema_version", "type": "string"},
+                    {"name": "flow_id", "type": ["null", "string"], "default": null},
+                    {"name": "correlation_id", "type": ["null", "string"], "default": null},
+                    {"name": "trace_id", "type": ["null", "string"], "default": null}
+                  ]
+                }
+                """);
+    }
+
+    static Schema party() {
+        return new Schema.Parser().parse("""
+                {
+                  "type": "record",
+                  "name": "Party",
+                  "namespace": "io.stablepay.events.common",
+                  "fields": [
+                    {"name": "name", "type": ["null", "string"], "default": null}
+                  ]
+                }
+                """);
+    }
+
+    static Schema payoutFiat(Schema envelope, Schema money, Schema party) {
+        return record("PayoutFiatV1", "io.stablepay.events.payments",
+                field("envelope", envelope),
+                field("customer_id", Schema.create(Schema.Type.STRING)),
+                field("account_id", Schema.create(Schema.Type.STRING)),
+                field("amount", money),
+                field("fee", nullable(money)),
+                field("source_amount", nullable(money)),
+                field("target_amount", nullable(money)),
+                field("fx_rate", nullable(Schema.create(Schema.Type.DOUBLE))),
+                field("internal_status", Schema.create(Schema.Type.STRING)),
+                field("customer_status", nullable(Schema.create(Schema.Type.STRING))),
+                field("screening_outcome", nullable(Schema.create(Schema.Type.STRING))),
+                field("payout_reference", nullable(Schema.create(Schema.Type.STRING))),
+                field("is_user_facing", nullable(Schema.create(Schema.Type.BOOLEAN))),
+                field("chain", nullable(Schema.create(Schema.Type.STRING))),
+                field("asset", nullable(Schema.create(Schema.Type.STRING))),
+                field("source_address", nullable(Schema.create(Schema.Type.STRING))),
+                field("destination_address", nullable(Schema.create(Schema.Type.STRING))),
+                field("tx_hash", nullable(Schema.create(Schema.Type.STRING))),
+                field("confirmations", nullable(Schema.create(Schema.Type.INT))),
+                field("gas_fee_micros", nullable(Schema.create(Schema.Type.LONG))),
+                field("block_number", nullable(Schema.create(Schema.Type.LONG))),
+                field("block_timestamp", nullable(Schema.create(Schema.Type.LONG))),
+                field("provider", nullable(Schema.create(Schema.Type.STRING))),
+                field("route", nullable(Schema.create(Schema.Type.STRING))),
+                field("beneficiary", nullable(party)),
+                field("sender", nullable(party)),
+                field("description", nullable(Schema.create(Schema.Type.STRING))),
+                field("notes", nullable(Schema.create(Schema.Type.STRING))));
+    }
+
+    static Schema screeningResult(Schema envelope) {
+        return record("ScreeningResultV1", "io.stablepay.events.screening",
+                field("envelope", envelope),
+                field("screening_id", nullable(Schema.create(Schema.Type.STRING))),
+                field("customer_id", nullable(Schema.create(Schema.Type.STRING))),
+                field("transaction_reference", nullable(Schema.create(Schema.Type.STRING))),
+                field("outcome", nullable(Schema.create(Schema.Type.STRING))),
+                field("provider", nullable(Schema.create(Schema.Type.STRING))),
+                field("rule_triggered", nullable(Schema.create(Schema.Type.STRING))),
+                field("score", nullable(Schema.create(Schema.Type.DOUBLE))),
+                field("duration_ms", nullable(Schema.create(Schema.Type.LONG))));
+    }
+
+    private static Schema nullable(Schema schema) {
+        return Schema.createUnion(Schema.create(Schema.Type.NULL), schema);
+    }
+
+    private static Schema record(String name, String namespace, Schema.Field... fields) {
+        return Schema.createRecord(name, null, namespace, false, List.of(fields));
+    }
+
+    private static Schema.Field field(String name, Schema schema) {
+        return new Schema.Field(name, schema, null, null);
+    }
+}

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactScreeningMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactScreeningMapperTest.java
@@ -1,0 +1,102 @@
+package io.stablepay.flink.mapper;
+
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_EVENT_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_EVENT_TIME_MILLIS;
+import static io.stablepay.flink.fixtures.FactFixtures.screeningEvent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EventToFactScreeningMapperTest {
+
+    @Test
+    void shouldProduceRowDataWith10Fields() {
+        // given
+        var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.1, 250L);
+
+        // when
+        var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+        // then
+        assertThat(result.getArity()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldMapAllFieldsCorrectly() {
+        // given
+        var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.85, 250L);
+
+        // when
+        var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+        // then
+        var expected = new GenericRowData(10);
+        expected.setField(0, StringData.fromString(SOME_EVENT_ID));
+        expected.setField(1, StringData.fromString("SCR-001"));
+        expected.setField(2, StringData.fromString("cust-001"));
+        expected.setField(3, StringData.fromString("TX-REF-001"));
+        expected.setField(4, StringData.fromString("PASS"));
+        expected.setField(5, StringData.fromString("chainalysis"));
+        expected.setField(6, StringData.fromString("RULE-01"));
+        expected.setField(7, 0.85);
+        expected.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
+        expected.setField(9, 250L);
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Nested
+    class CustomerIdIsNotMasked {
+
+        @Test
+        void shouldStoreCustomerIdUnmasked() {
+            // given
+            var customerId = "a1b2c3d4-e5f6-7890-abcd-1234";
+            var event = screeningEvent("SCR-001", customerId, "PASS", "provider", 0.5, 100L);
+
+            // when
+            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(2).toString()).isEqualTo(customerId);
+        }
+    }
+
+    @Nested
+    class ScoreUsesDouble {
+
+        @Test
+        void shouldStoreScoreAsDouble() {
+            // given
+            var event = screeningEvent("SCR-001", "cust-001", "FLAG", "provider", 0.95, 100L);
+
+            // when
+            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+            // then
+            assertThat(result.getDouble(7)).isEqualTo(0.95);
+        }
+    }
+
+    @Nested
+    class DurationUsesLong {
+
+        @Test
+        void shouldStoreDurationMsAsLong() {
+            // given
+            var event = screeningEvent("SCR-001", "cust-001", "PASS", "provider", 0.1, 3500L);
+
+            // when
+            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+            // then
+            assertThat(result.getLong(9)).isEqualTo(3500L);
+        }
+    }
+}

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactTransactionMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactTransactionMapperTest.java
@@ -1,0 +1,227 @@
+package io.stablepay.flink.mapper;
+
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_ACCOUNT_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_CORRELATION_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_CUSTOMER_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_EVENT_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_EVENT_TIME_MILLIS;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_FLOW_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_INGEST_TIME_MILLIS;
+import static io.stablepay.flink.fixtures.FactFixtures.SOME_TRACE_ID;
+import static io.stablepay.flink.fixtures.FactFixtures.fiatPayoutEvent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EventToFactTransactionMapperTest {
+
+    @Test
+    void shouldProduceRowDataWith41Fields() {
+        // given
+        var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+
+        // when
+        var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+        // then
+        assertThat(result.getArity()).isEqualTo(41);
+    }
+
+    @Test
+    void shouldMapAllFieldsForFiatPayout() {
+        // given
+        var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+
+        // when
+        var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+        // then
+        var expected = new GenericRowData(41);
+        expected.setField(0, StringData.fromString(SOME_EVENT_ID));
+        expected.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
+        expected.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_INGEST_TIME_MILLIS)));
+        expected.setField(3, StringData.fromString(SOME_FLOW_ID));
+        expected.setField(4, StringData.fromString(SOME_CORRELATION_ID));
+        expected.setField(5, StringData.fromString(SOME_TRACE_ID));
+        expected.setField(6, StringData.fromString("PAYOUT_FIAT"));
+        expected.setField(7, StringData.fromString("FIAT"));
+        expected.setField(8, StringData.fromString("OUTBOUND"));
+        expected.setField(9, false);
+        expected.setField(10, null);
+        expected.setField(11, StringData.fromString("PAY-REF-001"));
+        expected.setField(12, StringData.fromString(SOME_CUSTOMER_ID));
+        expected.setField(13, StringData.fromString(SOME_ACCOUNT_ID));
+        expected.setField(14, 5_000_000L);
+        expected.setField(15, StringData.fromString("USD"));
+        expected.setField(16, null);
+        expected.setField(17, null);
+        expected.setField(18, null);
+        expected.setField(19, null);
+        expected.setField(20, null);
+        expected.setField(21, null);
+        expected.setField(22, null);
+        expected.setField(23, StringData.fromString("COMPLETED"));
+        expected.setField(24, StringData.fromString("PROCESSING"));
+        expected.setField(25, null);
+        expected.setField(26, null);
+        expected.setField(27, null);
+        expected.setField(28, null);
+        expected.setField(29, null);
+        expected.setField(30, null);
+        expected.setField(31, null);
+        expected.setField(32, null);
+        expected.setField(33, null);
+        expected.setField(34, null);
+        expected.setField(35, StringData.fromString("provider-x"));
+        expected.setField(36, StringData.fromString("route-1"));
+        expected.setField(37, StringData.fromString(PiiMasker.mask("Jane Beneficiary")));
+        expected.setField(38, StringData.fromString(PiiMasker.mask("John Sender")));
+        expected.setField(39, StringData.fromString(PiiMasker.mask("Payment to vendor")));
+        expected.setField(40, StringData.fromString(PiiMasker.mask("Monthly invoice")));
+
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Nested
+    class CustomerIdIsNotMasked {
+
+        @Test
+        void shouldStoreCustomerIdUnmasked() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(12).toString()).isEqualTo(SOME_CUSTOMER_ID);
+        }
+
+        @Test
+        void shouldStoreAccountIdUnmasked() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(13).toString()).isEqualTo(SOME_ACCOUNT_ID);
+        }
+    }
+
+    @Nested
+    class PiiFieldsAreMasked {
+
+        @Test
+        void shouldMaskBeneficiaryName() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(37).toString()).isEqualTo("Jane************");
+        }
+
+        @Test
+        void shouldMaskDescription() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(39).toString()).startsWith("Paym");
+            assertThat(result.getString(39).toString()).contains("*");
+        }
+    }
+
+    @Nested
+    class MoneyFieldsUseLong {
+
+        @Test
+        void shouldStoreAmountMicrosAsLong() {
+            // given
+            var event = fiatPayoutEvent(12_345_678L, "GBP", "COMPLETED");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getLong(14)).isEqualTo(12_345_678L);
+        }
+
+        @Test
+        void shouldStoreCurrencyCodeAsString() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "GBP", "COMPLETED");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(15).toString()).isEqualTo("GBP");
+        }
+    }
+
+    @Nested
+    class DerivedFields {
+
+        @Test
+        void shouldDeriveEventTypeFromTopic() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(6).toString()).isEqualTo("PAYOUT_FIAT");
+        }
+
+        @Test
+        void shouldDeriveFlowTypeFiatFromFiatTopic() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(7).toString()).isEqualTo("FIAT");
+        }
+
+        @Test
+        void shouldDeriveDirectionOutboundFromPayoutTopic() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getString(8).toString()).isEqualTo("OUTBOUND");
+        }
+
+        @Test
+        void shouldSetIsCryptoFalseForFiatTopic() {
+            // given
+            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+
+            // when
+            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+            // then
+            assertThat(result.getBoolean(9)).isFalse();
+        }
+    }
+}

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/PiiMaskerTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/PiiMaskerTest.java
@@ -1,0 +1,77 @@
+package io.stablepay.flink.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+
+class PiiMaskerTest {
+
+    @Nested
+    class WhenInputIsNullOrEmpty {
+
+        @Test
+        void shouldReturnNullForNullInput() {
+            // when
+            var result = PiiMasker.mask(null);
+
+            // then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnEmptyForEmptyInput() {
+            // when
+            var result = PiiMasker.mask("");
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class WhenInputIsShorterThanPrefix {
+
+        @Test
+        void shouldFullyMaskSingleCharacter() {
+            // when
+            var result = PiiMasker.mask("A");
+
+            // then
+            assertThat(result).isEqualTo("*");
+        }
+
+        @Test
+        void shouldFullyMaskStringAtPrefixLength() {
+            // when
+            var result = PiiMasker.mask("abcd");
+
+            // then
+            assertThat(result).isEqualTo("****");
+        }
+    }
+
+    @Nested
+    class WhenInputIsLongerThanPrefix {
+
+        @Test
+        void shouldPreservePrefixAndMaskRemainder() {
+            // when
+            var result = PiiMasker.mask("John Doe");
+
+            // then
+            assertThat(result).isEqualTo("John****");
+        }
+
+        @Test
+        void shouldMaskUuidPreservingFirstFourChars() {
+            // when
+            var result = PiiMasker.mask("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+            // then
+            assertThat(result).startsWith("a1b2");
+            assertThat(result).hasSize(36);
+            assertThat(result.substring(4)).matches("\\*+");
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,8 @@ flink-connector-kafka = { module = "org.apache.flink:flink-connector-kafka", ver
 flink-avro = { module = "org.apache.flink:flink-avro", version.ref = "flink" }
 flink-avro-confluent-registry = { module = "org.apache.flink:flink-avro-confluent-registry", version.ref = "flink" }
 flink-table-common = { module = "org.apache.flink:flink-table-common", version.ref = "flink" }
+flink-table-api-bridge = { module = "org.apache.flink:flink-table-api-java-bridge", version.ref = "flink" }
+flink-table-planner = { module = "org.apache.flink:flink-table-planner_2.12", version.ref = "flink" }
 iceberg-flink-runtime = { module = "org.apache.iceberg:iceberg-flink-runtime-2.0", version.ref = "iceberg" }
 opensearch-java = { module = "org.opensearch.client:opensearch-java", version.ref = "opensearch-java" }
 httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }


### PR DESCRIPTION
## Summary
- Add three denormalized Iceberg fact tables: `fact_transactions` (41 fields), `fact_flows` (20 fields), `fact_screening_outcomes` (10 fields)
- Wire streaming enrichment sinks into `IngestJob` for `fact_transactions` and `fact_screening_outcomes`
- Create `FactFlowsMergeJob` batch job that periodically MERGEs raw Iceberg tables into `fact_flows`
- Add `FactTableSinkFactory` with schema definitions, partition specs (day + bucket), format-version 2, ZSTD compression
- Add `EventToFactTransactionMapper` and `EventToFactScreeningMapper` for RowData conversion
- Add `FACT_TX_TOPICS` constant to `FlinkConfig` and fact namespace constants to `IcebergCatalogConfig`
- Add `flink-table-api-bridge` and `flink-table-planner` dependencies for Table API support

## Closes

Closes #51
Closes #52
Closes #53
Closes #54
Closes #55

## Key design decisions
- Money fields use `long` micros (never float/double) — only `fx_rate` and `score` use `DoubleType`
- `fact_transactions` partitioned by `days(event_time)` + `bucket(customer_id, 16)` for analytics query performance
- `fact_flows` populated via periodic MERGE (not streaming) since it requires cross-table joins
- All fact tables use Iceberg format-version 2 for future row-level update support

## Test plan
- [x] `shadowJar` builds successfully
- [x] LongType count >= 6 for money fields
- [x] DoubleType count == 2 (fx_rate + score only)
- [x] Zero float/Float usage in FactTableSinkFactory
- [x] IngestJob references FactTableSinkFactory >= 2 times
- [x] fact-transactions-map and fact-screening-map operators present

🤖 Generated with [Claude Code](https://claude.com/claude-code)