### PR TITLE
SPP-79: Flyway migrations — users (with customer_id), refresh tokens, signing keys

### DIFF
--- a/apps/auth/main/src/business-test/java/io/stablepay/auth/migration/AuthMigrationsBusinessTest.java
+++ b/apps/auth/main/src/business-test/java/io/stablepay/auth/migration/AuthMigrationsBusinessTest.java
@@ -1,0 +1,149 @@
+package io.stablepay.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class AuthMigrationsBusinessTest {
+
+    private static final String PLAIN_PASSWORD = "demo1234";
+    private static final UUID ALICE_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID BOB_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID ADMIN_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID AGENT_ID = UUID.fromString("44444444-4444-4444-4444-444444444444");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:17-alpine")
+                    .withDatabaseName("stablepay_auth")
+                    .withUsername("stablepay")
+                    .withPassword("stablepay");
+
+    private static JdbcTemplate jdbc;
+
+    @BeforeAll
+    static void migrate() {
+        var dataSource =
+                new DriverManagerDataSource(
+                        POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations("classpath:db/migration")
+                .load()
+                .migrate();
+        jdbc = new JdbcTemplate(dataSource);
+    }
+
+    @Test
+    void v1SeedsFourUsersWithBcryptHashesMatchingDemo1234() {
+        var encoder = new BCryptPasswordEncoder();
+
+        var actual =
+                jdbc.query(
+                        "SELECT user_id, customer_id, email, roles, password FROM users ORDER BY email",
+                        (rs, rowNum) ->
+                                new SeededUser(
+                                        rs.getObject("user_id", UUID.class),
+                                        rs.getObject("customer_id", UUID.class),
+                                        rs.getString("email"),
+                                        rs.getString("roles"),
+                                        encoder.matches(PLAIN_PASSWORD, rs.getString("password"))));
+
+        var expected =
+                List.of(
+                        new SeededUser(ADMIN_ID, null, "admin@stablepay.io", "ADMIN", true),
+                        new SeededUser(AGENT_ID, null, "agent@stablepay.io", "AGENT", true),
+                        new SeededUser(ALICE_ID, ALICE_ID, "alice@stablepay.io", "ADMIN,CUSTOMER", true),
+                        new SeededUser(BOB_ID, BOB_ID, "bob@stablepay.io", "CUSTOMER", true));
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void v2RefreshTokensRejectsDuplicateActiveTokenHash() {
+        var hash = "duplicate-active-hash";
+        insertActiveRefreshToken(hash);
+
+        assertThatThrownBy(() -> insertActiveRefreshToken(hash))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    void v2RefreshTokensAllowsReuseOfTokenHashAfterRevocation() {
+        var hash = "revoke-then-reuse-hash";
+        var firstId = insertActiveRefreshToken(hash);
+        jdbc.update("UPDATE refresh_tokens SET revoked_at = NOW() WHERE token_id = ?", firstId);
+
+        insertActiveRefreshToken(hash);
+
+        var activeCount =
+                jdbc.queryForObject(
+                        "SELECT COUNT(*) FROM refresh_tokens WHERE token_hash = ? AND revoked_at IS NULL",
+                        Integer.class,
+                        hash);
+        assertThat(activeCount).isOne();
+    }
+
+    @Test
+    void v3JwtSigningKeysAppliesRs256AndIsActiveDefaults() {
+        jdbc.update(
+                "INSERT INTO jwt_signing_keys (kid, private_key_pem, public_key_pem) VALUES (?, ?, ?)",
+                "test-kid",
+                "test-private-pem",
+                "test-public-pem");
+
+        var actual =
+                jdbc.queryForObject(
+                        "SELECT kid, private_key_pem, public_key_pem, algorithm, is_active FROM jwt_signing_keys WHERE kid = ?",
+                        (rs, rowNum) ->
+                                new SigningKey(
+                                        rs.getString("kid"),
+                                        rs.getString("private_key_pem"),
+                                        rs.getString("public_key_pem"),
+                                        rs.getString("algorithm"),
+                                        rs.getBoolean("is_active")),
+                        "test-kid");
+
+        var expected =
+                new SigningKey("test-kid", "test-private-pem", "test-public-pem", "RS256", true);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    private UUID insertActiveRefreshToken(String tokenHash) {
+        var tokenId = UUID.randomUUID();
+        jdbc.update(
+                "INSERT INTO refresh_tokens (token_id, user_id, token_hash, expires_at) VALUES (?, ?, ?, NOW() + INTERVAL '1 hour')",
+                tokenId,
+                ALICE_ID,
+                tokenHash);
+        return tokenId;
+    }
+
+    private record SeededUser(
+            UUID userId,
+            UUID customerId,
+            String email,
+            String roles,
+            boolean passwordMatchesDemo1234) {}
+
+    private record SigningKey(
+            String kid,
+            String privateKeyPem,
+            String publicKeyPem,
+            String algorithm,
+            boolean isActive) {}
+}

--- a/apps/auth/main/src/main/resources/application.yml
+++ b/apps/auth/main/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    baseline-on-migrate: true
+  jpa:
+    open-in-view: false
 
 server:
   port: ${AUTH_PORT:9000}
@@ -21,3 +24,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: when-authorized

--- a/apps/auth/main/src/main/resources/db/migration/V1__seed_users.sql
+++ b/apps/auth/main/src/main/resources/db/migration/V1__seed_users.sql
@@ -1,0 +1,18 @@
+CREATE TABLE users (
+    user_id      UUID PRIMARY KEY,
+    customer_id  UUID,
+    email        VARCHAR(255) UNIQUE NOT NULL,
+    password     VARCHAR(60) NOT NULL,
+    roles        VARCHAR(255) NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_email ON users (LOWER(email));
+
+-- BCrypt cost 12 hashes of "demo1234"; v1 customer model: customer_id == user_id for CUSTOMER role, NULL for ADMIN/AGENT.
+INSERT INTO users (user_id, customer_id, email, password, roles) VALUES
+    ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'alice@stablepay.io', '$2a$12$EM1IpXmM8bThvR/pHFsOi.KAV.F1WpsL0/xCosKt.GfHu7c.m2JkO', 'ADMIN,CUSTOMER'),
+    ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'bob@stablepay.io',   '$2a$12$0OMsSqcM8VbRM/g88FWD3OJOT7gqEDNTPN1XfDj2gAMRhhi7BH9B.', 'CUSTOMER'),
+    ('33333333-3333-3333-3333-333333333333', NULL,                                   'admin@stablepay.io', '$2a$12$rG4YpMO6XAIOYq3AoYru1uEk0JKGJujpDbBJ6XAlN1VVNkFsKuzTy', 'ADMIN'),
+    ('44444444-4444-4444-4444-444444444444', NULL,                                   'agent@stablepay.io', '$2a$12$127udczsDQn8e3fFfNFFWeHb6ohAcLHnK25jAtbLL4i.I/2zuOnzm', 'AGENT');

--- a/apps/auth/main/src/main/resources/db/migration/V2__refresh_tokens.sql
+++ b/apps/auth/main/src/main/resources/db/migration/V2__refresh_tokens.sql
@@ -1,0 +1,12 @@
+CREATE TABLE refresh_tokens (
+    token_id    UUID PRIMARY KEY,
+    user_id     UUID NOT NULL REFERENCES users(user_id),
+    token_hash  VARCHAR(64) NOT NULL,
+    issued_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    revoked_at  TIMESTAMPTZ
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens (user_id);
+CREATE UNIQUE INDEX idx_refresh_tokens_token_hash_active ON refresh_tokens (token_hash) WHERE revoked_at IS NULL;
+CREATE INDEX idx_refresh_tokens_expires_at_active ON refresh_tokens (expires_at) WHERE revoked_at IS NULL;

--- a/apps/auth/main/src/main/resources/db/migration/V3__jwt_signing_keys.sql
+++ b/apps/auth/main/src/main/resources/db/migration/V3__jwt_signing_keys.sql
@@ -1,0 +1,8 @@
+CREATE TABLE jwt_signing_keys (
+    kid             VARCHAR(64) PRIMARY KEY,
+    private_key_pem TEXT NOT NULL,
+    public_key_pem  TEXT NOT NULL,
+    algorithm       VARCHAR(16) NOT NULL DEFAULT 'RS256',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    is_active       BOOLEAN NOT NULL DEFAULT TRUE
+);


### PR DESCRIPTION
## Summary
- Add Flyway V1/V2/V3 migrations under `apps/auth/main/src/main/resources/db/migration/`
- V1 creates `users(user_id, customer_id, email, password, roles, created_at, updated_at)` and seeds 4 fixed users (alice, bob, admin, agent) with BCrypt(12) hashes of `demo1234`
- V2 creates `refresh_tokens` with `revoked_at` and a partial **UNIQUE** index on `token_hash` where `revoked_at IS NULL`, plus an active-rows-only index on `expires_at`
- V3 creates `jwt_signing_keys(kid PK, private_key_pem, public_key_pem, algorithm DEFAULT 'RS256', created_at, is_active DEFAULT TRUE)`
- `application.yml` enables `baseline-on-migrate`, sets `jpa.open-in-view: false`, and exposes `health.show-details: when-authorized`

## Closes
Closes #85

## Customer-id rule
- alice, bob → `customer_id = user_id` (CUSTOMER role; v1 1:1 mapping)
- admin, agent → `customer_id = NULL` (no customer scope)

## BCrypt hashes (cost 12, all verified `matches("demo1234") == true`)
Generated via `BCryptPasswordEncoder(12).encode("demo1234")` using `spring-security-crypto:7.0.5`. The business-test re-verifies each row with `BCryptPasswordEncoder.matches()`.

## Test plan
- [x] V1 seeds 4 users with deterministic UUIDs and matching BCrypt hashes — verified by `AuthMigrationsBusinessTest.v1SeedsFourUsersWithBcryptHashesMatchingDemo1234`
- [x] V2 partial UNIQUE index blocks duplicate active `token_hash` — verified by `v2RefreshTokensRejectsDuplicateActiveTokenHash`
- [x] V2 partial UNIQUE index allows hash reuse after revocation — verified by `v2RefreshTokensAllowsReuseOfTokenHashAfterRevocation`
- [x] V3 defaults `algorithm = 'RS256'` and `is_active = TRUE` — verified by `v3JwtSigningKeysAppliesRs256AndIsActiveDefaults`
- [x] All migrations applied cleanly against `postgres:17-alpine` testcontainer
- [x] `./gradlew :apps:auth:main:build` green

## Notes
- Index renamed from plan's `idx_refresh_tokens_token_hash` to `idx_refresh_tokens_token_hash_active` to encode partial-unique intent in the name; plan-level non-unique was inconsistent with the issue's "partial **unique** index" acceptance criterion — followed the issue.
- `spotlessApply` not registered project-wide yet; build is green without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)