### PR TITLE
chore(tooling): wire Spotless + google-java-format across Java modules

### DIFF
--- a/apps/auth/main/src/main/java/io/stablepay/auth/StablepayAuthApplication.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/StablepayAuthApplication.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class StablepayAuthApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(StablepayAuthApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(StablepayAuthApplication.class, args);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/AggregationJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/AggregationJob.java
@@ -1,14 +1,5 @@
 package io.stablepay.flink;
 
-import java.time.Duration;
-
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.connector.kafka.source.KafkaSource;
-import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
-import org.apache.flink.core.execution.CheckpointingMode;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-
 import io.stablepay.flink.agg.Aggregators;
 import io.stablepay.flink.config.FlinkConfig;
 import io.stablepay.flink.deser.AvroEnvelopeDeserializer;
@@ -19,119 +10,135 @@ import io.stablepay.flink.model.ValidationResult;
 import io.stablepay.flink.sink.AggTableSinkFactory;
 import io.stablepay.flink.topic.TopicDerivation;
 import io.stablepay.flink.watermark.EnvelopeTimestampAssigner;
+import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.core.execution.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 
 @Slf4j
 public class AggregationJob {
 
-    private static final Duration CHECKPOINT_INTERVAL = Duration.ofMinutes(1);
-    private static final Duration CHECKPOINT_TIMEOUT = Duration.ofMinutes(10);
-    private static final Duration MIN_PAUSE_BETWEEN_CHECKPOINTS = Duration.ofSeconds(30);
+  private static final Duration CHECKPOINT_INTERVAL = Duration.ofMinutes(1);
+  private static final Duration CHECKPOINT_TIMEOUT = Duration.ofMinutes(10);
+  private static final Duration MIN_PAUSE_BETWEEN_CHECKPOINTS = Duration.ofSeconds(30);
 
-    public static void main(String[] args) throws Exception {
-        log.info("Starting stablepay-aggregation-job");
-        var env = StreamExecutionEnvironment.getExecutionEnvironment();
+  public static void main(String[] args) throws Exception {
+    log.info("Starting stablepay-aggregation-job");
+    var env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        var checkpointConfig = env.getCheckpointConfig();
-        env.enableCheckpointing(CHECKPOINT_INTERVAL.toMillis(), CheckpointingMode.EXACTLY_ONCE);
-        checkpointConfig.setCheckpointTimeout(CHECKPOINT_TIMEOUT.toMillis());
-        checkpointConfig.setMinPauseBetweenCheckpoints(MIN_PAUSE_BETWEEN_CHECKPOINTS.toMillis());
-        checkpointConfig.setMaxConcurrentCheckpoints(1);
+    var checkpointConfig = env.getCheckpointConfig();
+    env.enableCheckpointing(CHECKPOINT_INTERVAL.toMillis(), CheckpointingMode.EXACTLY_ONCE);
+    checkpointConfig.setCheckpointTimeout(CHECKPOINT_TIMEOUT.toMillis());
+    checkpointConfig.setMinPauseBetweenCheckpoints(MIN_PAUSE_BETWEEN_CHECKPOINTS.toMillis());
+    checkpointConfig.setMaxConcurrentCheckpoints(1);
 
-        var watermarkStrategy = WatermarkStrategy
-                .<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
-                .withIdleness(Duration.ofMinutes(1))
-                .withTimestampAssigner(new EnvelopeTimestampAssigner());
+    var watermarkStrategy =
+        WatermarkStrategy.<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
+            .withIdleness(Duration.ofMinutes(1))
+            .withTimestampAssigner(new EnvelopeTimestampAssigner());
 
-        var mainSource = KafkaSource.<ValidationResult>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setTopics(FlinkConfig.INPUT_TOPICS)
-                .setGroupId(FlinkConfig.AGGREGATION_CONSUMER_GROUP)
-                .setStartingOffsets(OffsetsInitializer.earliest())
-                .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
-                .build();
+    var mainSource =
+        KafkaSource.<ValidationResult>builder()
+            .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+            .setTopics(FlinkConfig.INPUT_TOPICS)
+            .setGroupId(FlinkConfig.AGGREGATION_CONSUMER_GROUP)
+            .setStartingOffsets(OffsetsInitializer.earliest())
+            .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
+            .build();
 
-        var validatedStream = env
-                .fromSource(mainSource, WatermarkStrategy.noWatermarks(), "agg-kafka-source")
-                .filter(r -> r instanceof ValidationResult.Valid)
-                .map(r -> ((ValidationResult.Valid) r).event())
-                .assignTimestampsAndWatermarks(watermarkStrategy)
-                .name("agg-validated-events");
+    var validatedStream =
+        env.fromSource(mainSource, WatermarkStrategy.noWatermarks(), "agg-kafka-source")
+            .filter(r -> r instanceof ValidationResult.Valid)
+            .map(r -> ((ValidationResult.Valid) r).event())
+            .assignTimestampsAndWatermarks(watermarkStrategy)
+            .name("agg-validated-events");
 
-        var aggSinkFactory = new AggTableSinkFactory();
-        aggSinkFactory.ensureAggTablesExist();
+    var aggSinkFactory = new AggTableSinkFactory();
+    aggSinkFactory.ensureAggTablesExist();
 
-        // --- Volume aggregation: payment topics → keyBy(flowType, direction, currency) ---
-        var volumeStream = validatedStream
-                .filter(e -> FlinkConfig.PAYMENT_TOPICS.contains(e.topic()))
-                .keyBy(e -> TopicDerivation.deriveFlowType(e.topic())
-                        + "|" + TopicDerivation.deriveDirection(e.topic())
-                        + "|" + extractCurrency(e))
-                .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
-                .aggregate(Aggregators.volume(), Aggregators.<String>windowTimestamptz(0, 1))
-                .name("agg-volume-hourly");
+    // --- Volume aggregation: payment topics → keyBy(flowType, direction, currency) ---
+    var volumeStream =
+        validatedStream
+            .filter(e -> FlinkConfig.PAYMENT_TOPICS.contains(e.topic()))
+            .keyBy(
+                e ->
+                    TopicDerivation.deriveFlowType(e.topic())
+                        + "|"
+                        + TopicDerivation.deriveDirection(e.topic())
+                        + "|"
+                        + extractCurrency(e))
+            .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
+            .aggregate(Aggregators.volume(), Aggregators.<String>windowTimestamptz(0, 1))
+            .name("agg-volume-hourly");
 
-        aggSinkFactory.addSink(volumeStream, "agg_volume_hourly");
+    aggSinkFactory.addSink(volumeStream, "agg_volume_hourly");
 
-        // --- Success rate aggregation: payment topics → keyBy(flowType) ---
-        var successRateStream = validatedStream
-                .filter(e -> FlinkConfig.PAYMENT_TOPICS.contains(e.topic()))
-                .keyBy(e -> TopicDerivation.deriveFlowType(e.topic()))
-                .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
-                .aggregate(Aggregators.successRate(), Aggregators.<String>windowTimestamptz(0, 1))
-                .name("agg-success-rate-hourly");
+    // --- Success rate aggregation: payment topics → keyBy(flowType) ---
+    var successRateStream =
+        validatedStream
+            .filter(e -> FlinkConfig.PAYMENT_TOPICS.contains(e.topic()))
+            .keyBy(e -> TopicDerivation.deriveFlowType(e.topic()))
+            .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
+            .aggregate(Aggregators.successRate(), Aggregators.<String>windowTimestamptz(0, 1))
+            .name("agg-success-rate-hourly");
 
-        aggSinkFactory.addSink(successRateStream, "agg_success_rate_hourly");
+    aggSinkFactory.addSink(successRateStream, "agg_success_rate_hourly");
 
-        // --- Screening outcomes aggregation: screening.result.v1 → keyBy(outcome, provider) ---
-        var screeningStream = validatedStream
-                .filter(e -> "screening.result.v1".equals(e.topic()))
-                .keyBy(e -> extractField(e, "outcome") + "|" + extractField(e, "provider"))
-                .window(TumblingEventTimeWindows.of(Duration.ofDays(1)))
-                .aggregate(Aggregators.screeningOutcomes(), Aggregators.<String>windowDate(0))
-                .name("agg-screening-outcomes-daily");
+    // --- Screening outcomes aggregation: screening.result.v1 → keyBy(outcome, provider) ---
+    var screeningStream =
+        validatedStream
+            .filter(e -> "screening.result.v1".equals(e.topic()))
+            .keyBy(e -> extractField(e, "outcome") + "|" + extractField(e, "provider"))
+            .window(TumblingEventTimeWindows.of(Duration.ofDays(1)))
+            .aggregate(Aggregators.screeningOutcomes(), Aggregators.<String>windowDate(0))
+            .name("agg-screening-outcomes-daily");
 
-        aggSinkFactory.addSink(screeningStream, "agg_screening_outcomes_daily");
+    aggSinkFactory.addSink(screeningStream, "agg_screening_outcomes_daily");
 
-        // --- DLQ summary aggregation: DLQ topics → keyBy(errorClass, sourceTopic) ---
-        var dlqWatermark = WatermarkStrategy
-                .<DlqEnvelope>forBoundedOutOfOrderness(Duration.ofSeconds(60))
-                .withIdleness(Duration.ofMinutes(1))
-                .withTimestampAssigner((e, ts) -> e.failedAt());
+    // --- DLQ summary aggregation: DLQ topics → keyBy(errorClass, sourceTopic) ---
+    var dlqWatermark =
+        WatermarkStrategy.<DlqEnvelope>forBoundedOutOfOrderness(Duration.ofSeconds(60))
+            .withIdleness(Duration.ofMinutes(1))
+            .withTimestampAssigner((e, ts) -> e.failedAt());
 
-        var dlqSource = KafkaSource.<DlqEnvelope>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setTopics(FlinkConfig.DLQ_TOPICS)
-                .setGroupId(FlinkConfig.AGGREGATION_CONSUMER_GROUP + "-dlq")
-                .setStartingOffsets(OffsetsInitializer.earliest())
-                .setDeserializer(new DlqDeserializer())
-                .build();
+    var dlqSource =
+        KafkaSource.<DlqEnvelope>builder()
+            .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+            .setTopics(FlinkConfig.DLQ_TOPICS)
+            .setGroupId(FlinkConfig.AGGREGATION_CONSUMER_GROUP + "-dlq")
+            .setStartingOffsets(OffsetsInitializer.earliest())
+            .setDeserializer(new DlqDeserializer())
+            .build();
 
-        var dlqSummaryStream = env
-                .fromSource(dlqSource, dlqWatermark, "agg-dlq-kafka-source")
-                .keyBy(e -> e.errorClass() + "|" + e.sourceTopic())
-                .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
-                .aggregate(Aggregators.dlqSummary(), Aggregators.<String>windowTimestamptz(0, 1))
-                .name("agg-dlq-summary-hourly");
+    var dlqSummaryStream =
+        env.fromSource(dlqSource, dlqWatermark, "agg-dlq-kafka-source")
+            .keyBy(e -> e.errorClass() + "|" + e.sourceTopic())
+            .window(TumblingEventTimeWindows.of(Duration.ofHours(1)))
+            .aggregate(Aggregators.dlqSummary(), Aggregators.<String>windowTimestamptz(0, 1))
+            .name("agg-dlq-summary-hourly");
 
-        aggSinkFactory.addSink(dlqSummaryStream, "agg_dlq_summary_hourly");
+    aggSinkFactory.addSink(dlqSummaryStream, "agg_dlq_summary_hourly");
 
-        env.execute("stablepay-aggregation-job");
+    env.execute("stablepay-aggregation-job");
+  }
+
+  private static String extractCurrency(ValidatedEvent event) {
+    var record = event.toRecord();
+    var amount = record.get("amount");
+    if (amount instanceof org.apache.avro.generic.GenericRecord moneyRecord) {
+      var code = moneyRecord.get("currency_code");
+      if (code != null) return code.toString();
     }
+    return "UNKNOWN";
+  }
 
-    private static String extractCurrency(ValidatedEvent event) {
-        var record = event.toRecord();
-        var amount = record.get("amount");
-        if (amount instanceof org.apache.avro.generic.GenericRecord moneyRecord) {
-            var code = moneyRecord.get("currency_code");
-            if (code != null) return code.toString();
-        }
-        return "UNKNOWN";
-    }
-
-    private static String extractField(ValidatedEvent event, String fieldName) {
-        var record = event.toRecord();
-        var value = record.get(fieldName);
-        return value != null ? value.toString() : "UNKNOWN";
-    }
+  private static String extractField(ValidatedEvent event, String fieldName) {
+    var record = event.toRecord();
+    var value = record.get(fieldName);
+    return value != null ? value.toString() : "UNKNOWN";
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/CorrelatorJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/CorrelatorJob.java
@@ -1,15 +1,5 @@
 package io.stablepay.flink;
 
-import java.time.Duration;
-import java.util.List;
-
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.connector.kafka.sink.KafkaSink;
-import org.apache.flink.connector.kafka.source.KafkaSource;
-import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-
 import io.stablepay.flink.config.FlinkConfig;
 import io.stablepay.flink.correlator.FlowCorrelatorFunction;
 import io.stablepay.flink.correlator.FlowEventSerializer;
@@ -17,54 +7,65 @@ import io.stablepay.flink.deser.AvroEnvelopeDeserializer;
 import io.stablepay.flink.model.ValidatedEvent;
 import io.stablepay.flink.model.ValidationResult;
 import io.stablepay.flink.watermark.EnvelopeTimestampAssigner;
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class CorrelatorJob {
 
-    private static final List<String> CORRELATOR_TOPICS = List.of(
-            "payment.payout.fiat.v1",
-            "payment.payout.crypto.v1",
-            "payment.payin.fiat.v1",
-            "payment.payin.crypto.v1",
-            "payment.flow.v1",
-            "chain.transaction.v1");
+  private static final List<String> CORRELATOR_TOPICS =
+      List.of(
+          "payment.payout.fiat.v1",
+          "payment.payout.crypto.v1",
+          "payment.payin.fiat.v1",
+          "payment.payin.crypto.v1",
+          "payment.flow.v1",
+          "chain.transaction.v1");
 
-    public static void main(String[] args) throws Exception {
-        var env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
+  public static void main(String[] args) throws Exception {
+    var env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
 
-        var kafkaSource = KafkaSource.<ValidationResult>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setTopics(CORRELATOR_TOPICS)
-                .setGroupId(FlinkConfig.CORRELATOR_CONSUMER_GROUP)
-                .setStartingOffsets(OffsetsInitializer.earliest())
-                .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
-                .build();
+    var kafkaSource =
+        KafkaSource.<ValidationResult>builder()
+            .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+            .setTopics(CORRELATOR_TOPICS)
+            .setGroupId(FlinkConfig.CORRELATOR_CONSUMER_GROUP)
+            .setStartingOffsets(OffsetsInitializer.earliest())
+            .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
+            .build();
 
-        var watermarkStrategy = WatermarkStrategy
-                .<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
-                .withIdleness(Duration.ofMinutes(1))
-                .withTimestampAssigner(new EnvelopeTimestampAssigner());
+    var watermarkStrategy =
+        WatermarkStrategy.<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
+            .withIdleness(Duration.ofMinutes(1))
+            .withTimestampAssigner(new EnvelopeTimestampAssigner());
 
-        var flowEvents = env
-                .fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "correlator-kafka-source")
-                .filter(r -> r instanceof ValidationResult.Valid)
-                .map(r -> ((ValidationResult.Valid) r).event())
-                .assignTimestampsAndWatermarks(watermarkStrategy)
-                .filter(e -> e.flowId() != null && !e.flowId().isEmpty())
-                .name("flow-id-filter");
+    var flowEvents =
+        env.fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "correlator-kafka-source")
+            .filter(r -> r instanceof ValidationResult.Valid)
+            .map(r -> ((ValidationResult.Valid) r).event())
+            .assignTimestampsAndWatermarks(watermarkStrategy)
+            .filter(e -> e.flowId() != null && !e.flowId().isEmpty())
+            .name("flow-id-filter");
 
-        var lifecycleStream = flowEvents
-                .keyBy(ValidatedEvent::flowId)
-                .process(new FlowCorrelatorFunction())
-                .name("flow-correlator");
+    var lifecycleStream =
+        flowEvents
+            .keyBy(ValidatedEvent::flowId)
+            .process(new FlowCorrelatorFunction())
+            .name("flow-correlator");
 
-        var flowSink = KafkaSink.<byte[]>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setRecordSerializer(new FlowEventSerializer())
-                .build();
+    var flowSink =
+        KafkaSink.<byte[]>builder()
+            .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+            .setRecordSerializer(new FlowEventSerializer())
+            .build();
 
-        lifecycleStream.sinkTo(flowSink).name("flow-lifecycle-sink");
+    lifecycleStream.sinkTo(flowSink).name("flow-lifecycle-sink");
 
-        env.execute("stablepay-correlator-job");
-    }
+    env.execute("stablepay-correlator-job");
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/FactFlowsMergeJob.java
@@ -1,57 +1,75 @@
 package io.stablepay.flink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
+import io.stablepay.flink.sink.FactTableSinkFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import io.stablepay.flink.sink.FactTableSinkFactory;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class FactFlowsMergeJob {
 
-    public static void main(String[] args) throws Exception {
-        var env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
-        var tableEnv = StreamTableEnvironment.create(env);
+  public static void main(String[] args) throws Exception {
+    var env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+    var tableEnv = StreamTableEnvironment.create(env);
 
-        var factSinkFactory = new FactTableSinkFactory();
-        factSinkFactory.ensureFactTablesExist();
+    var factSinkFactory = new FactTableSinkFactory();
+    factSinkFactory.ensureFactTablesExist();
 
-        registerIcebergCatalog(tableEnv);
+    registerIcebergCatalog(tableEnv);
 
-        log.info("Executing INSERT OVERWRITE facts.fact_flows from raw tables");
-        tableEnv.executeSql(buildInsertOverwriteSql());
-        log.info("INSERT OVERWRITE facts.fact_flows completed");
-    }
+    log.info("Executing INSERT OVERWRITE facts.fact_flows from raw tables");
+    tableEnv.executeSql(buildInsertOverwriteSql());
+    log.info("INSERT OVERWRITE facts.fact_flows completed");
+  }
 
-    private static void registerIcebergCatalog(StreamTableEnvironment tableEnv) {
-        var props = IcebergCatalogConfig.catalogProperties();
-        var sql = "CREATE CATALOG " + IcebergCatalogConfig.CATALOG_NAME + " WITH ("
-                + "'type'='iceberg',"
-                + "'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',"
-                + "'uri'='" + escapeSql(props.get("uri")) + "',"
-                + "'jdbc.user'='" + escapeSql(props.get("jdbc.user")) + "',"
-                + "'jdbc.password'='" + escapeSql(props.get("jdbc.password")) + "',"
-                + "'warehouse'='" + escapeSql(props.get("warehouse")) + "',"
-                + "'io-impl'='" + escapeSql(props.get("io-impl")) + "',"
-                + "'s3.endpoint'='" + escapeSql(props.get("s3.endpoint")) + "',"
-                + "'s3.access-key-id'='" + escapeSql(props.get("s3.access-key-id")) + "',"
-                + "'s3.secret-access-key'='" + escapeSql(props.get("s3.secret-access-key")) + "',"
-                + "'s3.path-style-access'='true'"
-                + ")";
+  private static void registerIcebergCatalog(StreamTableEnvironment tableEnv) {
+    var props = IcebergCatalogConfig.catalogProperties();
+    var sql =
+        "CREATE CATALOG "
+            + IcebergCatalogConfig.CATALOG_NAME
+            + " WITH ("
+            + "'type'='iceberg',"
+            + "'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',"
+            + "'uri'='"
+            + escapeSql(props.get("uri"))
+            + "',"
+            + "'jdbc.user'='"
+            + escapeSql(props.get("jdbc.user"))
+            + "',"
+            + "'jdbc.password'='"
+            + escapeSql(props.get("jdbc.password"))
+            + "',"
+            + "'warehouse'='"
+            + escapeSql(props.get("warehouse"))
+            + "',"
+            + "'io-impl'='"
+            + escapeSql(props.get("io-impl"))
+            + "',"
+            + "'s3.endpoint'='"
+            + escapeSql(props.get("s3.endpoint"))
+            + "',"
+            + "'s3.access-key-id'='"
+            + escapeSql(props.get("s3.access-key-id"))
+            + "',"
+            + "'s3.secret-access-key'='"
+            + escapeSql(props.get("s3.secret-access-key"))
+            + "',"
+            + "'s3.path-style-access'='true'"
+            + ")";
 
-        tableEnv.executeSql(sql);
-        tableEnv.executeSql("USE CATALOG " + IcebergCatalogConfig.CATALOG_NAME);
-    }
+    tableEnv.executeSql(sql);
+    tableEnv.executeSql("USE CATALOG " + IcebergCatalogConfig.CATALOG_NAME);
+  }
 
-    static String escapeSql(String value) {
-        return value != null ? value.replace("'", "''") : "";
-    }
+  static String escapeSql(String value) {
+    return value != null ? value.replace("'", "''") : "";
+  }
 
-    static String buildInsertOverwriteSql() {
-        return """
+  static String buildInsertOverwriteSql() {
+    return """
                 INSERT OVERWRITE facts.fact_flows
                 SELECT
                     f.flow_id,
@@ -180,5 +198,5 @@ public class FactFlowsMergeJob {
                     ) WHERE rn = 1
                 ) po ON f.flow_id = po.flow_id
                 """;
-    }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/IngestJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/IngestJob.java
@@ -1,18 +1,5 @@
 package io.stablepay.flink;
 
-import java.time.Duration;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.connector.kafka.source.KafkaSource;
-import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.data.RowData;
-
 import io.stablepay.flink.catalog.IcebergCatalogConfig;
 import io.stablepay.flink.config.FlinkConfig;
 import io.stablepay.flink.deser.AvroEnvelopeDeserializer;
@@ -22,7 +9,6 @@ import io.stablepay.flink.mapper.DlqToIcebergRowMapper;
 import io.stablepay.flink.mapper.EventToFactScreeningMapper;
 import io.stablepay.flink.mapper.EventToFactTransactionMapper;
 import io.stablepay.flink.mapper.EventToIcebergRowMapper;
-import io.stablepay.flink.model.DlqEnvelope;
 import io.stablepay.flink.model.ValidatedEvent;
 import io.stablepay.flink.model.ValidationResult;
 import io.stablepay.flink.process.ValidateAndRouteFunction;
@@ -32,129 +18,146 @@ import io.stablepay.flink.sink.FactTableSinkFactory;
 import io.stablepay.flink.sink.IcebergSinkFactory;
 import io.stablepay.flink.sink.OpenSearchAsyncSink;
 import io.stablepay.flink.watermark.EnvelopeTimestampAssigner;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class IngestJob {
 
-    public static void main(String[] args) throws Exception {
-        var env = StreamExecutionEnvironment.getExecutionEnvironment();
+  public static void main(String[] args) throws Exception {
+    var env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        var watermarkStrategy = WatermarkStrategy
-                .<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
-                .withIdleness(Duration.ofMinutes(1))
-                .withTimestampAssigner(new EnvelopeTimestampAssigner());
+    var watermarkStrategy =
+        WatermarkStrategy.<ValidatedEvent>forBoundedOutOfOrderness(Duration.ofSeconds(60))
+            .withIdleness(Duration.ofMinutes(1))
+            .withTimestampAssigner(new EnvelopeTimestampAssigner());
 
-        var kafkaSource = KafkaSource.<ValidationResult>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setTopics(FlinkConfig.INPUT_TOPICS)
-                .setGroupId(FlinkConfig.INGEST_CONSUMER_GROUP)
-                .setStartingOffsets(OffsetsInitializer.earliest())
-                .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
-                .build();
+    var kafkaSource =
+        KafkaSource.<ValidationResult>builder()
+            .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+            .setTopics(FlinkConfig.INPUT_TOPICS)
+            .setGroupId(FlinkConfig.INGEST_CONSUMER_GROUP)
+            .setStartingOffsets(OffsetsInitializer.earliest())
+            .setDeserializer(new AvroEnvelopeDeserializer(FlinkConfig.schemaRegistryUrl()))
+            .build();
 
-        var rawStream = env
-                .fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "kafka-source")
-                .name("avro-deserialized-events");
+    var rawStream =
+        env.fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "kafka-source")
+            .name("avro-deserialized-events");
 
-        var schemaInvalidStream = rawStream
-                .filter(r -> r instanceof ValidationResult.Invalid)
-                .map(r -> ((ValidationResult.Invalid) r).dlqEnvelope())
-                .name("schema-invalid-events");
+    var schemaInvalidStream =
+        rawStream
+            .filter(r -> r instanceof ValidationResult.Invalid)
+            .map(r -> ((ValidationResult.Invalid) r).dlqEnvelope())
+            .name("schema-invalid-events");
 
-        schemaInvalidStream
-                .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_SCHEMA_INVALID))
-                .name("dlq-schema-invalid-sink");
+    schemaInvalidStream
+        .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_SCHEMA_INVALID))
+        .name("dlq-schema-invalid-sink");
 
-        var validatedStream = rawStream
-                .filter(r -> r instanceof ValidationResult.Valid)
-                .map(r -> ((ValidationResult.Valid) r).event())
-                .assignTimestampsAndWatermarks(watermarkStrategy)
-                .name("validated-events");
+    var validatedStream =
+        rawStream
+            .filter(r -> r instanceof ValidationResult.Valid)
+            .map(r -> ((ValidationResult.Valid) r).event())
+            .assignTimestampsAndWatermarks(watermarkStrategy)
+            .name("validated-events");
 
-        var routedStream = validatedStream
-                .keyBy(IngestJob::extractEntityKey)
-                .process(new ValidateAndRouteFunction())
-                .name("validate-and-route");
+    var routedStream =
+        validatedStream
+            .keyBy(IngestJob::extractEntityKey)
+            .process(new ValidateAndRouteFunction())
+            .name("validate-and-route");
 
-        // DLQ side outputs to Kafka
-        routedStream.getSideOutput(DlqOutputTags.LATE_EVENT)
-                .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_LATE_EVENTS))
-                .name("dlq-late-event-sink");
+    // DLQ side outputs to Kafka
+    routedStream
+        .getSideOutput(DlqOutputTags.LATE_EVENT)
+        .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_LATE_EVENTS))
+        .name("dlq-late-event-sink");
 
-        routedStream.getSideOutput(DlqOutputTags.ILLEGAL_TRANSITION)
-                .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_PROCESSING_FAILED))
-                .name("dlq-illegal-transition-sink");
+    routedStream
+        .getSideOutput(DlqOutputTags.ILLEGAL_TRANSITION)
+        .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_PROCESSING_FAILED))
+        .name("dlq-illegal-transition-sink");
 
-        routedStream.getSideOutput(DlqOutputTags.SINK_FAILURE)
-                .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_SINK_FAILED))
-                .name("dlq-sink-failure-sink");
+    routedStream
+        .getSideOutput(DlqOutputTags.SINK_FAILURE)
+        .sinkTo(DlqKafkaSinkFactory.createSink(FlinkConfig.DLQ_SINK_FAILED))
+        .name("dlq-sink-failure-sink");
 
-        // --- Iceberg raw sink (one table per topic, independent branch) ---
-        var icebergSinkFactory = new IcebergSinkFactory();
-        icebergSinkFactory.ensureTablesExist();
+    // --- Iceberg raw sink (one table per topic, independent branch) ---
+    var icebergSinkFactory = new IcebergSinkFactory();
+    icebergSinkFactory.ensureTablesExist();
 
-        for (var entry : IcebergCatalogConfig.TOPIC_TO_TABLE.entrySet()) {
-            var topic = entry.getKey();
-            var tableName = entry.getValue();
+    for (var entry : IcebergCatalogConfig.TOPIC_TO_TABLE.entrySet()) {
+      var topic = entry.getKey();
+      var tableName = entry.getValue();
 
-            var tableStream = routedStream
-                    .filter(e -> topic.equals(e.topic()))
-                    .map(EventToIcebergRowMapper::toRowData)
-                    .name("iceberg-map-" + tableName);
+      var tableStream =
+          routedStream
+              .filter(e -> topic.equals(e.topic()))
+              .map(EventToIcebergRowMapper::toRowData)
+              .name("iceberg-map-" + tableName);
 
-            icebergSinkFactory.addSink(tableStream, tableName);
-        }
+      icebergSinkFactory.addSink(tableStream, tableName);
+    }
 
-        // --- OpenSearch transactions sink (independent branch) ---
+    // --- OpenSearch transactions sink (independent branch) ---
+    routedStream
+        .sinkTo(new OpenSearchAsyncSink(FlinkConfig.opensearchUrl()))
+        .name("opensearch-transactions-sink");
+
+    // --- Fact table sinks (independent branches) ---
+    var factSinkFactory = new FactTableSinkFactory();
+    factSinkFactory.ensureFactTablesExist();
+
+    var factTxStream =
         routedStream
-                .sinkTo(new OpenSearchAsyncSink(FlinkConfig.opensearchUrl()))
-                .name("opensearch-transactions-sink");
+            .filter(e -> FlinkConfig.FACT_TX_TOPICS.contains(e.topic()))
+            .map(EventToFactTransactionMapper::toRowData)
+            .name("fact-transactions-map");
+    factSinkFactory.addSink(factTxStream, "fact_transactions");
 
-        // --- Fact table sinks (independent branches) ---
-        var factSinkFactory = new FactTableSinkFactory();
-        factSinkFactory.ensureFactTablesExist();
+    var factScreeningStream =
+        routedStream
+            .filter(e -> "screening.result.v1".equals(e.topic()))
+            .map(EventToFactScreeningMapper::toRowData)
+            .name("fact-screening-map");
+    factSinkFactory.addSink(factScreeningStream, "fact_screening_outcomes");
 
-        var factTxStream = routedStream
-                .filter(e -> FlinkConfig.FACT_TX_TOPICS.contains(e.topic()))
-                .map(EventToFactTransactionMapper::toRowData)
-                .name("fact-transactions-map");
-        factSinkFactory.addSink(factTxStream, "fact_transactions");
+    // --- DLQ mirror: union all DLQ side outputs → Iceberg + OpenSearch ---
+    var dlqStream =
+        schemaInvalidStream.union(
+            routedStream.getSideOutput(DlqOutputTags.LATE_EVENT),
+            routedStream.getSideOutput(DlqOutputTags.ILLEGAL_TRANSITION),
+            routedStream.getSideOutput(DlqOutputTags.SINK_FAILURE));
 
-        var factScreeningStream = routedStream
-                .filter(e -> "screening.result.v1".equals(e.topic()))
-                .map(EventToFactScreeningMapper::toRowData)
-                .name("fact-screening-map");
-        factSinkFactory.addSink(factScreeningStream, "fact_screening_outcomes");
+    var dlqIcebergSinkFactory = new DlqIcebergSinkFactory();
+    dlqIcebergSinkFactory.ensureDlqTableExists();
 
-        // --- DLQ mirror: union all DLQ side outputs → Iceberg + OpenSearch ---
-        var dlqStream = schemaInvalidStream.union(
-                routedStream.getSideOutput(DlqOutputTags.LATE_EVENT),
-                routedStream.getSideOutput(DlqOutputTags.ILLEGAL_TRANSITION),
-                routedStream.getSideOutput(DlqOutputTags.SINK_FAILURE));
+    var dlqRowStream = dlqStream.map(DlqToIcebergRowMapper::toRowData).name("dlq-iceberg-map");
 
-        var dlqIcebergSinkFactory = new DlqIcebergSinkFactory();
-        dlqIcebergSinkFactory.ensureDlqTableExists();
+    dlqIcebergSinkFactory.addSink(dlqRowStream, "dlq_events");
 
-        var dlqRowStream = dlqStream
-                .map(DlqToIcebergRowMapper::toRowData)
-                .name("dlq-iceberg-map");
+    dlqStream
+        .sinkTo(new DlqOpenSearchSink(FlinkConfig.opensearchUrl(), "dlq-events-write"))
+        .name("opensearch-dlq-events-sink");
 
-        dlqIcebergSinkFactory.addSink(dlqRowStream, "dlq_events");
+    env.execute("stablepay-ingest-job");
+  }
 
-        dlqStream
-                .sinkTo(new DlqOpenSearchSink(FlinkConfig.opensearchUrl(), "dlq-events-write"))
-                .name("opensearch-dlq-events-sink");
-
-        env.execute("stablepay-ingest-job");
-    }
-
-    private static String extractEntityKey(ValidatedEvent event) {
-        var record = event.toRecord();
-        return Stream.of("payout_reference", "payin_reference", "tx_hash")
-                .map(record::get)
-                .filter(Objects::nonNull)
-                .map(Object::toString)
-                .findFirst()
-                .or(() -> Optional.ofNullable(event.flowId()))
-                .orElse(event.eventId());
-    }
+  private static String extractEntityKey(ValidatedEvent event) {
+    var record = event.toRecord();
+    return Stream.of("payout_reference", "payin_reference", "tx_hash")
+        .map(record::get)
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .findFirst()
+        .or(() -> Optional.ofNullable(event.flowId()))
+        .orElse(event.eventId());
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/StuckWithdrawalsJob.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/StuckWithdrawalsJob.java
@@ -1,26 +1,26 @@
 package io.stablepay.flink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class StuckWithdrawalsJob {
 
-    private static final String JOB_NAME = "stablepay-stuck-withdrawals-job";
+  private static final String JOB_NAME = "stablepay-stuck-withdrawals-job";
 
-    public static void main(String[] args) throws Exception {
-        log.info("Starting {}", JOB_NAME);
-        var settings = EnvironmentSettings.newInstance().inBatchMode().build();
-        var tableEnv = TableEnvironment.create(settings);
-        tableEnv.getConfig().set(PipelineOptions.NAME, JOB_NAME);
+  public static void main(String[] args) throws Exception {
+    log.info("Starting {}", JOB_NAME);
+    var settings = EnvironmentSettings.newInstance().inBatchMode().build();
+    var tableEnv = TableEnvironment.create(settings);
+    tableEnv.getConfig().set(PipelineOptions.NAME, JOB_NAME);
 
-        var catalogProps = IcebergCatalogConfig.catalogProperties();
-        tableEnv.executeSql(String.format(
-                "CREATE CATALOG IF NOT EXISTS %s WITH ("
+    var catalogProps = IcebergCatalogConfig.catalogProperties();
+    tableEnv.executeSql(
+        String.format(
+            "CREATE CATALOG IF NOT EXISTS %s WITH ("
                 + "'type'='iceberg',"
                 + "'catalog-impl'='org.apache.iceberg.jdbc.JdbcCatalog',"
                 + "'uri'='%s',"
@@ -33,20 +33,23 @@ public class StuckWithdrawalsJob {
                 + "'s3.secret-access-key'='%s',"
                 + "'s3.path-style-access'='true'"
                 + ")",
-                IcebergCatalogConfig.CATALOG_NAME,
-                sqlLiteral(catalogProps.get("uri")),
-                sqlLiteral(catalogProps.get("jdbc.user")),
-                sqlLiteral(catalogProps.get("jdbc.password")),
-                sqlLiteral(catalogProps.get("warehouse")),
-                sqlLiteral(catalogProps.get("io-impl")),
-                sqlLiteral(catalogProps.get("s3.endpoint")),
-                sqlLiteral(catalogProps.get("s3.access-key-id")),
-                sqlLiteral(catalogProps.get("s3.secret-access-key"))));
+            IcebergCatalogConfig.CATALOG_NAME,
+            sqlLiteral(catalogProps.get("uri")),
+            sqlLiteral(catalogProps.get("jdbc.user")),
+            sqlLiteral(catalogProps.get("jdbc.password")),
+            sqlLiteral(catalogProps.get("warehouse")),
+            sqlLiteral(catalogProps.get("io-impl")),
+            sqlLiteral(catalogProps.get("s3.endpoint")),
+            sqlLiteral(catalogProps.get("s3.access-key-id")),
+            sqlLiteral(catalogProps.get("s3.secret-access-key"))));
 
-        tableEnv.useCatalog(IcebergCatalogConfig.CATALOG_NAME);
+    tableEnv.useCatalog(IcebergCatalogConfig.CATALOG_NAME);
 
-        var insertResult = tableEnv.executeSql(
-                "INSERT OVERWRITE " + IcebergCatalogConfig.AGG_NAMESPACE + ".agg_stuck_withdrawals "
+    var insertResult =
+        tableEnv.executeSql(
+            "INSERT OVERWRITE "
+                + IcebergCatalogConfig.AGG_NAMESPACE
+                + ".agg_stuck_withdrawals "
                 + "SELECT "
                 + "  CURRENT_TIMESTAMP AS snapshot_time, "
                 + "  transaction_reference, customer_id, "
@@ -61,11 +64,11 @@ public class StuckWithdrawalsJob {
                 + "    'COMPLETED','FAILED','CANCELLED','REJECTED','REFUNDED','CONFISCATED') "
                 + "  AND event_time < CURRENT_TIMESTAMP - INTERVAL '1' HOUR");
 
-        insertResult.await();
-        log.info("{} completed successfully", JOB_NAME);
-    }
+    insertResult.await();
+    log.info("{} completed successfully", JOB_NAME);
+  }
 
-    private static String sqlLiteral(String value) {
-        return value == null ? "" : value.replace("'", "''");
-    }
+  private static String sqlLiteral(String value) {
+    return value == null ? "" : value.replace("'", "''");
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/Aggregators.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/Aggregators.java
@@ -1,40 +1,39 @@
 package io.stablepay.flink.agg;
 
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.ValidatedEvent;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.table.data.RowData;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class Aggregators {
 
-    private Aggregators() {}
+  private Aggregators() {}
 
-    public static AggregateFunction<ValidatedEvent, ?, RowData> volume() {
-        return new VolumeAggregator();
-    }
+  public static AggregateFunction<ValidatedEvent, ?, RowData> volume() {
+    return new VolumeAggregator();
+  }
 
-    public static AggregateFunction<ValidatedEvent, ?, RowData> successRate() {
-        return new SuccessRateAggregator();
-    }
+  public static AggregateFunction<ValidatedEvent, ?, RowData> successRate() {
+    return new SuccessRateAggregator();
+  }
 
-    public static AggregateFunction<ValidatedEvent, ?, RowData> screeningOutcomes() {
-        return new ScreeningOutcomesAggregator();
-    }
+  public static AggregateFunction<ValidatedEvent, ?, RowData> screeningOutcomes() {
+    return new ScreeningOutcomesAggregator();
+  }
 
-    public static AggregateFunction<DlqEnvelope, ?, RowData> dlqSummary() {
-        return new DlqSummaryAggregator();
-    }
+  public static AggregateFunction<DlqEnvelope, ?, RowData> dlqSummary() {
+    return new DlqSummaryAggregator();
+  }
 
-    public static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> windowTimestamptz(
-            int startFieldIndex, int endFieldIndex) {
-        return WindowTimestampEmitter.timestamptz(startFieldIndex, endFieldIndex);
-    }
+  public static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> windowTimestamptz(
+      int startFieldIndex, int endFieldIndex) {
+    return WindowTimestampEmitter.timestamptz(startFieldIndex, endFieldIndex);
+  }
 
-    public static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> windowDate(
-            int dateFieldIndex) {
-        return WindowTimestampEmitter.date(dateFieldIndex);
-    }
+  public static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> windowDate(
+      int dateFieldIndex) {
+    return WindowTimestampEmitter.date(dateFieldIndex);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/DlqAccumulator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/DlqAccumulator.java
@@ -3,8 +3,4 @@ package io.stablepay.flink.agg;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
-record DlqAccumulator(
-        long eventCount,
-        int maxRetryCount,
-        String errorClass,
-        String sourceTopic) {}
+record DlqAccumulator(long eventCount, int maxRetryCount, String errorClass, String sourceTopic) {}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/DlqSummaryAggregator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/DlqSummaryAggregator.java
@@ -1,50 +1,49 @@
 package io.stablepay.flink.agg;
 
+import io.stablepay.flink.model.DlqEnvelope;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import io.stablepay.flink.model.DlqEnvelope;
-
 class DlqSummaryAggregator implements AggregateFunction<DlqEnvelope, DlqAccumulator, RowData> {
 
-    static final String UNKNOWN = "UNKNOWN";
+  static final String UNKNOWN = "UNKNOWN";
 
-    @Override
-    public DlqAccumulator createAccumulator() {
-        return new DlqAccumulator(0L, 0, UNKNOWN, UNKNOWN);
-    }
+  @Override
+  public DlqAccumulator createAccumulator() {
+    return new DlqAccumulator(0L, 0, UNKNOWN, UNKNOWN);
+  }
 
-    @Override
-    public DlqAccumulator add(DlqEnvelope envelope, DlqAccumulator acc) {
-        return acc.toBuilder()
-                .eventCount(acc.eventCount() + 1)
-                .maxRetryCount(Math.max(acc.maxRetryCount(), envelope.retryCount()))
-                .errorClass(envelope.errorClass() != null ? envelope.errorClass() : acc.errorClass())
-                .sourceTopic(envelope.sourceTopic() != null ? envelope.sourceTopic() : acc.sourceTopic())
-                .build();
-    }
+  @Override
+  public DlqAccumulator add(DlqEnvelope envelope, DlqAccumulator acc) {
+    return acc.toBuilder()
+        .eventCount(acc.eventCount() + 1)
+        .maxRetryCount(Math.max(acc.maxRetryCount(), envelope.retryCount()))
+        .errorClass(envelope.errorClass() != null ? envelope.errorClass() : acc.errorClass())
+        .sourceTopic(envelope.sourceTopic() != null ? envelope.sourceTopic() : acc.sourceTopic())
+        .build();
+  }
 
-    @Override
-    public RowData getResult(DlqAccumulator acc) {
-        var row = new GenericRowData(6);
-        row.setField(0, null);
-        row.setField(1, null);
-        row.setField(2, StringData.fromString(acc.errorClass()));
-        row.setField(3, StringData.fromString(acc.sourceTopic()));
-        row.setField(4, acc.eventCount());
-        row.setField(5, acc.maxRetryCount());
-        return row;
-    }
+  @Override
+  public RowData getResult(DlqAccumulator acc) {
+    var row = new GenericRowData(6);
+    row.setField(0, null);
+    row.setField(1, null);
+    row.setField(2, StringData.fromString(acc.errorClass()));
+    row.setField(3, StringData.fromString(acc.sourceTopic()));
+    row.setField(4, acc.eventCount());
+    row.setField(5, acc.maxRetryCount());
+    return row;
+  }
 
-    @Override
-    public DlqAccumulator merge(DlqAccumulator a, DlqAccumulator b) {
-        return a.toBuilder()
-                .eventCount(a.eventCount() + b.eventCount())
-                .maxRetryCount(Math.max(a.maxRetryCount(), b.maxRetryCount()))
-                .errorClass(UNKNOWN.equals(a.errorClass()) ? b.errorClass() : a.errorClass())
-                .sourceTopic(UNKNOWN.equals(a.sourceTopic()) ? b.sourceTopic() : a.sourceTopic())
-                .build();
-    }
+  @Override
+  public DlqAccumulator merge(DlqAccumulator a, DlqAccumulator b) {
+    return a.toBuilder()
+        .eventCount(a.eventCount() + b.eventCount())
+        .maxRetryCount(Math.max(a.maxRetryCount(), b.maxRetryCount()))
+        .errorClass(UNKNOWN.equals(a.errorClass()) ? b.errorClass() : a.errorClass())
+        .sourceTopic(UNKNOWN.equals(a.sourceTopic()) ? b.sourceTopic() : a.sourceTopic())
+        .build();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/ScreeningAccumulator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/ScreeningAccumulator.java
@@ -4,9 +4,9 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 record ScreeningAccumulator(
-        long totalCount,
-        long totalDurationMs,
-        double totalScore,
-        long scoreCount,
-        String outcome,
-        String provider) {}
+    long totalCount,
+    long totalDurationMs,
+    double totalScore,
+    long scoreCount,
+    String outcome,
+    String provider) {}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/ScreeningOutcomesAggregator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/ScreeningOutcomesAggregator.java
@@ -1,87 +1,83 @@
 package io.stablepay.flink.agg;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 class ScreeningOutcomesAggregator
-        implements AggregateFunction<ValidatedEvent, ScreeningAccumulator, RowData> {
+    implements AggregateFunction<ValidatedEvent, ScreeningAccumulator, RowData> {
 
-    static final String UNKNOWN = "UNKNOWN";
+  static final String UNKNOWN = "UNKNOWN";
 
-    @Override
-    public ScreeningAccumulator createAccumulator() {
-        return new ScreeningAccumulator(0L, 0L, 0.0, 0L, UNKNOWN, UNKNOWN);
+  @Override
+  public ScreeningAccumulator createAccumulator() {
+    return new ScreeningAccumulator(0L, 0L, 0.0, 0L, UNKNOWN, UNKNOWN);
+  }
+
+  @Override
+  public ScreeningAccumulator add(ValidatedEvent event, ScreeningAccumulator acc) {
+    var record = event.toRecord();
+    var outcome = record.get("outcome");
+    var provider = record.get("provider");
+    var durationMs = extractScreeningLatencyMs(record);
+    var score = 0.0;
+    var scoreCount = 0L;
+    var scoreField = record.get("risk_score");
+    if (scoreField instanceof Number n) {
+      score = n.doubleValue();
+      scoreCount = 1L;
     }
 
-    @Override
-    public ScreeningAccumulator add(ValidatedEvent event, ScreeningAccumulator acc) {
-        var record = event.toRecord();
-        var outcome = record.get("outcome");
-        var provider = record.get("provider");
-        var durationMs = extractScreeningLatencyMs(record);
-        var score = 0.0;
-        var scoreCount = 0L;
-        var scoreField = record.get("risk_score");
-        if (scoreField instanceof Number n) {
-            score = n.doubleValue();
-            scoreCount = 1L;
-        }
+    return acc.toBuilder()
+        .totalCount(acc.totalCount() + 1)
+        .totalDurationMs(acc.totalDurationMs() + durationMs)
+        .totalScore(acc.totalScore() + score)
+        .scoreCount(acc.scoreCount() + scoreCount)
+        .outcome(outcome != null ? outcome.toString() : acc.outcome())
+        .provider(provider != null ? provider.toString() : acc.provider())
+        .build();
+  }
 
-        return acc.toBuilder()
-                .totalCount(acc.totalCount() + 1)
-                .totalDurationMs(acc.totalDurationMs() + durationMs)
-                .totalScore(acc.totalScore() + score)
-                .scoreCount(acc.scoreCount() + scoreCount)
-                .outcome(outcome != null ? outcome.toString() : acc.outcome())
-                .provider(provider != null ? provider.toString() : acc.provider())
-                .build();
-    }
+  @Override
+  public RowData getResult(ScreeningAccumulator acc) {
+    var row = new GenericRowData(6);
+    row.setField(0, null);
+    row.setField(1, StringData.fromString(acc.outcome()));
+    row.setField(2, StringData.fromString(acc.provider()));
+    row.setField(3, acc.totalCount());
+    var avgDuration =
+        acc.totalCount() > 0 ? acc.totalDurationMs() / (double) acc.totalCount() : 0.0;
+    row.setField(4, avgDuration);
+    var avgScore = acc.scoreCount() > 0 ? acc.totalScore() / acc.scoreCount() : 0.0;
+    row.setField(5, avgScore);
+    return row;
+  }
 
-    @Override
-    public RowData getResult(ScreeningAccumulator acc) {
-        var row = new GenericRowData(6);
-        row.setField(0, null);
-        row.setField(1, StringData.fromString(acc.outcome()));
-        row.setField(2, StringData.fromString(acc.provider()));
-        row.setField(3, acc.totalCount());
-        var avgDuration = acc.totalCount() > 0
-                ? acc.totalDurationMs() / (double) acc.totalCount()
-                : 0.0;
-        row.setField(4, avgDuration);
-        var avgScore = acc.scoreCount() > 0
-                ? acc.totalScore() / acc.scoreCount()
-                : 0.0;
-        row.setField(5, avgScore);
-        return row;
-    }
+  @Override
+  public ScreeningAccumulator merge(ScreeningAccumulator a, ScreeningAccumulator b) {
+    return a.toBuilder()
+        .totalCount(a.totalCount() + b.totalCount())
+        .totalDurationMs(a.totalDurationMs() + b.totalDurationMs())
+        .totalScore(a.totalScore() + b.totalScore())
+        .scoreCount(a.scoreCount() + b.scoreCount())
+        .outcome(UNKNOWN.equals(a.outcome()) ? b.outcome() : a.outcome())
+        .provider(UNKNOWN.equals(a.provider()) ? b.provider() : a.provider())
+        .build();
+  }
 
-    @Override
-    public ScreeningAccumulator merge(ScreeningAccumulator a, ScreeningAccumulator b) {
-        return a.toBuilder()
-                .totalCount(a.totalCount() + b.totalCount())
-                .totalDurationMs(a.totalDurationMs() + b.totalDurationMs())
-                .totalScore(a.totalScore() + b.totalScore())
-                .scoreCount(a.scoreCount() + b.scoreCount())
-                .outcome(UNKNOWN.equals(a.outcome()) ? b.outcome() : a.outcome())
-                .provider(UNKNOWN.equals(a.provider()) ? b.provider() : a.provider())
-                .build();
+  private static long extractScreeningLatencyMs(GenericRecord record) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var eventTime = env.get("event_time");
+      var ingestTime = env.get("ingest_time");
+      if (eventTime instanceof Number e && ingestTime instanceof Number i) {
+        var diff = i.longValue() - e.longValue();
+        return Math.max(diff, 0L);
+      }
     }
-
-    private static long extractScreeningLatencyMs(GenericRecord record) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var eventTime = env.get("event_time");
-            var ingestTime = env.get("ingest_time");
-            if (eventTime instanceof Number e && ingestTime instanceof Number i) {
-                var diff = i.longValue() - e.longValue();
-                return Math.max(diff, 0L);
-            }
-        }
-        return 0L;
-    }
+    return 0L;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/SuccessRateAccumulator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/SuccessRateAccumulator.java
@@ -4,7 +4,4 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 record SuccessRateAccumulator(
-        long totalCount,
-        long completedCount,
-        long failedCount,
-        String flowType) {}
+    long totalCount, long completedCount, long failedCount, String flowType) {}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/SuccessRateAggregator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/SuccessRateAggregator.java
@@ -1,74 +1,71 @@
 package io.stablepay.flink.agg;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.util.Set;
-
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import io.stablepay.flink.model.ValidatedEvent;
+class SuccessRateAggregator
+    implements AggregateFunction<ValidatedEvent, SuccessRateAccumulator, RowData> {
 
-class SuccessRateAggregator implements AggregateFunction<ValidatedEvent, SuccessRateAccumulator, RowData> {
+  static final String UNKNOWN = "UNKNOWN";
 
-    static final String UNKNOWN = "UNKNOWN";
+  private static final Set<String> COMPLETED_STATUSES = Set.of("COMPLETED");
+  private static final Set<String> FAILED_STATUSES =
+      Set.of("FAILED", "CANCELLED", "REJECTED", "CONFISCATED");
 
-    private static final Set<String> COMPLETED_STATUSES = Set.of("COMPLETED");
-    private static final Set<String> FAILED_STATUSES = Set.of(
-            "FAILED", "CANCELLED", "REJECTED", "CONFISCATED");
+  @Override
+  public SuccessRateAccumulator createAccumulator() {
+    return new SuccessRateAccumulator(0L, 0L, 0L, UNKNOWN);
+  }
 
-    @Override
-    public SuccessRateAccumulator createAccumulator() {
-        return new SuccessRateAccumulator(0L, 0L, 0L, UNKNOWN);
-    }
+  @Override
+  public SuccessRateAccumulator add(ValidatedEvent event, SuccessRateAccumulator acc) {
+    var record = event.toRecord();
+    var status = record.get("internal_status");
+    var statusStr = status != null ? status.toString() : "";
+    var flowType = deriveFlowType(event.topic());
 
-    @Override
-    public SuccessRateAccumulator add(ValidatedEvent event, SuccessRateAccumulator acc) {
-        var record = event.toRecord();
-        var status = record.get("internal_status");
-        var statusStr = status != null ? status.toString() : "";
-        var flowType = deriveFlowType(event.topic());
+    var completed = COMPLETED_STATUSES.contains(statusStr) ? 1L : 0L;
+    var failed = FAILED_STATUSES.contains(statusStr) ? 1L : 0L;
 
-        var completed = COMPLETED_STATUSES.contains(statusStr) ? 1L : 0L;
-        var failed = FAILED_STATUSES.contains(statusStr) ? 1L : 0L;
+    return acc.toBuilder()
+        .totalCount(acc.totalCount() + 1)
+        .completedCount(acc.completedCount() + completed)
+        .failedCount(acc.failedCount() + failed)
+        .flowType(flowType)
+        .build();
+  }
 
-        return acc.toBuilder()
-                .totalCount(acc.totalCount() + 1)
-                .completedCount(acc.completedCount() + completed)
-                .failedCount(acc.failedCount() + failed)
-                .flowType(flowType)
-                .build();
-    }
+  @Override
+  public RowData getResult(SuccessRateAccumulator acc) {
+    var row = new GenericRowData(7);
+    row.setField(0, null);
+    row.setField(1, null);
+    row.setField(2, StringData.fromString(acc.flowType()));
+    row.setField(3, acc.totalCount());
+    row.setField(4, acc.completedCount());
+    row.setField(5, acc.failedCount());
+    var successRate = acc.totalCount() > 0 ? acc.completedCount() / (double) acc.totalCount() : 0.0;
+    row.setField(6, successRate);
+    return row;
+  }
 
-    @Override
-    public RowData getResult(SuccessRateAccumulator acc) {
-        var row = new GenericRowData(7);
-        row.setField(0, null);
-        row.setField(1, null);
-        row.setField(2, StringData.fromString(acc.flowType()));
-        row.setField(3, acc.totalCount());
-        row.setField(4, acc.completedCount());
-        row.setField(5, acc.failedCount());
-        var successRate = acc.totalCount() > 0
-                ? acc.completedCount() / (double) acc.totalCount()
-                : 0.0;
-        row.setField(6, successRate);
-        return row;
-    }
+  @Override
+  public SuccessRateAccumulator merge(SuccessRateAccumulator a, SuccessRateAccumulator b) {
+    return a.toBuilder()
+        .totalCount(a.totalCount() + b.totalCount())
+        .completedCount(a.completedCount() + b.completedCount())
+        .failedCount(a.failedCount() + b.failedCount())
+        .flowType(UNKNOWN.equals(a.flowType()) ? b.flowType() : a.flowType())
+        .build();
+  }
 
-    @Override
-    public SuccessRateAccumulator merge(SuccessRateAccumulator a, SuccessRateAccumulator b) {
-        return a.toBuilder()
-                .totalCount(a.totalCount() + b.totalCount())
-                .completedCount(a.completedCount() + b.completedCount())
-                .failedCount(a.failedCount() + b.failedCount())
-                .flowType(UNKNOWN.equals(a.flowType()) ? b.flowType() : a.flowType())
-                .build();
-    }
-
-    private static String deriveFlowType(String topic) {
-        if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
-        if (topic.contains("fiat")) return "FIAT";
-        return "MIXED";
-    }
+  private static String deriveFlowType(String topic) {
+    if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
+    if (topic.contains("fiat")) return "FIAT";
+    return "MIXED";
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/VolumeAccumulator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/VolumeAccumulator.java
@@ -4,8 +4,8 @@ import lombok.Builder;
 
 @Builder(toBuilder = true)
 record VolumeAccumulator(
-        long totalAmountMicros,
-        long transactionCount,
-        String flowType,
-        String direction,
-        String currencyCode) {}
+    long totalAmountMicros,
+    long transactionCount,
+    String flowType,
+    String direction,
+    String currencyCode) {}

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/VolumeAggregator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/VolumeAggregator.java
@@ -1,84 +1,83 @@
 package io.stablepay.flink.agg;
 
+import io.stablepay.flink.model.ValidatedEvent;
+import io.stablepay.flink.topic.TopicDerivation;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 
-import io.stablepay.flink.model.ValidatedEvent;
-import io.stablepay.flink.topic.TopicDerivation;
-
 class VolumeAggregator implements AggregateFunction<ValidatedEvent, VolumeAccumulator, RowData> {
 
-    static final String UNKNOWN = "UNKNOWN";
+  static final String UNKNOWN = "UNKNOWN";
 
-    @Override
-    public VolumeAccumulator createAccumulator() {
-        return new VolumeAccumulator(0L, 0L, UNKNOWN, UNKNOWN, UNKNOWN);
+  @Override
+  public VolumeAccumulator createAccumulator() {
+    return new VolumeAccumulator(0L, 0L, UNKNOWN, UNKNOWN, UNKNOWN);
+  }
+
+  @Override
+  public VolumeAccumulator add(ValidatedEvent event, VolumeAccumulator acc) {
+    var record = event.toRecord();
+    var amountMicros = extractAmountMicros(record);
+    var flowType = TopicDerivation.deriveFlowType(event.topic());
+    var direction = TopicDerivation.deriveDirection(event.topic());
+    var currency = extractCurrencyCode(record);
+
+    return acc.toBuilder()
+        .totalAmountMicros(acc.totalAmountMicros() + amountMicros)
+        .transactionCount(acc.transactionCount() + 1)
+        .flowType(flowType)
+        .direction(direction)
+        .currencyCode(currency)
+        .build();
+  }
+
+  @Override
+  public RowData getResult(VolumeAccumulator acc) {
+    var row = new GenericRowData(7);
+    row.setField(0, null);
+    row.setField(1, null);
+    row.setField(2, StringData.fromString(acc.flowType()));
+    row.setField(3, StringData.fromString(acc.direction()));
+    row.setField(4, StringData.fromString(acc.currencyCode()));
+    row.setField(5, acc.totalAmountMicros());
+    row.setField(6, acc.transactionCount());
+    return row;
+  }
+
+  @Override
+  public VolumeAccumulator merge(VolumeAccumulator a, VolumeAccumulator b) {
+    return a.toBuilder()
+        .totalAmountMicros(a.totalAmountMicros() + b.totalAmountMicros())
+        .transactionCount(a.transactionCount() + b.transactionCount())
+        .flowType(preferKnown(a.flowType(), b.flowType()))
+        .direction(preferKnown(a.direction(), b.direction()))
+        .currencyCode(preferKnown(a.currencyCode(), b.currencyCode()))
+        .build();
+  }
+
+  private static long extractAmountMicros(GenericRecord record) {
+    var amount = record.get("amount");
+    if (amount instanceof GenericRecord moneyRecord) {
+      var micros = moneyRecord.get("amount_micros");
+      if (micros instanceof Long l) return l;
+      if (micros instanceof Number n) return n.longValue();
     }
+    return 0L;
+  }
 
-    @Override
-    public VolumeAccumulator add(ValidatedEvent event, VolumeAccumulator acc) {
-        var record = event.toRecord();
-        var amountMicros = extractAmountMicros(record);
-        var flowType = TopicDerivation.deriveFlowType(event.topic());
-        var direction = TopicDerivation.deriveDirection(event.topic());
-        var currency = extractCurrencyCode(record);
-
-        return acc.toBuilder()
-                .totalAmountMicros(acc.totalAmountMicros() + amountMicros)
-                .transactionCount(acc.transactionCount() + 1)
-                .flowType(flowType)
-                .direction(direction)
-                .currencyCode(currency)
-                .build();
+  private static String extractCurrencyCode(GenericRecord record) {
+    var amount = record.get("amount");
+    if (amount instanceof GenericRecord moneyRecord) {
+      var code = moneyRecord.get("currency_code");
+      if (code != null) return code.toString();
     }
+    return UNKNOWN;
+  }
 
-    @Override
-    public RowData getResult(VolumeAccumulator acc) {
-        var row = new GenericRowData(7);
-        row.setField(0, null);
-        row.setField(1, null);
-        row.setField(2, StringData.fromString(acc.flowType()));
-        row.setField(3, StringData.fromString(acc.direction()));
-        row.setField(4, StringData.fromString(acc.currencyCode()));
-        row.setField(5, acc.totalAmountMicros());
-        row.setField(6, acc.transactionCount());
-        return row;
-    }
-
-    @Override
-    public VolumeAccumulator merge(VolumeAccumulator a, VolumeAccumulator b) {
-        return a.toBuilder()
-                .totalAmountMicros(a.totalAmountMicros() + b.totalAmountMicros())
-                .transactionCount(a.transactionCount() + b.transactionCount())
-                .flowType(preferKnown(a.flowType(), b.flowType()))
-                .direction(preferKnown(a.direction(), b.direction()))
-                .currencyCode(preferKnown(a.currencyCode(), b.currencyCode()))
-                .build();
-    }
-
-    private static long extractAmountMicros(GenericRecord record) {
-        var amount = record.get("amount");
-        if (amount instanceof GenericRecord moneyRecord) {
-            var micros = moneyRecord.get("amount_micros");
-            if (micros instanceof Long l) return l;
-            if (micros instanceof Number n) return n.longValue();
-        }
-        return 0L;
-    }
-
-    private static String extractCurrencyCode(GenericRecord record) {
-        var amount = record.get("amount");
-        if (amount instanceof GenericRecord moneyRecord) {
-            var code = moneyRecord.get("currency_code");
-            if (code != null) return code.toString();
-        }
-        return UNKNOWN;
-    }
-
-    private static String preferKnown(String a, String b) {
-        return UNKNOWN.equals(a) ? b : a;
-    }
+  private static String preferKnown(String a, String b) {
+    return UNKNOWN.equals(a) ? b : a;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/WindowTimestampEmitter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/agg/WindowTimestampEmitter.java
@@ -3,7 +3,6 @@ package io.stablepay.flink.agg;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.table.data.GenericRowData;
@@ -13,40 +12,43 @@ import org.apache.flink.util.Collector;
 
 final class WindowTimestampEmitter {
 
-    private WindowTimestampEmitter() {}
+  private WindowTimestampEmitter() {}
 
-    static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> timestamptz(
-            int startFieldIndex, int endFieldIndex) {
-        return new ProcessWindowFunction<>() {
-            @Override
-            public void process(K key, Context context, Iterable<RowData> elements,
-                    Collector<RowData> out) {
-                var window = context.window();
-                for (var element : elements) {
-                    var row = (GenericRowData) element;
-                    row.setField(startFieldIndex, TimestampData.fromInstant(
-                            Instant.ofEpochMilli(window.getStart())));
-                    row.setField(endFieldIndex, TimestampData.fromInstant(
-                            Instant.ofEpochMilli(window.getEnd())));
-                    out.collect(row);
-                }
-            }
-        };
-    }
+  static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> timestamptz(
+      int startFieldIndex, int endFieldIndex) {
+    return new ProcessWindowFunction<>() {
+      @Override
+      public void process(
+          K key, Context context, Iterable<RowData> elements, Collector<RowData> out) {
+        var window = context.window();
+        for (var element : elements) {
+          var row = (GenericRowData) element;
+          row.setField(
+              startFieldIndex, TimestampData.fromInstant(Instant.ofEpochMilli(window.getStart())));
+          row.setField(
+              endFieldIndex, TimestampData.fromInstant(Instant.ofEpochMilli(window.getEnd())));
+          out.collect(row);
+        }
+      }
+    };
+  }
 
-    static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> date(int dateFieldIndex) {
-        return new ProcessWindowFunction<>() {
-            @Override
-            public void process(K key, Context context, Iterable<RowData> elements,
-                    Collector<RowData> out) {
-                var epochDay = (int) LocalDate.ofInstant(
-                        Instant.ofEpochMilli(context.window().getStart()), ZoneOffset.UTC).toEpochDay();
-                for (var element : elements) {
-                    var row = (GenericRowData) element;
-                    row.setField(dateFieldIndex, epochDay);
-                    out.collect(row);
-                }
-            }
-        };
-    }
+  static <K> ProcessWindowFunction<RowData, RowData, K, TimeWindow> date(int dateFieldIndex) {
+    return new ProcessWindowFunction<>() {
+      @Override
+      public void process(
+          K key, Context context, Iterable<RowData> elements, Collector<RowData> out) {
+        var epochDay =
+            (int)
+                LocalDate.ofInstant(
+                        Instant.ofEpochMilli(context.window().getStart()), ZoneOffset.UTC)
+                    .toEpochDay();
+        for (var element : elements) {
+          var row = (GenericRowData) element;
+          row.setField(dateFieldIndex, epochDay);
+          out.collect(row);
+        }
+      }
+    };
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/catalog/IcebergCatalogConfig.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/catalog/IcebergCatalogConfig.java
@@ -6,59 +6,68 @@ import java.util.Map;
 
 public final class IcebergCatalogConfig {
 
-    private IcebergCatalogConfig() {}
+  private IcebergCatalogConfig() {}
 
-    public static final String CATALOG_NAME = "iceberg_catalog";
-    public static final String RAW_NAMESPACE = "raw";
-    public static final String AGG_NAMESPACE = "agg";
-    public static final String FACTS_NAMESPACE = "facts";
-    public static final String DLQ_NAMESPACE = "dlq";
+  public static final String CATALOG_NAME = "iceberg_catalog";
+  public static final String RAW_NAMESPACE = "raw";
+  public static final String AGG_NAMESPACE = "agg";
+  public static final String FACTS_NAMESPACE = "facts";
+  public static final String DLQ_NAMESPACE = "dlq";
 
-    public static final List<String> AGG_TABLES = List.of(
-            "agg_volume_hourly",
-            "agg_success_rate_hourly",
-            "agg_screening_outcomes_daily",
-            "agg_dlq_summary_hourly",
-            "agg_stuck_withdrawals");
+  public static final List<String> AGG_TABLES =
+      List.of(
+          "agg_volume_hourly",
+          "agg_success_rate_hourly",
+          "agg_screening_outcomes_daily",
+          "agg_dlq_summary_hourly",
+          "agg_stuck_withdrawals");
 
-    public static final List<String> FACT_TABLES = List.of(
-            "fact_transactions", "fact_flows", "fact_screening_outcomes");
+  public static final List<String> FACT_TABLES =
+      List.of("fact_transactions", "fact_flows", "fact_screening_outcomes");
 
-    public static final List<String> RAW_TABLES = List.of(
-            "raw_payment_payout_fiat",
-            "raw_payment_payout_crypto",
-            "raw_payment_payin_fiat",
-            "raw_payment_payin_crypto",
-            "raw_payment_flow",
-            "raw_chain_transaction",
-            "raw_signing_request",
-            "raw_screening_result",
-            "raw_approval_decision");
+  public static final List<String> RAW_TABLES =
+      List.of(
+          "raw_payment_payout_fiat",
+          "raw_payment_payout_crypto",
+          "raw_payment_payin_fiat",
+          "raw_payment_payin_crypto",
+          "raw_payment_flow",
+          "raw_chain_transaction",
+          "raw_signing_request",
+          "raw_screening_result",
+          "raw_approval_decision");
 
-    public static final Map<String, String> TOPIC_TO_TABLE = Map.of(
-            "payment.payout.fiat.v1", "raw_payment_payout_fiat",
-            "payment.payout.crypto.v1", "raw_payment_payout_crypto",
-            "payment.payin.fiat.v1", "raw_payment_payin_fiat",
-            "payment.payin.crypto.v1", "raw_payment_payin_crypto",
-            "payment.flow.v1", "raw_payment_flow",
-            "chain.transaction.v1", "raw_chain_transaction",
-            "signing.request.v1", "raw_signing_request",
-            "screening.result.v1", "raw_screening_result",
-            "approval.decision.v1", "raw_approval_decision");
+  public static final Map<String, String> TOPIC_TO_TABLE =
+      Map.of(
+          "payment.payout.fiat.v1", "raw_payment_payout_fiat",
+          "payment.payout.crypto.v1", "raw_payment_payout_crypto",
+          "payment.payin.fiat.v1", "raw_payment_payin_fiat",
+          "payment.payin.crypto.v1", "raw_payment_payin_crypto",
+          "payment.flow.v1", "raw_payment_flow",
+          "chain.transaction.v1", "raw_chain_transaction",
+          "signing.request.v1", "raw_signing_request",
+          "screening.result.v1", "raw_screening_result",
+          "approval.decision.v1", "raw_approval_decision");
 
-    public static Map<String, String> catalogProperties() {
-        var props = new HashMap<String, String>();
-        props.put("type", "jdbc");
-        props.put("uri", System.getenv().getOrDefault("STBLPAY_ICEBERG_JDBC_URI",
-                "jdbc:postgresql://postgres:5432/iceberg_catalog"));
-        props.put("jdbc.user", System.getenv().getOrDefault("POSTGRES_USER", "stablepay"));
-        props.put("jdbc.password", System.getenv().getOrDefault("POSTGRES_PASSWORD", "stablepay_dev"));
-        props.put("warehouse", "s3a://warehouse/");
-        props.put("io-impl", "org.apache.iceberg.aws.s3.S3FileIO");
-        props.put("s3.endpoint", System.getenv().getOrDefault("STBLPAY_S3_ENDPOINT", "http://minio:9000"));
-        props.put("s3.access-key-id", System.getenv().getOrDefault("MINIO_ROOT_USER", "minioadmin"));
-        props.put("s3.secret-access-key", System.getenv().getOrDefault("MINIO_ROOT_PASSWORD", "minioadmin123"));
-        props.put("s3.path-style-access", "true");
-        return Map.copyOf(props);
-    }
+  public static Map<String, String> catalogProperties() {
+    var props = new HashMap<String, String>();
+    props.put("type", "jdbc");
+    props.put(
+        "uri",
+        System.getenv()
+            .getOrDefault(
+                "STBLPAY_ICEBERG_JDBC_URI", "jdbc:postgresql://postgres:5432/iceberg_catalog"));
+    props.put("jdbc.user", System.getenv().getOrDefault("POSTGRES_USER", "stablepay"));
+    props.put("jdbc.password", System.getenv().getOrDefault("POSTGRES_PASSWORD", "stablepay_dev"));
+    props.put("warehouse", "s3a://warehouse/");
+    props.put("io-impl", "org.apache.iceberg.aws.s3.S3FileIO");
+    props.put(
+        "s3.endpoint", System.getenv().getOrDefault("STBLPAY_S3_ENDPOINT", "http://minio:9000"));
+    props.put("s3.access-key-id", System.getenv().getOrDefault("MINIO_ROOT_USER", "minioadmin"));
+    props.put(
+        "s3.secret-access-key",
+        System.getenv().getOrDefault("MINIO_ROOT_PASSWORD", "minioadmin123"));
+    props.put("s3.path-style-access", "true");
+    return Map.copyOf(props);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/config/FlinkConfig.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/config/FlinkConfig.java
@@ -5,61 +5,64 @@ import java.util.Set;
 
 public final class FlinkConfig {
 
-    private FlinkConfig() {}
+  private FlinkConfig() {}
 
-    public static final Set<String> FACT_TX_TOPICS = Set.of(
-            "payment.payout.fiat.v1",
-            "payment.payout.crypto.v1",
-            "payment.payin.fiat.v1",
-            "payment.payin.crypto.v1",
-            "chain.transaction.v1");
+  public static final Set<String> FACT_TX_TOPICS =
+      Set.of(
+          "payment.payout.fiat.v1",
+          "payment.payout.crypto.v1",
+          "payment.payin.fiat.v1",
+          "payment.payin.crypto.v1",
+          "chain.transaction.v1");
 
-    public static final List<String> INPUT_TOPICS = List.of(
-            "payment.payout.fiat.v1",
-            "payment.payout.crypto.v1",
-            "payment.payin.fiat.v1",
-            "payment.payin.crypto.v1",
-            "payment.flow.v1",
-            "chain.transaction.v1",
-            "signing.request.v1",
-            "screening.result.v1",
-            "approval.decision.v1");
+  public static final List<String> INPUT_TOPICS =
+      List.of(
+          "payment.payout.fiat.v1",
+          "payment.payout.crypto.v1",
+          "payment.payin.fiat.v1",
+          "payment.payin.crypto.v1",
+          "payment.flow.v1",
+          "chain.transaction.v1",
+          "signing.request.v1",
+          "screening.result.v1",
+          "approval.decision.v1");
 
-    public static final String DLQ_SCHEMA_INVALID = "dlq.schema-invalid.v1";
-    public static final String DLQ_LATE_EVENTS = "dlq.late-events.v1";
-    public static final String DLQ_PROCESSING_FAILED = "dlq.processing-failed.v1";
-    public static final String DLQ_SINK_FAILED = "dlq.sink-failed.v1";
+  public static final String DLQ_SCHEMA_INVALID = "dlq.schema-invalid.v1";
+  public static final String DLQ_LATE_EVENTS = "dlq.late-events.v1";
+  public static final String DLQ_PROCESSING_FAILED = "dlq.processing-failed.v1";
+  public static final String DLQ_SINK_FAILED = "dlq.sink-failed.v1";
 
-    public static final List<String> DLQ_TOPICS = List.of(
-            DLQ_SCHEMA_INVALID, DLQ_LATE_EVENTS, DLQ_PROCESSING_FAILED, DLQ_SINK_FAILED);
+  public static final List<String> DLQ_TOPICS =
+      List.of(DLQ_SCHEMA_INVALID, DLQ_LATE_EVENTS, DLQ_PROCESSING_FAILED, DLQ_SINK_FAILED);
 
-    public static final Set<String> PAYMENT_TOPICS = Set.of(
-            "payment.payout.fiat.v1",
-            "payment.payout.crypto.v1",
-            "payment.payin.fiat.v1",
-            "payment.payin.crypto.v1");
+  public static final Set<String> PAYMENT_TOPICS =
+      Set.of(
+          "payment.payout.fiat.v1",
+          "payment.payout.crypto.v1",
+          "payment.payin.fiat.v1",
+          "payment.payin.crypto.v1");
 
-    public static final String INGEST_CONSUMER_GROUP = "stablepay-ingest-job";
-    public static final String CORRELATOR_CONSUMER_GROUP = "stablepay-correlator-job";
-    public static final String AGGREGATION_CONSUMER_GROUP = "stablepay-aggregation-job";
+  public static final String INGEST_CONSUMER_GROUP = "stablepay-ingest-job";
+  public static final String CORRELATOR_CONSUMER_GROUP = "stablepay-correlator-job";
+  public static final String AGGREGATION_CONSUMER_GROUP = "stablepay-aggregation-job";
 
-    private static final String ENV_KAFKA_BOOTSTRAP = "STBLPAY_KAFKA_BOOTSTRAP_SERVERS";
-    private static final String ENV_SCHEMA_REGISTRY = "STBLPAY_SCHEMA_REGISTRY_URL";
-    private static final String ENV_OPENSEARCH_URL = "STBLPAY_OPENSEARCH_URL";
+  private static final String ENV_KAFKA_BOOTSTRAP = "STBLPAY_KAFKA_BOOTSTRAP_SERVERS";
+  private static final String ENV_SCHEMA_REGISTRY = "STBLPAY_SCHEMA_REGISTRY_URL";
+  private static final String ENV_OPENSEARCH_URL = "STBLPAY_OPENSEARCH_URL";
 
-    private static final String DEFAULT_KAFKA_BOOTSTRAP = "kafka:9092";
-    private static final String DEFAULT_SCHEMA_REGISTRY = "http://schema-registry:8081";
-    private static final String DEFAULT_OPENSEARCH_URL = "http://opensearch:9200";
+  private static final String DEFAULT_KAFKA_BOOTSTRAP = "kafka:9092";
+  private static final String DEFAULT_SCHEMA_REGISTRY = "http://schema-registry:8081";
+  private static final String DEFAULT_OPENSEARCH_URL = "http://opensearch:9200";
 
-    public static String kafkaBootstrapServers() {
-        return System.getenv().getOrDefault(ENV_KAFKA_BOOTSTRAP, DEFAULT_KAFKA_BOOTSTRAP);
-    }
+  public static String kafkaBootstrapServers() {
+    return System.getenv().getOrDefault(ENV_KAFKA_BOOTSTRAP, DEFAULT_KAFKA_BOOTSTRAP);
+  }
 
-    public static String schemaRegistryUrl() {
-        return System.getenv().getOrDefault(ENV_SCHEMA_REGISTRY, DEFAULT_SCHEMA_REGISTRY);
-    }
+  public static String schemaRegistryUrl() {
+    return System.getenv().getOrDefault(ENV_SCHEMA_REGISTRY, DEFAULT_SCHEMA_REGISTRY);
+  }
 
-    public static String opensearchUrl() {
-        return System.getenv().getOrDefault(ENV_OPENSEARCH_URL, DEFAULT_OPENSEARCH_URL);
-    }
+  public static String opensearchUrl() {
+    return System.getenv().getOrDefault(ENV_OPENSEARCH_URL, DEFAULT_OPENSEARCH_URL);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/CompensationEventEmitter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/CompensationEventEmitter.java
@@ -2,19 +2,20 @@ package io.stablepay.flink.correlator;
 
 public final class CompensationEventEmitter {
 
-    private CompensationEventEmitter() {}
+  private CompensationEventEmitter() {}
 
-    public static boolean shouldTrigger(FlowState state) {
-        return state.anyLegCompleted() && state.anyLegFailed()
-                && !"COMPENSATION_INITIATED".equals(state.currentFlowStatus())
-                && !"COMPENSATION_COMPLETED".equals(state.currentFlowStatus());
-    }
+  public static boolean shouldTrigger(FlowState state) {
+    return state.anyLegCompleted()
+        && state.anyLegFailed()
+        && !"COMPENSATION_INITIATED".equals(state.currentFlowStatus())
+        && !"COMPENSATION_COMPLETED".equals(state.currentFlowStatus());
+  }
 
-    public static byte[] emitCompensationInitiated(FlowState state) {
-        return FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_INITIATED");
-    }
+  public static byte[] emitCompensationInitiated(FlowState state) {
+    return FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_INITIATED");
+  }
 
-    public static byte[] emitCompensationCompleted(FlowState state) {
-        return FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_COMPLETED");
-    }
+  public static byte[] emitCompensationCompleted(FlowState state) {
+    return FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_COMPLETED");
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowCorrelatorFunction.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowCorrelatorFunction.java
@@ -1,8 +1,9 @@
 package io.stablepay.flink.correlator;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.time.Duration;
 import java.util.Objects;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.state.StateTtlConfig;
@@ -11,115 +12,113 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.util.Collector;
 
-import io.stablepay.flink.model.ValidatedEvent;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class FlowCorrelatorFunction extends KeyedProcessFunction<String, ValidatedEvent, byte[]> {
 
-    private transient ValueState<FlowState> flowState;
+  private transient ValueState<FlowState> flowState;
 
-    @Override
-    public void open(OpenContext openContext) throws Exception {
-        var descriptor =
-                new ValueStateDescriptor<>("flow-state", FlowState.class);
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    var descriptor = new ValueStateDescriptor<>("flow-state", FlowState.class);
 
-        var ttlConfig = StateTtlConfig.newBuilder(Duration.ofHours(24))
-                .setUpdateType(StateTtlConfig.UpdateType.OnReadAndWrite)
-                .setStateVisibility(StateTtlConfig.StateVisibility.NeverReturnExpired)
-                .build();
-        descriptor.enableTimeToLive(ttlConfig);
+    var ttlConfig =
+        StateTtlConfig.newBuilder(Duration.ofHours(24))
+            .setUpdateType(StateTtlConfig.UpdateType.OnReadAndWrite)
+            .setStateVisibility(StateTtlConfig.StateVisibility.NeverReturnExpired)
+            .build();
+    descriptor.enableTimeToLive(ttlConfig);
 
-        flowState = getRuntimeContext().getState(descriptor);
+    flowState = getRuntimeContext().getState(descriptor);
+  }
+
+  @Override
+  public void processElement(ValidatedEvent event, Context ctx, Collector<byte[]> out)
+      throws Exception {
+    if (event.flowId() == null || event.flowId().isEmpty()) {
+      return;
     }
 
-    @Override
-    public void processElement(ValidatedEvent event, Context ctx, Collector<byte[]> out)
-            throws Exception {
-        if (event.flowId() == null || event.flowId().isEmpty()) {
-            return;
-        }
+    var state = flowState.value();
+    if (state == null) {
+      state = new FlowState();
+    }
 
-        var state = flowState.value();
-        if (state == null) {
-            state = new FlowState();
-        }
+    var topic = event.topic();
+    var previousStatus = state.currentFlowStatus();
 
-        var topic = event.topic();
-        var previousStatus = state.currentFlowStatus();
+    if ("payment.flow.v1".equals(topic)) {
+      handleFlowEvent(state, event);
+    } else {
+      handleChildEvent(state, event, topic);
+    }
 
-        if ("payment.flow.v1".equals(topic)) {
-            handleFlowEvent(state, event);
-        } else {
-            handleChildEvent(state, event, topic);
-        }
+    var eventTime = event.eventTimeMillis();
+    var newStatus = state.deriveFlowStatus();
+    state.setCurrentFlowStatus(newStatus, eventTime);
+    flowState.update(state);
 
-        var eventTime = event.eventTimeMillis();
-        var newStatus = state.deriveFlowStatus();
-        state.setCurrentFlowStatus(newStatus, eventTime);
+    if (!Objects.equals(newStatus, previousStatus)) {
+      out.collect(FlowLifecycleEmitter.serializeToBytes(state, newStatus));
+      log.info(
+          "flow_lifecycle: flow_id={} status={}->{}", event.flowId(), previousStatus, newStatus);
+
+      if ("PARTIALLY_COMPLETED".equals(newStatus)) {
+        state.setCurrentFlowStatus("COMPENSATION_INITIATED", eventTime);
         flowState.update(state);
+        out.collect(FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_INITIATED"));
+        log.info("compensation_initiated: flow_id={}", event.flowId());
+      }
+    }
+  }
 
-        if (!Objects.equals(newStatus, previousStatus)) {
-            out.collect(FlowLifecycleEmitter.serializeToBytes(state, newStatus));
-            log.info("flow_lifecycle: flow_id={} status={}->{}", event.flowId(), previousStatus, newStatus);
+  private void handleFlowEvent(FlowState state, ValidatedEvent event) {
+    var record = event.toRecord();
+    var flowStatus = record.get("flow_status");
+    if (flowStatus != null && "INITIATED".equals(flowStatus.toString())) {
+      var customerId = record.get("customer_id");
+      var flowType = record.get("flow_type");
+      state.initialize(
+          event.flowId(),
+          customerId != null ? customerId.toString() : "",
+          flowType != null ? flowType.toString() : "ONRAMP",
+          event.eventTimeMillis());
+    }
+  }
 
-            if ("PARTIALLY_COMPLETED".equals(newStatus)) {
-                state.setCurrentFlowStatus("COMPENSATION_INITIATED", eventTime);
-                flowState.update(state);
-                out.collect(FlowLifecycleEmitter.serializeToBytes(state, "COMPENSATION_INITIATED"));
-                log.info("compensation_initiated: flow_id={}", event.flowId());
-            }
-        }
+  private void handleChildEvent(FlowState state, ValidatedEvent event, String topic) {
+    if (state.flowId() == null) {
+      state.initialize(event.flowId(), "", "ONRAMP", event.eventTimeMillis());
     }
 
-    private void handleFlowEvent(FlowState state, ValidatedEvent event) {
-        var record = event.toRecord();
-        var flowStatus = record.get("flow_status");
-        if (flowStatus != null && "INITIATED".equals(flowStatus.toString())) {
-            var customerId = record.get("customer_id");
-            var flowType = record.get("flow_type");
-            state.initialize(
-                    event.flowId(),
-                    customerId != null ? customerId.toString() : "",
-                    flowType != null ? flowType.toString() : "ONRAMP",
-                    event.eventTimeMillis());
-        }
+    var record = event.toRecord();
+    var legType = classifyLegType(topic);
+    var legId = legType + "-" + event.flowId();
+    var status = extractChildStatus(record);
+    var reference = extractReference(record, event.eventId());
+
+    state.updateLeg(legId, legType, status, reference, event.eventTimeMillis());
+  }
+
+  private static String classifyLegType(String topic) {
+    if (topic.contains("payin")) return "PAYIN";
+    if (topic.contains("payout")) return "PAYOUT";
+    if (topic.contains("chain.transaction")) return "TRADE";
+    return "TRADE";
+  }
+
+  private static String extractChildStatus(GenericRecord record) {
+    for (String field : new String[] {"internal_status", "status", "flow_status"}) {
+      var val = record.get(field);
+      if (val != null) return val.toString();
     }
+    return "UNKNOWN";
+  }
 
-    private void handleChildEvent(FlowState state, ValidatedEvent event, String topic) {
-        if (state.flowId() == null) {
-            state.initialize(event.flowId(), "", "ONRAMP", event.eventTimeMillis());
-        }
-
-        var record = event.toRecord();
-        var legType = classifyLegType(topic);
-        var legId = legType + "-" + event.flowId();
-        var status = extractChildStatus(record);
-        var reference = extractReference(record, event.eventId());
-
-        state.updateLeg(legId, legType, status, reference, event.eventTimeMillis());
+  private static String extractReference(GenericRecord record, String fallbackEventId) {
+    for (String field : new String[] {"payout_reference", "payin_reference", "tx_hash"}) {
+      var val = record.get(field);
+      if (val != null) return val.toString();
     }
-
-    private static String classifyLegType(String topic) {
-        if (topic.contains("payin")) return "PAYIN";
-        if (topic.contains("payout")) return "PAYOUT";
-        if (topic.contains("chain.transaction")) return "TRADE";
-        return "TRADE";
-    }
-
-    private static String extractChildStatus(GenericRecord record) {
-        for (String field : new String[]{"internal_status", "status", "flow_status"}) {
-            var val = record.get(field);
-            if (val != null) return val.toString();
-        }
-        return "UNKNOWN";
-    }
-
-    private static String extractReference(GenericRecord record, String fallbackEventId) {
-        for (String field : new String[]{"payout_reference", "payin_reference", "tx_hash"}) {
-            var val = record.get(field);
-            if (val != null) return val.toString();
-        }
-        return fallbackEventId;
-    }
+    return fallbackEventId;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowEventSerializer.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowEventSerializer.java
@@ -1,11 +1,15 @@
 package io.stablepay.flink.correlator;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.stablepay.events.flow.PaymentFlowV1;
+import io.stablepay.flink.config.FlinkConfig;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
@@ -13,65 +17,59 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.stablepay.events.flow.PaymentFlowV1;
-import io.stablepay.flink.config.FlinkConfig;
-
 public class FlowEventSerializer implements KafkaRecordSerializationSchema<byte[]> {
 
-    private static final String TOPIC = "payment.flow.v1";
-    private static final Schema SCHEMA = PaymentFlowV1.getClassSchema();
+  private static final String TOPIC = "payment.flow.v1";
+  private static final Schema SCHEMA = PaymentFlowV1.getClassSchema();
 
-    private transient SchemaRegistryClient schemaRegistryClient;
-    private transient int schemaId;
-    private transient boolean initialized;
+  private transient SchemaRegistryClient schemaRegistryClient;
+  private transient int schemaId;
+  private transient boolean initialized;
 
-    private void ensureInitialized() {
-        if (!initialized) {
-            schemaRegistryClient = new CachedSchemaRegistryClient(FlinkConfig.schemaRegistryUrl(), 100);
-            try {
-                var subject = TOPIC + "-value";
-                schemaId = schemaRegistryClient.register(subject, new AvroSchema(SCHEMA));
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to register schema with Schema Registry", e);
-            }
-            initialized = true;
-        }
+  private void ensureInitialized() {
+    if (!initialized) {
+      schemaRegistryClient = new CachedSchemaRegistryClient(FlinkConfig.schemaRegistryUrl(), 100);
+      try {
+        var subject = TOPIC + "-value";
+        schemaId = schemaRegistryClient.register(subject, new AvroSchema(SCHEMA));
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to register schema with Schema Registry", e);
+      }
+      initialized = true;
     }
+  }
 
-    @Override
-    public ProducerRecord<byte[], byte[]> serialize(
-            byte[] avroBytes, KafkaSinkContext context, Long timestamp) {
-        ensureInitialized();
-        var flowId = extractFlowId(avroBytes);
-        byte[] key = flowId != null ? flowId.getBytes(StandardCharsets.UTF_8) : null;
-        byte[] value = prependConfluentHeader(avroBytes);
-        return new ProducerRecord<>(TOPIC, key, value);
-    }
+  @Override
+  public ProducerRecord<byte[], byte[]> serialize(
+      byte[] avroBytes, KafkaSinkContext context, Long timestamp) {
+    ensureInitialized();
+    var flowId = extractFlowId(avroBytes);
+    byte[] key = flowId != null ? flowId.getBytes(StandardCharsets.UTF_8) : null;
+    byte[] value = prependConfluentHeader(avroBytes);
+    return new ProducerRecord<>(TOPIC, key, value);
+  }
 
-    private String extractFlowId(byte[] avroBytes) {
-        try {
-            var reader = new GenericDatumReader<GenericRecord>(SCHEMA);
-            var decoder = DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(avroBytes), null);
-            var record = reader.read(null, decoder);
-            var flowId = record.get("flow_id");
-            return flowId != null ? flowId.toString() : null;
-        } catch (IOException e) {
-            return null;
-        }
+  private String extractFlowId(byte[] avroBytes) {
+    try {
+      var reader = new GenericDatumReader<GenericRecord>(SCHEMA);
+      var decoder = DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(avroBytes), null);
+      var record = reader.read(null, decoder);
+      var flowId = record.get("flow_id");
+      return flowId != null ? flowId.toString() : null;
+    } catch (IOException e) {
+      return null;
     }
+  }
 
-    private byte[] prependConfluentHeader(byte[] avroBytes) {
-        try {
-            var out = new ByteArrayOutputStream(1 + 4 + avroBytes.length);
-            out.write(0x0);
-            out.write(ByteBuffer.allocate(4).putInt(schemaId).array());
-            out.write(avroBytes);
-            return out.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to build Confluent wire format", e);
-        }
+  private byte[] prependConfluentHeader(byte[] avroBytes) {
+    try {
+      var out = new ByteArrayOutputStream(1 + 4 + avroBytes.length);
+      out.write(0x0);
+      out.write(ByteBuffer.allocate(4).putInt(schemaId).array());
+      out.write(avroBytes);
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to build Confluent wire format", e);
     }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowLifecycleEmitter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowLifecycleEmitter.java
@@ -1,77 +1,76 @@
 package io.stablepay.flink.correlator;
 
+import io.stablepay.events.flow.PaymentFlowV1;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
-
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.EncoderFactory;
 
-import io.stablepay.events.flow.PaymentFlowV1;
-
 public final class FlowLifecycleEmitter {
 
-    private static final Schema SCHEMA = PaymentFlowV1.getClassSchema();
-    private static final Schema ENVELOPE_SCHEMA = SCHEMA.getField("envelope").schema();
-    private static final Schema LEG_SCHEMA = SCHEMA.getField("legs").schema().getElementType();
+  private static final Schema SCHEMA = PaymentFlowV1.getClassSchema();
+  private static final Schema ENVELOPE_SCHEMA = SCHEMA.getField("envelope").schema();
+  private static final Schema LEG_SCHEMA = SCHEMA.getField("legs").schema().getElementType();
 
-    private FlowLifecycleEmitter() {}
+  private FlowLifecycleEmitter() {}
 
-    public static byte[] serializeToBytes(FlowState state, String newStatus) {
-        var record = emit(state, newStatus);
-        try {
-            var out = new ByteArrayOutputStream();
-            var writer = new GenericDatumWriter<GenericRecord>(SCHEMA);
-            var encoder = EncoderFactory.get().binaryEncoder(out, null);
-            writer.write(record, encoder);
-            encoder.flush();
-            return out.toByteArray();
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to serialize flow lifecycle event", e);
-        }
+  public static byte[] serializeToBytes(FlowState state, String newStatus) {
+    var record = emit(state, newStatus);
+    try {
+      var out = new ByteArrayOutputStream();
+      var writer = new GenericDatumWriter<GenericRecord>(SCHEMA);
+      var encoder = EncoderFactory.get().binaryEncoder(out, null);
+      writer.write(record, encoder);
+      encoder.flush();
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to serialize flow lifecycle event", e);
+    }
+  }
+
+  static GenericRecord emit(FlowState state, String newStatus) {
+    var now = System.currentTimeMillis();
+
+    var envelope = new GenericData.Record(ENVELOPE_SCHEMA);
+    envelope.put("event_id", UUID.randomUUID().toString());
+    envelope.put("event_time", now);
+    envelope.put("ingest_time", now);
+    envelope.put("schema_version", "1.0.0");
+    envelope.put("flow_id", state.flowId());
+    envelope.put("correlation_id", null);
+    envelope.put("trace_id", null);
+
+    var legs = new ArrayList<GenericRecord>();
+    for (var leg : state.toLegList()) {
+      var legRecord = new GenericData.Record(LEG_SCHEMA);
+      legRecord.put("leg_id", leg.legId());
+      legRecord.put("leg_type", leg.legType());
+      legRecord.put("status", leg.status());
+      legRecord.put("reference", leg.reference());
+      legs.add(legRecord);
     }
 
-    static GenericRecord emit(FlowState state, String newStatus) {
-        var now = System.currentTimeMillis();
+    var flow = new GenericData.Record(SCHEMA);
+    flow.put("envelope", envelope);
+    flow.put("flow_id", state.flowId());
+    flow.put("customer_id", state.customerId());
+    flow.put(
+        "flow_type",
+        new GenericData.EnumSymbol(SCHEMA.getField("flow_type").schema(), state.flowType()));
+    flow.put(
+        "flow_status",
+        new GenericData.EnumSymbol(SCHEMA.getField("flow_status").schema(), newStatus));
+    flow.put("source_amount", null);
+    flow.put("target_amount", null);
+    flow.put("fx_rate", null);
+    flow.put("legs", legs);
+    flow.put("description", null);
 
-        var envelope = new GenericData.Record(ENVELOPE_SCHEMA);
-        envelope.put("event_id", UUID.randomUUID().toString());
-        envelope.put("event_time", now);
-        envelope.put("ingest_time", now);
-        envelope.put("schema_version", "1.0.0");
-        envelope.put("flow_id", state.flowId());
-        envelope.put("correlation_id", null);
-        envelope.put("trace_id", null);
-
-        var legs = new ArrayList<GenericRecord>();
-        for (var leg : state.toLegList()) {
-            var legRecord = new GenericData.Record(LEG_SCHEMA);
-            legRecord.put("leg_id", leg.legId());
-            legRecord.put("leg_type", leg.legType());
-            legRecord.put("status", leg.status());
-            legRecord.put("reference", leg.reference());
-            legs.add(legRecord);
-        }
-
-        var flow = new GenericData.Record(SCHEMA);
-        flow.put("envelope", envelope);
-        flow.put("flow_id", state.flowId());
-        flow.put("customer_id", state.customerId());
-        flow.put("flow_type", new GenericData.EnumSymbol(
-                SCHEMA.getField("flow_type").schema(), state.flowType()));
-        flow.put("flow_status", new GenericData.EnumSymbol(
-                SCHEMA.getField("flow_status").schema(), newStatus));
-        flow.put("source_amount", null);
-        flow.put("target_amount", null);
-        flow.put("fx_rate", null);
-        flow.put("legs", legs);
-        flow.put("description", null);
-
-        return flow;
-    }
+    return flow;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowState.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/correlator/FlowState.java
@@ -9,117 +9,138 @@ import java.util.Map;
 
 public class FlowState implements Serializable {
 
-    private String flowId;
-    private String customerId;
-    private String flowType;
-    private String currentFlowStatus;
-    private Map<String, LegState> legs;
-    private int expectedLegCount;
-    private long initiatedAt;
-    private long lastUpdatedAt;
+  private String flowId;
+  private String customerId;
+  private String flowType;
+  private String currentFlowStatus;
+  private Map<String, LegState> legs;
+  private int expectedLegCount;
+  private long initiatedAt;
+  private long lastUpdatedAt;
 
-    public FlowState() {
-        this.legs = new HashMap<>();
-        this.expectedLegCount = 3;
+  public FlowState() {
+    this.legs = new HashMap<>();
+    this.expectedLegCount = 3;
+  }
+
+  @lombok.Builder
+  public record LegState(String legId, String legType, String status, String reference)
+      implements Serializable {}
+
+  public void initialize(String flowId, String customerId, String flowType, long initiatedAt) {
+    this.flowId = flowId;
+    this.customerId = customerId;
+    this.flowType = flowType;
+    this.currentFlowStatus = "INITIATED";
+    this.expectedLegCount = deriveExpectedLegCount(flowType);
+    this.initiatedAt = initiatedAt;
+    this.lastUpdatedAt = initiatedAt;
+  }
+
+  private static int deriveExpectedLegCount(String flowType) {
+    return switch (flowType) {
+      case "ONRAMP", "OFFRAMP", "CRYPTO_TO_CRYPTO" -> 3;
+      default -> 3;
+    };
+  }
+
+  public void updateLeg(
+      String legId, String legType, String status, String reference, long eventTimeMillis) {
+    legs.put(
+        legId,
+        LegState.builder()
+            .legId(legId)
+            .legType(legType)
+            .status(status)
+            .reference(reference)
+            .build());
+    lastUpdatedAt = eventTimeMillis;
+  }
+
+  public boolean allLegsCompleted() {
+    if (legs.size() < expectedLegCount) return false;
+    return legs.values().stream().allMatch(l -> "COMPLETED".equals(l.status()));
+  }
+
+  public boolean anyLegFailed() {
+    return legs.values().stream()
+        .anyMatch(l -> "FAILED".equals(l.status()) || "CANCELLED".equals(l.status()));
+  }
+
+  public boolean anyLegCompleted() {
+    return legs.values().stream().anyMatch(l -> "COMPLETED".equals(l.status()));
+  }
+
+  public String deriveFlowStatus() {
+    if (allLegsCompleted()) return "COMPLETED";
+
+    if (anyLegCompleted() && anyLegFailed()) {
+      if ("COMPENSATION_INITIATED".equals(currentFlowStatus)
+          || "COMPENSATION_COMPLETED".equals(currentFlowStatus)) {
+        return currentFlowStatus;
+      }
+      return "PARTIALLY_COMPLETED";
     }
 
-    @lombok.Builder
-    public record LegState(
-            String legId,
-            String legType,
-            String status,
-            String reference) implements Serializable {}
-
-    public void initialize(String flowId, String customerId, String flowType, long initiatedAt) {
-        this.flowId = flowId;
-        this.customerId = customerId;
-        this.flowType = flowType;
-        this.currentFlowStatus = "INITIATED";
-        this.expectedLegCount = deriveExpectedLegCount(flowType);
-        this.initiatedAt = initiatedAt;
-        this.lastUpdatedAt = initiatedAt;
+    if (legs.size() == expectedLegCount
+        && legs.values().stream()
+            .allMatch(l -> "FAILED".equals(l.status()) || "CANCELLED".equals(l.status()))) {
+      return "FAILED";
     }
 
-    private static int deriveExpectedLegCount(String flowType) {
-        return switch (flowType) {
-            case "ONRAMP", "OFFRAMP", "CRYPTO_TO_CRYPTO" -> 3;
-            default -> 3;
-        };
-    }
+    var hasPayinCompleted =
+        legs.values().stream()
+            .anyMatch(l -> "PAYIN".equals(l.legType()) && "COMPLETED".equals(l.status()));
+    var hasPayoutStarted = legs.values().stream().anyMatch(l -> "PAYOUT".equals(l.legType()));
+    var hasTradeCompleted =
+        legs.values().stream()
+            .anyMatch(l -> "TRADE".equals(l.legType()) && "COMPLETED".equals(l.status()));
+    var hasTradeStarted = legs.values().stream().anyMatch(l -> "TRADE".equals(l.legType()));
+    var hasPayinStarted = legs.values().stream().anyMatch(l -> "PAYIN".equals(l.legType()));
 
-    public void updateLeg(String legId, String legType, String status, String reference, long eventTimeMillis) {
-        legs.put(legId, LegState.builder()
-                .legId(legId)
-                .legType(legType)
-                .status(status)
-                .reference(reference)
-                .build());
-        lastUpdatedAt = eventTimeMillis;
-    }
+    if (hasPayoutStarted && hasTradeCompleted) return "PAYOUT_PENDING";
+    if (hasTradeCompleted) return "TRADE_COMPLETED";
+    if (hasTradeStarted && hasPayinCompleted) return "TRADE_PENDING";
+    if (hasPayinCompleted) return "PAYIN_COMPLETED";
+    if (hasPayinStarted) return "PAYIN_PENDING";
 
-    public boolean allLegsCompleted() {
-        if (legs.size() < expectedLegCount) return false;
-        return legs.values().stream().allMatch(l -> "COMPLETED".equals(l.status()));
-    }
+    return currentFlowStatus != null ? currentFlowStatus : "INITIATED";
+  }
 
-    public boolean anyLegFailed() {
-        return legs.values().stream().anyMatch(l -> "FAILED".equals(l.status()) || "CANCELLED".equals(l.status()));
-    }
+  public void setCurrentFlowStatus(String status, long eventTimeMillis) {
+    this.currentFlowStatus = status;
+    this.lastUpdatedAt = eventTimeMillis;
+  }
 
-    public boolean anyLegCompleted() {
-        return legs.values().stream().anyMatch(l -> "COMPLETED".equals(l.status()));
-    }
+  public List<LegState> toLegList() {
+    return new ArrayList<>(legs.values());
+  }
 
-    public String deriveFlowStatus() {
-        if (allLegsCompleted()) return "COMPLETED";
+  public String flowId() {
+    return flowId;
+  }
 
-        if (anyLegCompleted() && anyLegFailed()) {
-            if ("COMPENSATION_INITIATED".equals(currentFlowStatus)
-                    || "COMPENSATION_COMPLETED".equals(currentFlowStatus)) {
-                return currentFlowStatus;
-            }
-            return "PARTIALLY_COMPLETED";
-        }
+  public String customerId() {
+    return customerId;
+  }
 
-        if (legs.size() == expectedLegCount && legs.values().stream().allMatch(
-                l -> "FAILED".equals(l.status()) || "CANCELLED".equals(l.status()))) {
-            return "FAILED";
-        }
+  public String flowType() {
+    return flowType;
+  }
 
-        var hasPayinCompleted = legs.values().stream()
-                .anyMatch(l -> "PAYIN".equals(l.legType()) && "COMPLETED".equals(l.status()));
-        var hasPayoutStarted = legs.values().stream()
-                .anyMatch(l -> "PAYOUT".equals(l.legType()));
-        var hasTradeCompleted = legs.values().stream()
-                .anyMatch(l -> "TRADE".equals(l.legType()) && "COMPLETED".equals(l.status()));
-        var hasTradeStarted = legs.values().stream()
-                .anyMatch(l -> "TRADE".equals(l.legType()));
-        var hasPayinStarted = legs.values().stream()
-                .anyMatch(l -> "PAYIN".equals(l.legType()));
+  public String currentFlowStatus() {
+    return currentFlowStatus;
+  }
 
-        if (hasPayoutStarted && hasTradeCompleted) return "PAYOUT_PENDING";
-        if (hasTradeCompleted) return "TRADE_COMPLETED";
-        if (hasTradeStarted && hasPayinCompleted) return "TRADE_PENDING";
-        if (hasPayinCompleted) return "PAYIN_COMPLETED";
-        if (hasPayinStarted) return "PAYIN_PENDING";
+  public Map<String, LegState> legs() {
+    return Collections.unmodifiableMap(legs);
+  }
 
-        return currentFlowStatus != null ? currentFlowStatus : "INITIATED";
-    }
+  public long initiatedAt() {
+    return initiatedAt;
+  }
 
-    public void setCurrentFlowStatus(String status, long eventTimeMillis) {
-        this.currentFlowStatus = status;
-        this.lastUpdatedAt = eventTimeMillis;
-    }
-
-    public List<LegState> toLegList() {
-        return new ArrayList<>(legs.values());
-    }
-
-    public String flowId() { return flowId; }
-    public String customerId() { return customerId; }
-    public String flowType() { return flowType; }
-    public String currentFlowStatus() { return currentFlowStatus; }
-    public Map<String, LegState> legs() { return Collections.unmodifiableMap(legs); }
-    public long initiatedAt() { return initiatedAt; }
-    public long lastUpdatedAt() { return lastUpdatedAt; }
+  public long lastUpdatedAt() {
+    return lastUpdatedAt;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/AvroEnvelopeDeserializer.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/AvroEnvelopeDeserializer.java
@@ -1,10 +1,14 @@
 package io.stablepay.flink.deser;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.ValidationResult;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import org.apache.avro.Schema;
+import lombok.RequiredArgsConstructor;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DecoderFactory;
@@ -14,76 +18,90 @@ import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDe
 import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.ValidatedEvent;
-import io.stablepay.flink.model.ValidationResult;
-import lombok.RequiredArgsConstructor;
-
 @RequiredArgsConstructor
-public class AvroEnvelopeDeserializer implements KafkaRecordDeserializationSchema<ValidationResult> {
+public class AvroEnvelopeDeserializer
+    implements KafkaRecordDeserializationSchema<ValidationResult> {
 
-    private static final int MAGIC_BYTE = 0x0;
-    private static final int SCHEMA_ID_SIZE = 4;
+  private static final int MAGIC_BYTE = 0x0;
+  private static final int SCHEMA_ID_SIZE = 4;
 
-    private final String schemaRegistryUrl;
-    private transient SchemaRegistryClient schemaRegistryClient;
+  private final String schemaRegistryUrl;
+  private transient SchemaRegistryClient schemaRegistryClient;
 
-    @Override
-    public void open(DeserializationSchema.InitializationContext context) {
-        this.schemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryUrl, 100);
+  @Override
+  public void open(DeserializationSchema.InitializationContext context) {
+    this.schemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryUrl, 100);
+  }
+
+  @Override
+  public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<ValidationResult> out)
+      throws IOException {
+    var topic = record.topic();
+    var partition = record.partition();
+    var offset = record.offset();
+    var key = record.key() != null ? new String(record.key()) : null;
+    var valueBytes = record.value();
+
+    if (valueBytes == null || valueBytes.length < 1 + SCHEMA_ID_SIZE) {
+      out.collect(
+          toDlqResult(
+              topic, partition, offset, "EMPTY_PAYLOAD", "Null or too-short value", valueBytes));
+      return;
     }
 
-    @Override
-    public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<ValidationResult> out) throws IOException {
-        var topic = record.topic();
-        var partition = record.partition();
-        var offset = record.offset();
-        var key = record.key() != null ? new String(record.key()) : null;
-        var valueBytes = record.value();
-
-        if (valueBytes == null || valueBytes.length < 1 + SCHEMA_ID_SIZE) {
-            out.collect(toDlqResult(topic, partition, offset, "EMPTY_PAYLOAD", "Null or too-short value", valueBytes));
-            return;
-        }
-
-        if (valueBytes[0] != MAGIC_BYTE) {
-            out.collect(toDlqResult(topic, partition, offset, "INVALID_MAGIC_BYTE", "Not Confluent wire format", valueBytes));
-            return;
-        }
-
-        var schemaId = ByteBuffer.wrap(valueBytes, 1, SCHEMA_ID_SIZE).getInt();
-
-        try {
-            var writerSchema = ((AvroSchema) schemaRegistryClient.getSchemaById(schemaId)).rawSchema();
-            var reader = new GenericDatumReader<GenericRecord>(writerSchema);
-            var decoder = DecoderFactory.get().binaryDecoder(
-                    new ByteArrayInputStream(valueBytes, 1 + SCHEMA_ID_SIZE, valueBytes.length - 1 - SCHEMA_ID_SIZE),
-                    null);
-            var genericRecord = reader.read(null, decoder);
-            out.collect(EnvelopeValidator.validate(topic, partition, offset, key, genericRecord, valueBytes));
-        } catch (Exception e) {
-            out.collect(toDlqResult(topic, partition, offset, "SCHEMA_INVALID", e.getMessage(), valueBytes));
-        }
+    if (valueBytes[0] != MAGIC_BYTE) {
+      out.collect(
+          toDlqResult(
+              topic,
+              partition,
+              offset,
+              "INVALID_MAGIC_BYTE",
+              "Not Confluent wire format",
+              valueBytes));
+      return;
     }
 
-    @Override
-    public TypeInformation<ValidationResult> getProducedType() {
-        return TypeInformation.of(ValidationResult.class);
-    }
+    var schemaId = ByteBuffer.wrap(valueBytes, 1, SCHEMA_ID_SIZE).getInt();
 
-    private static ValidationResult toDlqResult(
-            String topic, int partition, long offset, String errorClass, String errorMessage, byte[] rawBytes) {
-        return new ValidationResult.Invalid(DlqEnvelope.builder()
-                .sourceTopic(topic)
-                .sourcePartition(partition)
-                .sourceOffset(offset)
-                .errorClass(errorClass)
-                .errorMessage(errorMessage)
-                .originalPayloadBytes(rawBytes)
-                .failedAt(java.time.Instant.now().toEpochMilli())
-                .build());
+    try {
+      var writerSchema = ((AvroSchema) schemaRegistryClient.getSchemaById(schemaId)).rawSchema();
+      var reader = new GenericDatumReader<GenericRecord>(writerSchema);
+      var decoder =
+          DecoderFactory.get()
+              .binaryDecoder(
+                  new ByteArrayInputStream(
+                      valueBytes, 1 + SCHEMA_ID_SIZE, valueBytes.length - 1 - SCHEMA_ID_SIZE),
+                  null);
+      var genericRecord = reader.read(null, decoder);
+      out.collect(
+          EnvelopeValidator.validate(topic, partition, offset, key, genericRecord, valueBytes));
+    } catch (Exception e) {
+      out.collect(
+          toDlqResult(topic, partition, offset, "SCHEMA_INVALID", e.getMessage(), valueBytes));
     }
+  }
+
+  @Override
+  public TypeInformation<ValidationResult> getProducedType() {
+    return TypeInformation.of(ValidationResult.class);
+  }
+
+  private static ValidationResult toDlqResult(
+      String topic,
+      int partition,
+      long offset,
+      String errorClass,
+      String errorMessage,
+      byte[] rawBytes) {
+    return new ValidationResult.Invalid(
+        DlqEnvelope.builder()
+            .sourceTopic(topic)
+            .sourcePartition(partition)
+            .sourceOffset(offset)
+            .errorClass(errorClass)
+            .errorMessage(errorMessage)
+            .originalPayloadBytes(rawBytes)
+            .failedAt(java.time.Instant.now().toEpochMilli())
+            .build());
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/DlqDeserializer.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/DlqDeserializer.java
@@ -1,74 +1,78 @@
 package io.stablepay.flink.deser;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.flink.model.DlqEnvelope;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class DlqDeserializer implements KafkaRecordDeserializationSchema<DlqEnvelope> {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    static final String DESERIALIZATION_FAILED = "DESERIALIZATION_FAILED";
+  static final String DESERIALIZATION_FAILED = "DESERIALIZATION_FAILED";
 
-    @Override
-    public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<DlqEnvelope> out)
-            throws IOException {
-        if (record.value() == null) return;
+  @Override
+  public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<DlqEnvelope> out)
+      throws IOException {
+    if (record.value() == null) return;
 
-        try {
-            var node = MAPPER.readTree(record.value());
-            var envelope = DlqEnvelope.builder()
-                    .sourceTopic(textOrDefault(node, "source_topic", record.topic()))
-                    .sourcePartition(intOrDefault(node, "source_partition", record.partition()))
-                    .sourceOffset(longOrDefault(node, "source_offset", record.offset()))
-                    .errorClass(textOrDefault(node, "error_class", "UNKNOWN"))
-                    .errorMessage(textOrDefault(node, "error_message", ""))
-                    .failedAt(longOrDefault(node, "failed_at", record.timestamp()))
-                    .retryCount(intOrDefault(node, "retry_count", 0))
-                    .build();
-            out.collect(envelope);
-        } catch (Exception e) {
-            log.warn("Failed to deserialize DLQ record from topic={} partition={} offset={} cause={}",
-                    record.topic(), record.partition(), record.offset(), e.getClass().getSimpleName());
-            out.collect(DlqEnvelope.builder()
-                    .sourceTopic(record.topic())
-                    .sourcePartition(record.partition())
-                    .sourceOffset(record.offset())
-                    .errorClass(DESERIALIZATION_FAILED)
-                    .errorMessage(e.getClass().getSimpleName())
-                    .originalPayloadBytes(record.value())
-                    .failedAt(record.timestamp())
-                    .retryCount(0)
-                    .build());
-        }
+    try {
+      var node = MAPPER.readTree(record.value());
+      var envelope =
+          DlqEnvelope.builder()
+              .sourceTopic(textOrDefault(node, "source_topic", record.topic()))
+              .sourcePartition(intOrDefault(node, "source_partition", record.partition()))
+              .sourceOffset(longOrDefault(node, "source_offset", record.offset()))
+              .errorClass(textOrDefault(node, "error_class", "UNKNOWN"))
+              .errorMessage(textOrDefault(node, "error_message", ""))
+              .failedAt(longOrDefault(node, "failed_at", record.timestamp()))
+              .retryCount(intOrDefault(node, "retry_count", 0))
+              .build();
+      out.collect(envelope);
+    } catch (Exception e) {
+      log.warn(
+          "Failed to deserialize DLQ record from topic={} partition={} offset={} cause={}",
+          record.topic(),
+          record.partition(),
+          record.offset(),
+          e.getClass().getSimpleName());
+      out.collect(
+          DlqEnvelope.builder()
+              .sourceTopic(record.topic())
+              .sourcePartition(record.partition())
+              .sourceOffset(record.offset())
+              .errorClass(DESERIALIZATION_FAILED)
+              .errorMessage(e.getClass().getSimpleName())
+              .originalPayloadBytes(record.value())
+              .failedAt(record.timestamp())
+              .retryCount(0)
+              .build());
     }
+  }
 
-    @Override
-    public TypeInformation<DlqEnvelope> getProducedType() {
-        return TypeInformation.of(DlqEnvelope.class);
-    }
+  @Override
+  public TypeInformation<DlqEnvelope> getProducedType() {
+    return TypeInformation.of(DlqEnvelope.class);
+  }
 
-    private static String textOrDefault(JsonNode node, String field, String defaultValue) {
-        var child = node.get(field);
-        return child != null && !child.isNull() ? child.asText() : defaultValue;
-    }
+  private static String textOrDefault(JsonNode node, String field, String defaultValue) {
+    var child = node.get(field);
+    return child != null && !child.isNull() ? child.asText() : defaultValue;
+  }
 
-    private static int intOrDefault(JsonNode node, String field, int defaultValue) {
-        var child = node.get(field);
-        return child != null && !child.isNull() ? child.asInt(defaultValue) : defaultValue;
-    }
+  private static int intOrDefault(JsonNode node, String field, int defaultValue) {
+    var child = node.get(field);
+    return child != null && !child.isNull() ? child.asInt(defaultValue) : defaultValue;
+  }
 
-    private static long longOrDefault(JsonNode node, String field, long defaultValue) {
-        var child = node.get(field);
-        return child != null && !child.isNull() ? child.asLong(defaultValue) : defaultValue;
-    }
+  private static long longOrDefault(JsonNode node, String field, long defaultValue) {
+    var child = node.get(field);
+    return child != null && !child.isNull() ? child.asLong(defaultValue) : defaultValue;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/EnvelopeValidator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/deser/EnvelopeValidator.java
@@ -1,83 +1,106 @@
 package io.stablepay.flink.deser;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-
-import org.apache.avro.generic.GenericRecord;
-
 import io.stablepay.flink.model.DlqEnvelope;
 import io.stablepay.flink.model.ValidatedEvent;
 import io.stablepay.flink.model.ValidationResult;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.apache.avro.generic.GenericRecord;
 
 public final class EnvelopeValidator {
 
-    private static final long MAX_FUTURE_SKEW_MILLIS = ChronoUnit.HOURS.getDuration().toMillis();
+  private static final long MAX_FUTURE_SKEW_MILLIS = ChronoUnit.HOURS.getDuration().toMillis();
 
-    private EnvelopeValidator() {}
+  private EnvelopeValidator() {}
 
-    public static ValidationResult validate(
-            String topic, int partition, long offset, String key, GenericRecord record, byte[] rawBytes) {
-        var envelope = record.get("envelope");
-        if (envelope == null) {
-            return toDlq(topic, partition, offset, "MISSING_ENVELOPE", "Record has no envelope field", rawBytes);
-        }
-
-        if (!(envelope instanceof GenericRecord envelopeRecord)) {
-            return toDlq(topic, partition, offset, "INVALID_ENVELOPE", "Envelope is not a record", rawBytes);
-        }
-
-        var eventId = envelopeRecord.get("event_id");
-        if (eventId == null || eventId.toString().isBlank()) {
-            return toDlq(topic, partition, offset, "MISSING_EVENT_ID", "Envelope event_id is null or blank", rawBytes);
-        }
-
-        var eventTime = envelopeRecord.get("event_time");
-        if (eventTime == null || !(eventTime instanceof Long eventTimeMillis)) {
-            return toDlq(
-                    topic, partition, offset, "MISSING_EVENT_TIME", "Envelope event_time is null or not a long", rawBytes);
-        }
-
-        if (eventTimeMillis <= 0) {
-            return toDlq(
-                    topic, partition, offset, "INVALID_EVENT_TIME", "Envelope event_time is not positive", rawBytes);
-        }
-
-        var now = Instant.now().toEpochMilli();
-        if (eventTimeMillis > now + MAX_FUTURE_SKEW_MILLIS) {
-            return toDlq(
-                    topic,
-                    partition,
-                    offset,
-                    "FUTURE_EVENT_TIME",
-                    "Envelope event_time is more than 1 hour in the future",
-                    rawBytes);
-        }
-
-        var schemaVersion = envelopeRecord.get("schema_version");
-        var flowId = envelopeRecord.get("flow_id");
-
-        return new ValidationResult.Valid(ValidatedEvent.fromRecord(
-                topic,
-                partition,
-                offset,
-                key,
-                record,
-                eventId.toString(),
-                eventTimeMillis,
-                flowId != null ? flowId.toString() : null,
-                schemaVersion != null ? schemaVersion.toString() : "unknown"));
+  public static ValidationResult validate(
+      String topic, int partition, long offset, String key, GenericRecord record, byte[] rawBytes) {
+    var envelope = record.get("envelope");
+    if (envelope == null) {
+      return toDlq(
+          topic, partition, offset, "MISSING_ENVELOPE", "Record has no envelope field", rawBytes);
     }
 
-    private static ValidationResult.Invalid toDlq(
-            String topic, int partition, long offset, String errorClass, String errorMessage, byte[] rawBytes) {
-        return new ValidationResult.Invalid(DlqEnvelope.builder()
-                .sourceTopic(topic)
-                .sourcePartition(partition)
-                .sourceOffset(offset)
-                .errorClass(errorClass)
-                .errorMessage(errorMessage)
-                .originalPayloadBytes(rawBytes)
-                .failedAt(Instant.now().toEpochMilli())
-                .build());
+    if (!(envelope instanceof GenericRecord envelopeRecord)) {
+      return toDlq(
+          topic, partition, offset, "INVALID_ENVELOPE", "Envelope is not a record", rawBytes);
     }
+
+    var eventId = envelopeRecord.get("event_id");
+    if (eventId == null || eventId.toString().isBlank()) {
+      return toDlq(
+          topic,
+          partition,
+          offset,
+          "MISSING_EVENT_ID",
+          "Envelope event_id is null or blank",
+          rawBytes);
+    }
+
+    var eventTime = envelopeRecord.get("event_time");
+    if (eventTime == null || !(eventTime instanceof Long eventTimeMillis)) {
+      return toDlq(
+          topic,
+          partition,
+          offset,
+          "MISSING_EVENT_TIME",
+          "Envelope event_time is null or not a long",
+          rawBytes);
+    }
+
+    if (eventTimeMillis <= 0) {
+      return toDlq(
+          topic,
+          partition,
+          offset,
+          "INVALID_EVENT_TIME",
+          "Envelope event_time is not positive",
+          rawBytes);
+    }
+
+    var now = Instant.now().toEpochMilli();
+    if (eventTimeMillis > now + MAX_FUTURE_SKEW_MILLIS) {
+      return toDlq(
+          topic,
+          partition,
+          offset,
+          "FUTURE_EVENT_TIME",
+          "Envelope event_time is more than 1 hour in the future",
+          rawBytes);
+    }
+
+    var schemaVersion = envelopeRecord.get("schema_version");
+    var flowId = envelopeRecord.get("flow_id");
+
+    return new ValidationResult.Valid(
+        ValidatedEvent.fromRecord(
+            topic,
+            partition,
+            offset,
+            key,
+            record,
+            eventId.toString(),
+            eventTimeMillis,
+            flowId != null ? flowId.toString() : null,
+            schemaVersion != null ? schemaVersion.toString() : "unknown"));
+  }
+
+  private static ValidationResult.Invalid toDlq(
+      String topic,
+      int partition,
+      long offset,
+      String errorClass,
+      String errorMessage,
+      byte[] rawBytes) {
+    return new ValidationResult.Invalid(
+        DlqEnvelope.builder()
+            .sourceTopic(topic)
+            .sourcePartition(partition)
+            .sourceOffset(offset)
+            .errorClass(errorClass)
+            .errorMessage(errorMessage)
+            .originalPayloadBytes(rawBytes)
+            .failedAt(Instant.now().toEpochMilli())
+            .build());
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqKafkaSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqKafkaSinkFactory.java
@@ -1,18 +1,17 @@
 package io.stablepay.flink.dlq;
 
-import org.apache.flink.connector.kafka.sink.KafkaSink;
-
 import io.stablepay.flink.config.FlinkConfig;
 import io.stablepay.flink.model.DlqEnvelope;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
 
 public final class DlqKafkaSinkFactory {
 
-    private DlqKafkaSinkFactory() {}
+  private DlqKafkaSinkFactory() {}
 
-    public static KafkaSink<DlqEnvelope> createSink(String dlqTopic) {
-        return KafkaSink.<DlqEnvelope>builder()
-                .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
-                .setRecordSerializer(new DlqRecordSerializer(dlqTopic))
-                .build();
-    }
+  public static KafkaSink<DlqEnvelope> createSink(String dlqTopic) {
+    return KafkaSink.<DlqEnvelope>builder()
+        .setBootstrapServers(FlinkConfig.kafkaBootstrapServers())
+        .setRecordSerializer(new DlqRecordSerializer(dlqTopic))
+        .build();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqMetrics.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqMetrics.java
@@ -1,38 +1,37 @@
 package io.stablepay.flink.dlq;
 
 import java.io.Serializable;
-
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.Counter;
 
 public class DlqMetrics implements Serializable {
 
-    private final Counter schemaInvalidCounter;
-    private final Counter lateEventCounter;
-    private final Counter illegalTransitionCounter;
-    private final Counter sinkFailureCounter;
+  private final Counter schemaInvalidCounter;
+  private final Counter lateEventCounter;
+  private final Counter illegalTransitionCounter;
+  private final Counter sinkFailureCounter;
 
-    public DlqMetrics(RuntimeContext runtimeContext) {
-        var metricGroup = runtimeContext.getMetricGroup();
-        this.schemaInvalidCounter = metricGroup.counter("dlq_schema_invalid_total");
-        this.lateEventCounter = metricGroup.counter("dlq_late_event_total");
-        this.illegalTransitionCounter = metricGroup.counter("dlq_illegal_transition_total");
-        this.sinkFailureCounter = metricGroup.counter("dlq_sink_failure_total");
-    }
+  public DlqMetrics(RuntimeContext runtimeContext) {
+    var metricGroup = runtimeContext.getMetricGroup();
+    this.schemaInvalidCounter = metricGroup.counter("dlq_schema_invalid_total");
+    this.lateEventCounter = metricGroup.counter("dlq_late_event_total");
+    this.illegalTransitionCounter = metricGroup.counter("dlq_illegal_transition_total");
+    this.sinkFailureCounter = metricGroup.counter("dlq_sink_failure_total");
+  }
 
-    public void incrementSchemaInvalid() {
-        schemaInvalidCounter.inc();
-    }
+  public void incrementSchemaInvalid() {
+    schemaInvalidCounter.inc();
+  }
 
-    public void incrementLateEvent() {
-        lateEventCounter.inc();
-    }
+  public void incrementLateEvent() {
+    lateEventCounter.inc();
+  }
 
-    public void incrementIllegalTransition() {
-        illegalTransitionCounter.inc();
-    }
+  public void incrementIllegalTransition() {
+    illegalTransitionCounter.inc();
+  }
 
-    public void incrementSinkFailure() {
-        sinkFailureCounter.inc();
-    }
+  public void incrementSinkFailure() {
+    sinkFailureCounter.inc();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqOutputTags.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqOutputTags.java
@@ -1,22 +1,19 @@
 package io.stablepay.flink.dlq;
 
-import org.apache.flink.util.OutputTag;
-
 import io.stablepay.flink.model.DlqEnvelope;
+import org.apache.flink.util.OutputTag;
 
 public final class DlqOutputTags {
 
-    public static final OutputTag<DlqEnvelope> SCHEMA_INVALID =
-            new OutputTag<>("dlq-schema-invalid") {};
+  public static final OutputTag<DlqEnvelope> SCHEMA_INVALID =
+      new OutputTag<>("dlq-schema-invalid") {};
 
-    public static final OutputTag<DlqEnvelope> LATE_EVENT =
-            new OutputTag<>("dlq-late-event") {};
+  public static final OutputTag<DlqEnvelope> LATE_EVENT = new OutputTag<>("dlq-late-event") {};
 
-    public static final OutputTag<DlqEnvelope> ILLEGAL_TRANSITION =
-            new OutputTag<>("dlq-illegal-transition") {};
+  public static final OutputTag<DlqEnvelope> ILLEGAL_TRANSITION =
+      new OutputTag<>("dlq-illegal-transition") {};
 
-    public static final OutputTag<DlqEnvelope> SINK_FAILURE =
-            new OutputTag<>("dlq-sink-failure") {};
+  public static final OutputTag<DlqEnvelope> SINK_FAILURE = new OutputTag<>("dlq-sink-failure") {};
 
-    private DlqOutputTags() {}
+  private DlqOutputTags() {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqRecordSerializer.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqRecordSerializer.java
@@ -1,45 +1,45 @@
 package io.stablepay.flink.dlq;
 
-import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.flink.model.DlqEnvelope;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import lombok.RequiredArgsConstructor;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.kafka.clients.producer.ProducerRecord;
-
-import io.stablepay.flink.model.DlqEnvelope;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class DlqRecordSerializer implements KafkaRecordSerializationSchema<DlqEnvelope> {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final String topic;
+  private final String topic;
 
-    @Override
-    public ProducerRecord<byte[], byte[]> serialize(
-            DlqEnvelope envelope, KafkaSinkContext context, Long timestamp) {
-        byte[] value = toJsonBytes(envelope);
-        byte[] key = envelope.sourceTopic() != null
-                ? envelope.sourceTopic().getBytes(StandardCharsets.UTF_8) : null;
-        return new ProducerRecord<>(topic, key, value);
+  @Override
+  public ProducerRecord<byte[], byte[]> serialize(
+      DlqEnvelope envelope, KafkaSinkContext context, Long timestamp) {
+    byte[] value = toJsonBytes(envelope);
+    byte[] key =
+        envelope.sourceTopic() != null
+            ? envelope.sourceTopic().getBytes(StandardCharsets.UTF_8)
+            : null;
+    return new ProducerRecord<>(topic, key, value);
+  }
+
+  private static byte[] toJsonBytes(DlqEnvelope e) {
+    try {
+      var map = new LinkedHashMap<String, Object>();
+      map.put("source_topic", e.sourceTopic());
+      map.put("source_partition", e.sourcePartition());
+      map.put("source_offset", e.sourceOffset());
+      map.put("error_class", e.errorClass());
+      map.put("error_message", e.errorMessage());
+      map.put("failed_at", e.failedAt());
+      map.put("retry_count", e.retryCount());
+      return MAPPER.writeValueAsBytes(map);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("Failed to serialize DLQ envelope to JSON", ex);
     }
-
-    private static byte[] toJsonBytes(DlqEnvelope e) {
-        try {
-            var map = new LinkedHashMap<String, Object>();
-            map.put("source_topic", e.sourceTopic());
-            map.put("source_partition", e.sourcePartition());
-            map.put("source_offset", e.sourceOffset());
-            map.put("error_class", e.errorClass());
-            map.put("error_message", e.errorMessage());
-            map.put("failed_at", e.failedAt());
-            map.put("retry_count", e.retryCount());
-            return MAPPER.writeValueAsBytes(map);
-        } catch (JsonProcessingException ex) {
-            throw new IllegalStateException("Failed to serialize DLQ envelope to JSON", ex);
-        }
-    }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqRouter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/dlq/DlqRouter.java
@@ -1,66 +1,66 @@
 package io.stablepay.flink.dlq;
 
-import java.time.Instant;
-
 import io.stablepay.flink.model.DlqEnvelope;
 import io.stablepay.flink.model.ValidatedEvent;
+import java.time.Instant;
 
 public final class DlqRouter {
 
-    private DlqRouter() {}
+  private DlqRouter() {}
 
-    public static DlqEnvelope schemaInvalid(
-            String topic, int partition, long offset, byte[] rawBytes, String errorMsg) {
-        return DlqEnvelope.builder()
-                .sourceTopic(topic)
-                .sourcePartition(partition)
-                .sourceOffset(offset)
-                .errorClass("SCHEMA_INVALID")
-                .errorMessage(errorMsg)
-                .originalPayloadBytes(rawBytes)
-                .failedAt(Instant.now().toEpochMilli())
-                .retryCount(0)
-                .build();
-    }
+  public static DlqEnvelope schemaInvalid(
+      String topic, int partition, long offset, byte[] rawBytes, String errorMsg) {
+    return DlqEnvelope.builder()
+        .sourceTopic(topic)
+        .sourcePartition(partition)
+        .sourceOffset(offset)
+        .errorClass("SCHEMA_INVALID")
+        .errorMessage(errorMsg)
+        .originalPayloadBytes(rawBytes)
+        .failedAt(Instant.now().toEpochMilli())
+        .retryCount(0)
+        .build();
+  }
 
-    public static DlqEnvelope lateEvent(ValidatedEvent event, long watermark, String errorMsg) {
-        return DlqEnvelope.builder()
-                .sourceTopic(event.topic())
-                .sourcePartition(event.sourcePartition())
-                .sourceOffset(event.sourceOffset())
-                .errorClass("LATE_EVENT")
-                .errorMessage(errorMsg + " (event_time=" + event.eventTimeMillis() + ", watermark=" + watermark + ")")
-                .originalPayloadBytes(event.recordBytes())
-                .failedAt(Instant.now().toEpochMilli())
-                .retryCount(0)
-                .build();
-    }
+  public static DlqEnvelope lateEvent(ValidatedEvent event, long watermark, String errorMsg) {
+    return DlqEnvelope.builder()
+        .sourceTopic(event.topic())
+        .sourcePartition(event.sourcePartition())
+        .sourceOffset(event.sourceOffset())
+        .errorClass("LATE_EVENT")
+        .errorMessage(
+            errorMsg + " (event_time=" + event.eventTimeMillis() + ", watermark=" + watermark + ")")
+        .originalPayloadBytes(event.recordBytes())
+        .failedAt(Instant.now().toEpochMilli())
+        .retryCount(0)
+        .build();
+  }
 
-    public static DlqEnvelope illegalTransition(
-            ValidatedEvent event, String fromStatus, String toStatus) {
-        return DlqEnvelope.builder()
-                .sourceTopic(event.topic())
-                .sourcePartition(event.sourcePartition())
-                .sourceOffset(event.sourceOffset())
-                .errorClass("ILLEGAL_TRANSITION")
-                .errorMessage("Invalid transition: " + fromStatus + " -> " + toStatus)
-                .originalPayloadBytes(event.recordBytes())
-                .failedAt(Instant.now().toEpochMilli())
-                .retryCount(0)
-                .build();
-    }
+  public static DlqEnvelope illegalTransition(
+      ValidatedEvent event, String fromStatus, String toStatus) {
+    return DlqEnvelope.builder()
+        .sourceTopic(event.topic())
+        .sourcePartition(event.sourcePartition())
+        .sourceOffset(event.sourceOffset())
+        .errorClass("ILLEGAL_TRANSITION")
+        .errorMessage("Invalid transition: " + fromStatus + " -> " + toStatus)
+        .originalPayloadBytes(event.recordBytes())
+        .failedAt(Instant.now().toEpochMilli())
+        .retryCount(0)
+        .build();
+  }
 
-    public static DlqEnvelope sinkFailure(
-            ValidatedEvent event, String sinkType, String errorMsg, int retryCount) {
-        return DlqEnvelope.builder()
-                .sourceTopic(event.topic())
-                .sourcePartition(event.sourcePartition())
-                .sourceOffset(event.sourceOffset())
-                .errorClass("SINK_FAILURE")
-                .errorMessage(sinkType + ": " + errorMsg)
-                .originalPayloadBytes(event.recordBytes())
-                .failedAt(Instant.now().toEpochMilli())
-                .retryCount(retryCount)
-                .build();
-    }
+  public static DlqEnvelope sinkFailure(
+      ValidatedEvent event, String sinkType, String errorMsg, int retryCount) {
+    return DlqEnvelope.builder()
+        .sourceTopic(event.topic())
+        .sourcePartition(event.sourcePartition())
+        .sourceOffset(event.sourceOffset())
+        .errorClass("SINK_FAILURE")
+        .errorMessage(sinkType + ": " + errorMsg)
+        .originalPayloadBytes(event.recordBytes())
+        .failedAt(Instant.now().toEpochMilli())
+        .retryCount(retryCount)
+        .build();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/DlqToIcebergRowMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/DlqToIcebergRowMapper.java
@@ -1,43 +1,43 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.DlqEventIds;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Objects;
-
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.DlqEventIds;
-
 public final class DlqToIcebergRowMapper {
 
-    private DlqToIcebergRowMapper() {}
+  private DlqToIcebergRowMapper() {}
 
-    public static RowData toRowData(DlqEnvelope envelope) {
-        Objects.requireNonNull(envelope, "envelope");
-        Objects.requireNonNull(envelope.sourceTopic(), "sourceTopic");
-        Objects.requireNonNull(envelope.errorClass(), "errorClass");
-        Objects.requireNonNull(envelope.errorMessage(), "errorMessage");
+  public static RowData toRowData(DlqEnvelope envelope) {
+    Objects.requireNonNull(envelope, "envelope");
+    Objects.requireNonNull(envelope.sourceTopic(), "sourceTopic");
+    Objects.requireNonNull(envelope.errorClass(), "errorClass");
+    Objects.requireNonNull(envelope.errorMessage(), "errorMessage");
 
-        var row = new GenericRowData(9);
+    var row = new GenericRowData(9);
 
-        row.setField(0, StringData.fromString(DlqEventIds.of(envelope)));
-        row.setField(1, StringData.fromString(envelope.sourceTopic()));
-        row.setField(2, envelope.sourcePartition());
-        row.setField(3, envelope.sourceOffset());
-        row.setField(4, StringData.fromString(envelope.errorClass()));
-        row.setField(5, StringData.fromString(envelope.errorMessage()));
-        row.setField(6, TimestampData.fromInstant(Instant.ofEpochMilli(envelope.failedAt())));
-        row.setField(7, envelope.retryCount());
+    row.setField(0, StringData.fromString(DlqEventIds.of(envelope)));
+    row.setField(1, StringData.fromString(envelope.sourceTopic()));
+    row.setField(2, envelope.sourcePartition());
+    row.setField(3, envelope.sourceOffset());
+    row.setField(4, StringData.fromString(envelope.errorClass()));
+    row.setField(5, StringData.fromString(envelope.errorMessage()));
+    row.setField(6, TimestampData.fromInstant(Instant.ofEpochMilli(envelope.failedAt())));
+    row.setField(7, envelope.retryCount());
 
-        var payload = envelope.originalPayloadBytes();
-        row.setField(8, payload != null
-                ? StringData.fromString(new String(payload, StandardCharsets.UTF_8))
-                : null);
+    var payload = envelope.originalPayloadBytes();
+    row.setField(
+        8,
+        payload != null
+            ? StringData.fromString(new String(payload, StandardCharsets.UTF_8))
+            : null);
 
-        return row;
-    }
+    return row;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/DlqToOpenSearchDocMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/DlqToOpenSearchDocMapper.java
@@ -1,39 +1,38 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.DlqEventIds;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.DlqEventIds;
-
 public final class DlqToOpenSearchDocMapper {
 
-    private DlqToOpenSearchDocMapper() {}
+  private DlqToOpenSearchDocMapper() {}
 
-    public static Map<String, Object> toDocument(DlqEnvelope envelope) {
-        Objects.requireNonNull(envelope, "envelope");
-        Objects.requireNonNull(envelope.sourceTopic(), "sourceTopic");
-        Objects.requireNonNull(envelope.errorClass(), "errorClass");
-        Objects.requireNonNull(envelope.errorMessage(), "errorMessage");
+  public static Map<String, Object> toDocument(DlqEnvelope envelope) {
+    Objects.requireNonNull(envelope, "envelope");
+    Objects.requireNonNull(envelope.sourceTopic(), "sourceTopic");
+    Objects.requireNonNull(envelope.errorClass(), "errorClass");
+    Objects.requireNonNull(envelope.errorMessage(), "errorMessage");
 
-        var doc = new HashMap<String, Object>();
+    var doc = new HashMap<String, Object>();
 
-        doc.put("event_id", DlqEventIds.of(envelope));
-        doc.put("source_topic", envelope.sourceTopic());
-        doc.put("source_partition", envelope.sourcePartition());
-        doc.put("source_offset", envelope.sourceOffset());
-        doc.put("error_class", envelope.errorClass());
-        doc.put("error_message", envelope.errorMessage());
-        doc.put("failed_at", envelope.failedAt());
-        doc.put("retry_count", envelope.retryCount());
+    doc.put("event_id", DlqEventIds.of(envelope));
+    doc.put("source_topic", envelope.sourceTopic());
+    doc.put("source_partition", envelope.sourcePartition());
+    doc.put("source_offset", envelope.sourceOffset());
+    doc.put("error_class", envelope.errorClass());
+    doc.put("error_message", envelope.errorMessage());
+    doc.put("failed_at", envelope.failedAt());
+    doc.put("retry_count", envelope.retryCount());
 
-        var payload = envelope.originalPayloadBytes();
-        if (payload != null) {
-            doc.put("original_payload_json", new String(payload, StandardCharsets.UTF_8));
-        }
-
-        return doc;
+    var payload = envelope.originalPayloadBytes();
+    if (payload != null) {
+      doc.put("original_payload_json", new String(payload, StandardCharsets.UTF_8));
     }
+
+    return doc;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactScreeningMapper.java
@@ -1,54 +1,52 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.time.Instant;
-
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class EventToFactScreeningMapper {
 
-    private EventToFactScreeningMapper() {}
+  private EventToFactScreeningMapper() {}
 
-    public static RowData toRowData(ValidatedEvent event) {
-        var record = event.toRecord();
-        var row = new GenericRowData(10);
+  public static RowData toRowData(ValidatedEvent event) {
+    var record = event.toRecord();
+    var row = new GenericRowData(10);
 
-        row.setField(0, StringData.fromString(event.eventId()));
-        row.setField(1, stringDataOrNull(stringVal(record.get("screening_id"))));
-        row.setField(2, stringDataOrNull(stringVal(record.get("customer_id"))));
-        row.setField(3, stringDataOrNull(extractTransactionReference(record)));
-        row.setField(4, stringDataOrNull(stringVal(record.get("outcome"))));
-        row.setField(5, stringDataOrNull(stringVal(record.get("provider"))));
-        row.setField(6, stringDataOrNull(stringVal(record.get("rule_triggered"))));
+    row.setField(0, StringData.fromString(event.eventId()));
+    row.setField(1, stringDataOrNull(stringVal(record.get("screening_id"))));
+    row.setField(2, stringDataOrNull(stringVal(record.get("customer_id"))));
+    row.setField(3, stringDataOrNull(extractTransactionReference(record)));
+    row.setField(4, stringDataOrNull(stringVal(record.get("outcome"))));
+    row.setField(5, stringDataOrNull(stringVal(record.get("provider"))));
+    row.setField(6, stringDataOrNull(stringVal(record.get("rule_triggered"))));
 
-        var score = record.get("score");
-        row.setField(7, score instanceof Number n ? n.doubleValue() : null);
+    var score = record.get("score");
+    row.setField(7, score instanceof Number n ? n.doubleValue() : null);
 
-        row.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
+    row.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
 
-        var durationMs = record.get("duration_ms");
-        row.setField(9, durationMs instanceof Number n ? n.longValue() : null);
+    var durationMs = record.get("duration_ms");
+    row.setField(9, durationMs instanceof Number n ? n.longValue() : null);
 
-        return row;
-    }
+    return row;
+  }
 
-    private static String extractTransactionReference(GenericRecord record) {
-        var ref = record.get("transaction_reference");
-        if (ref != null) return ref.toString();
-        var payoutRef = record.get("payout_reference");
-        return payoutRef != null ? payoutRef.toString() : null;
-    }
+  private static String extractTransactionReference(GenericRecord record) {
+    var ref = record.get("transaction_reference");
+    if (ref != null) return ref.toString();
+    var payoutRef = record.get("payout_reference");
+    return payoutRef != null ? payoutRef.toString() : null;
+  }
 
-    private static StringData stringDataOrNull(String value) {
-        return value != null ? StringData.fromString(value) : null;
-    }
+  private static StringData stringDataOrNull(String value) {
+    return value != null ? StringData.fromString(value) : null;
+  }
 
-    private static String stringVal(Object value) {
-        return value != null ? value.toString() : null;
-    }
+  private static String stringVal(Object value) {
+    return value != null ? value.toString() : null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToFactTransactionMapper.java
@@ -1,162 +1,164 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.time.Instant;
 import java.util.Map;
-
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class EventToFactTransactionMapper {
 
-    private EventToFactTransactionMapper() {}
+  private EventToFactTransactionMapper() {}
 
-    private static final Map<String, String> TOPIC_TO_EVENT_TYPE = Map.of(
-            "payment.payout.fiat.v1", "PAYOUT_FIAT",
-            "payment.payout.crypto.v1", "PAYOUT_CRYPTO",
-            "payment.payin.fiat.v1", "PAYIN_FIAT",
-            "payment.payin.crypto.v1", "PAYIN_CRYPTO",
-            "chain.transaction.v1", "CHAIN_TRANSACTION");
+  private static final Map<String, String> TOPIC_TO_EVENT_TYPE =
+      Map.of(
+          "payment.payout.fiat.v1", "PAYOUT_FIAT",
+          "payment.payout.crypto.v1", "PAYOUT_CRYPTO",
+          "payment.payin.fiat.v1", "PAYIN_FIAT",
+          "payment.payin.crypto.v1", "PAYIN_CRYPTO",
+          "chain.transaction.v1", "CHAIN_TRANSACTION");
 
-    public static RowData toRowData(ValidatedEvent event) {
-        var record = event.toRecord();
-        var topic = event.topic();
-        var row = new GenericRowData(41);
+  public static RowData toRowData(ValidatedEvent event) {
+    var record = event.toRecord();
+    var topic = event.topic();
+    var row = new GenericRowData(41);
 
-        row.setField(0, StringData.fromString(event.eventId()));
-        row.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
-        row.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(extractIngestTime(record))));
-        row.setField(3, stringDataOrNull(event.flowId()));
-        row.setField(4, stringDataOrNull(extractEnvelopeField(record, "correlation_id")));
-        row.setField(5, stringDataOrNull(extractEnvelopeField(record, "trace_id")));
-        row.setField(6, StringData.fromString(TOPIC_TO_EVENT_TYPE.getOrDefault(topic, "UNKNOWN")));
-        row.setField(7, StringData.fromString(deriveFlowType(topic)));
-        row.setField(8, StringData.fromString(deriveDirection(topic)));
-        row.setField(9, isCrypto(topic));
-        row.setField(10, extractBoolean(record, "is_user_facing"));
-        row.setField(11, stringDataOrNull(extractTransactionReference(record, topic)));
-        row.setField(12, stringDataOrNull(stringVal(record.get("customer_id"))));
-        row.setField(13, stringDataOrNull(stringVal(record.get("account_id"))));
+    row.setField(0, StringData.fromString(event.eventId()));
+    row.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
+    row.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(extractIngestTime(record))));
+    row.setField(3, stringDataOrNull(event.flowId()));
+    row.setField(4, stringDataOrNull(extractEnvelopeField(record, "correlation_id")));
+    row.setField(5, stringDataOrNull(extractEnvelopeField(record, "trace_id")));
+    row.setField(6, StringData.fromString(TOPIC_TO_EVENT_TYPE.getOrDefault(topic, "UNKNOWN")));
+    row.setField(7, StringData.fromString(deriveFlowType(topic)));
+    row.setField(8, StringData.fromString(deriveDirection(topic)));
+    row.setField(9, isCrypto(topic));
+    row.setField(10, extractBoolean(record, "is_user_facing"));
+    row.setField(11, stringDataOrNull(extractTransactionReference(record, topic)));
+    row.setField(12, stringDataOrNull(stringVal(record.get("customer_id"))));
+    row.setField(13, stringDataOrNull(stringVal(record.get("account_id"))));
 
-        extractMoneyField(record, "amount", row, 14, 15);
-        extractMoneyField(record, "fee", row, 16, 17);
-        extractMoneyField(record, "source_amount", row, 18, 19);
-        extractMoneyField(record, "target_amount", row, 20, 21);
+    extractMoneyField(record, "amount", row, 14, 15);
+    extractMoneyField(record, "fee", row, 16, 17);
+    extractMoneyField(record, "source_amount", row, 18, 19);
+    extractMoneyField(record, "target_amount", row, 20, 21);
 
-        var fxRate = record.get("fx_rate");
-        row.setField(22, fxRate instanceof Number n ? n.doubleValue() : null);
+    var fxRate = record.get("fx_rate");
+    row.setField(22, fxRate instanceof Number n ? n.doubleValue() : null);
 
-        row.setField(23, stringDataOrNull(stringVal(record.get("internal_status"))));
-        row.setField(24, stringDataOrNull(stringVal(record.get("customer_status"))));
-        row.setField(25, stringDataOrNull(stringVal(record.get("screening_outcome"))));
-        row.setField(26, stringDataOrNull(stringVal(record.get("chain"))));
-        row.setField(27, stringDataOrNull(stringVal(record.get("asset"))));
-        row.setField(28, stringDataOrNull(PiiMasker.mask(stringVal(record.get("source_address")))));
-        row.setField(29, stringDataOrNull(PiiMasker.mask(stringVal(record.get("destination_address")))));
-        row.setField(30, stringDataOrNull(stringVal(record.get("tx_hash"))));
+    row.setField(23, stringDataOrNull(stringVal(record.get("internal_status"))));
+    row.setField(24, stringDataOrNull(stringVal(record.get("customer_status"))));
+    row.setField(25, stringDataOrNull(stringVal(record.get("screening_outcome"))));
+    row.setField(26, stringDataOrNull(stringVal(record.get("chain"))));
+    row.setField(27, stringDataOrNull(stringVal(record.get("asset"))));
+    row.setField(28, stringDataOrNull(PiiMasker.mask(stringVal(record.get("source_address")))));
+    row.setField(
+        29, stringDataOrNull(PiiMasker.mask(stringVal(record.get("destination_address")))));
+    row.setField(30, stringDataOrNull(stringVal(record.get("tx_hash"))));
 
-        var confirmations = record.get("confirmations");
-        row.setField(31, confirmations instanceof Number n ? n.intValue() : null);
+    var confirmations = record.get("confirmations");
+    row.setField(31, confirmations instanceof Number n ? n.intValue() : null);
 
-        var gasFee = record.get("gas_fee_micros");
-        row.setField(32, gasFee instanceof Number n ? n.longValue() : null);
+    var gasFee = record.get("gas_fee_micros");
+    row.setField(32, gasFee instanceof Number n ? n.longValue() : null);
 
-        var blockNumber = record.get("block_number");
-        row.setField(33, blockNumber instanceof Number n ? n.longValue() : null);
+    var blockNumber = record.get("block_number");
+    row.setField(33, blockNumber instanceof Number n ? n.longValue() : null);
 
-        var blockTimestamp = record.get("block_timestamp");
-        row.setField(34, blockTimestamp instanceof Long ts
-                ? TimestampData.fromInstant(Instant.ofEpochMilli(ts)) : null);
+    var blockTimestamp = record.get("block_timestamp");
+    row.setField(
+        34,
+        blockTimestamp instanceof Long ts
+            ? TimestampData.fromInstant(Instant.ofEpochMilli(ts))
+            : null);
 
-        row.setField(35, stringDataOrNull(stringVal(record.get("provider"))));
-        row.setField(36, stringDataOrNull(stringVal(record.get("route"))));
+    row.setField(35, stringDataOrNull(stringVal(record.get("provider"))));
+    row.setField(36, stringDataOrNull(stringVal(record.get("route"))));
 
-        row.setField(37, maskedNestedName(record, "beneficiary"));
-        row.setField(38, maskedNestedName(record, "sender"));
+    row.setField(37, maskedNestedName(record, "beneficiary"));
+    row.setField(38, maskedNestedName(record, "sender"));
 
-        row.setField(39, stringDataOrNull(PiiMasker.mask(stringVal(record.get("description")))));
-        row.setField(40, stringDataOrNull(PiiMasker.mask(stringVal(record.get("notes")))));
+    row.setField(39, stringDataOrNull(PiiMasker.mask(stringVal(record.get("description")))));
+    row.setField(40, stringDataOrNull(PiiMasker.mask(stringVal(record.get("notes")))));
 
-        return row;
+    return row;
+  }
+
+  private static long extractIngestTime(GenericRecord record) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var ingestTime = env.get("ingest_time");
+      if (ingestTime instanceof Long l) return l;
     }
+    return Instant.now().toEpochMilli();
+  }
 
-    private static long extractIngestTime(GenericRecord record) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var ingestTime = env.get("ingest_time");
-            if (ingestTime instanceof Long l) return l;
-        }
-        return Instant.now().toEpochMilli();
+  private static String extractEnvelopeField(GenericRecord record, String field) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var val = env.get(field);
+      return val != null ? val.toString() : null;
     }
+    return null;
+  }
 
-    private static String extractEnvelopeField(GenericRecord record, String field) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var val = env.get(field);
-            return val != null ? val.toString() : null;
-        }
-        return null;
+  private static void extractMoneyField(
+      GenericRecord record, String field, GenericRowData row, int microsIndex, int currencyIndex) {
+    var money = record.get(field);
+    if (money instanceof GenericRecord moneyRecord) {
+      var micros = moneyRecord.get("amount_micros");
+      row.setField(microsIndex, micros instanceof Number n ? n.longValue() : null);
+      row.setField(currencyIndex, stringDataOrNull(stringVal(moneyRecord.get("currency_code"))));
+    } else {
+      row.setField(microsIndex, null);
+      row.setField(currencyIndex, null);
     }
+  }
 
-    private static void extractMoneyField(
-            GenericRecord record, String field, GenericRowData row,
-            int microsIndex, int currencyIndex) {
-        var money = record.get(field);
-        if (money instanceof GenericRecord moneyRecord) {
-            var micros = moneyRecord.get("amount_micros");
-            row.setField(microsIndex, micros instanceof Number n ? n.longValue() : null);
-            row.setField(currencyIndex, stringDataOrNull(stringVal(moneyRecord.get("currency_code"))));
-        } else {
-            row.setField(microsIndex, null);
-            row.setField(currencyIndex, null);
-        }
-    }
+  private static Boolean extractBoolean(GenericRecord record, String field) {
+    var val = record.get(field);
+    return val instanceof Boolean b ? b : null;
+  }
 
-    private static Boolean extractBoolean(GenericRecord record, String field) {
-        var val = record.get(field);
-        return val instanceof Boolean b ? b : null;
+  private static StringData maskedNestedName(GenericRecord record, String field) {
+    var nested = record.get(field);
+    if (nested instanceof GenericRecord party) {
+      return stringDataOrNull(PiiMasker.mask(stringVal(party.get("name"))));
     }
+    return null;
+  }
 
-    private static StringData maskedNestedName(GenericRecord record, String field) {
-        var nested = record.get(field);
-        if (nested instanceof GenericRecord party) {
-            return stringDataOrNull(PiiMasker.mask(stringVal(party.get("name"))));
-        }
-        return null;
-    }
+  private static String extractTransactionReference(GenericRecord record, String topic) {
+    if (topic.contains("payout")) return stringVal(record.get("payout_reference"));
+    if (topic.contains("payin")) return stringVal(record.get("payin_reference"));
+    if (topic.contains("chain.transaction")) return stringVal(record.get("tx_hash"));
+    return stringVal(record.get("flow_id"));
+  }
 
-    private static String extractTransactionReference(GenericRecord record, String topic) {
-        if (topic.contains("payout")) return stringVal(record.get("payout_reference"));
-        if (topic.contains("payin")) return stringVal(record.get("payin_reference"));
-        if (topic.contains("chain.transaction")) return stringVal(record.get("tx_hash"));
-        return stringVal(record.get("flow_id"));
-    }
+  private static String deriveFlowType(String topic) {
+    if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
+    if (topic.contains("fiat")) return "FIAT";
+    return "MIXED";
+  }
 
-    private static String deriveFlowType(String topic) {
-        if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
-        if (topic.contains("fiat")) return "FIAT";
-        return "MIXED";
-    }
+  private static String deriveDirection(String topic) {
+    if (topic.contains("payin")) return "INBOUND";
+    if (topic.contains("payout")) return "OUTBOUND";
+    return "INTERNAL";
+  }
 
-    private static String deriveDirection(String topic) {
-        if (topic.contains("payin")) return "INBOUND";
-        if (topic.contains("payout")) return "OUTBOUND";
-        return "INTERNAL";
-    }
+  private static boolean isCrypto(String topic) {
+    return topic.contains("crypto") || topic.contains("chain");
+  }
 
-    private static boolean isCrypto(String topic) {
-        return topic.contains("crypto") || topic.contains("chain");
-    }
+  private static StringData stringDataOrNull(String value) {
+    return value != null ? StringData.fromString(value) : null;
+  }
 
-    private static StringData stringDataOrNull(String value) {
-        return value != null ? StringData.fromString(value) : null;
-    }
-
-    private static String stringVal(Object value) {
-        return value != null ? value.toString() : null;
-    }
+  private static String stringVal(Object value) {
+    return value != null ? value.toString() : null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToIcebergRowMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToIcebergRowMapper.java
@@ -1,80 +1,78 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
+import io.stablepay.flink.model.ValidatedEvent;
 import java.time.Instant;
-
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class EventToIcebergRowMapper {
 
-    private EventToIcebergRowMapper() {}
+  private EventToIcebergRowMapper() {}
 
-    public static String resolveTable(ValidatedEvent event) {
-        return IcebergCatalogConfig.TOPIC_TO_TABLE.getOrDefault(event.topic(), null);
+  public static String resolveTable(ValidatedEvent event) {
+    return IcebergCatalogConfig.TOPIC_TO_TABLE.getOrDefault(event.topic(), null);
+  }
+
+  public static RowData toRowData(ValidatedEvent event) {
+    var record = event.toRecord();
+    var isChainTx = "chain.transaction.v1".equals(event.topic());
+
+    var row = new GenericRowData(isChainTx ? 11 : 10);
+
+    row.setField(0, StringData.fromString(event.eventId()));
+    row.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
+
+    var ingestTime = extractIngestTime(record);
+    row.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(ingestTime)));
+
+    row.setField(3, stringDataOrNull(event.schemaVersion()));
+    row.setField(4, stringDataOrNull(event.flowId()));
+    row.setField(5, stringDataOrNull(extractCorrelationId(record)));
+    row.setField(6, stringDataOrNull(extractTraceId(record)));
+    row.setField(7, StringData.fromString(event.topic()));
+    row.setField(8, stringDataOrNull(event.key()));
+    row.setField(9, StringData.fromString(record.toString()));
+
+    if (isChainTx) {
+      var txHash = record.get("tx_hash");
+      row.setField(10, StringData.fromString(txHash != null ? txHash.toString() : ""));
     }
 
-    public static RowData toRowData(ValidatedEvent event) {
-        var record = event.toRecord();
-        var isChainTx = "chain.transaction.v1".equals(event.topic());
+    return row;
+  }
 
-        var row = new GenericRowData(isChainTx ? 11 : 10);
-
-        row.setField(0, StringData.fromString(event.eventId()));
-        row.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(event.eventTimeMillis())));
-
-        var ingestTime = extractIngestTime(record);
-        row.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(ingestTime)));
-
-        row.setField(3, stringDataOrNull(event.schemaVersion()));
-        row.setField(4, stringDataOrNull(event.flowId()));
-        row.setField(5, stringDataOrNull(extractCorrelationId(record)));
-        row.setField(6, stringDataOrNull(extractTraceId(record)));
-        row.setField(7, StringData.fromString(event.topic()));
-        row.setField(8, stringDataOrNull(event.key()));
-        row.setField(9, StringData.fromString(record.toString()));
-
-        if (isChainTx) {
-            var txHash = record.get("tx_hash");
-            row.setField(10, StringData.fromString(txHash != null ? txHash.toString() : ""));
-        }
-
-        return row;
+  private static long extractIngestTime(GenericRecord record) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var ingestTime = env.get("ingest_time");
+      if (ingestTime instanceof Long l) return l;
     }
+    return Instant.now().toEpochMilli();
+  }
 
-    private static long extractIngestTime(GenericRecord record) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var ingestTime = env.get("ingest_time");
-            if (ingestTime instanceof Long l) return l;
-        }
-        return Instant.now().toEpochMilli();
+  private static String extractCorrelationId(GenericRecord record) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var val = env.get("correlation_id");
+      return val != null ? val.toString() : null;
     }
+    return null;
+  }
 
-    private static String extractCorrelationId(GenericRecord record) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var val = env.get("correlation_id");
-            return val != null ? val.toString() : null;
-        }
-        return null;
+  private static String extractTraceId(GenericRecord record) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      var val = env.get("trace_id");
+      return val != null ? val.toString() : null;
     }
+    return null;
+  }
 
-    private static String extractTraceId(GenericRecord record) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            var val = env.get("trace_id");
-            return val != null ? val.toString() : null;
-        }
-        return null;
-    }
-
-    private static StringData stringDataOrNull(String value) {
-        return value != null ? StringData.fromString(value) : null;
-    }
+  private static StringData stringDataOrNull(String value) {
+    return value != null ? StringData.fromString(value) : null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToOpenSearchDocMapper.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/EventToOpenSearchDocMapper.java
@@ -1,167 +1,171 @@
 package io.stablepay.flink.mapper;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.avro.generic.GenericRecord;
-
-import io.stablepay.flink.model.ValidatedEvent;
 
 public final class EventToOpenSearchDocMapper {
 
-    private EventToOpenSearchDocMapper() {}
+  private EventToOpenSearchDocMapper() {}
 
-    private static final Map<String, String> TOPIC_TO_EVENT_TYPE = Map.of(
-            "payment.payout.fiat.v1", "PAYOUT_FIAT",
-            "payment.payout.crypto.v1", "PAYOUT_CRYPTO",
-            "payment.payin.fiat.v1", "PAYIN_FIAT",
-            "payment.payin.crypto.v1", "PAYIN_CRYPTO",
-            "payment.flow.v1", "PAYMENT_FLOW",
-            "chain.transaction.v1", "CHAIN_TRANSACTION",
-            "signing.request.v1", "SIGNING_REQUEST",
-            "screening.result.v1", "SCREENING_RESULT",
-            "approval.decision.v1", "APPROVAL_DECISION");
+  private static final Map<String, String> TOPIC_TO_EVENT_TYPE =
+      Map.of(
+          "payment.payout.fiat.v1", "PAYOUT_FIAT",
+          "payment.payout.crypto.v1", "PAYOUT_CRYPTO",
+          "payment.payin.fiat.v1", "PAYIN_FIAT",
+          "payment.payin.crypto.v1", "PAYIN_CRYPTO",
+          "payment.flow.v1", "PAYMENT_FLOW",
+          "chain.transaction.v1", "CHAIN_TRANSACTION",
+          "signing.request.v1", "SIGNING_REQUEST",
+          "screening.result.v1", "SCREENING_RESULT",
+          "approval.decision.v1", "APPROVAL_DECISION");
 
-    public static Map<String, Object> toDocument(ValidatedEvent event) {
-        var doc = new HashMap<String, Object>();
-        var record = event.toRecord();
-        var topic = event.topic();
+  public static Map<String, Object> toDocument(ValidatedEvent event) {
+    var doc = new HashMap<String, Object>();
+    var record = event.toRecord();
+    var topic = event.topic();
 
-        doc.put("event_id", event.eventId());
-        doc.put("event_time", event.eventTimeMillis());
-        doc.put("schema_version", event.schemaVersion());
-        doc.put("flow_id", event.flowId());
+    doc.put("event_id", event.eventId());
+    doc.put("event_time", event.eventTimeMillis());
+    doc.put("schema_version", event.schemaVersion());
+    doc.put("flow_id", event.flowId());
 
-        extractEnvelopeFields(record, doc);
+    extractEnvelopeFields(record, doc);
 
-        var eventType = TOPIC_TO_EVENT_TYPE.getOrDefault(topic, "UNKNOWN");
-        doc.put("event_type", eventType);
-        doc.put("flow_type", deriveFlowType(topic));
-        doc.put("direction", deriveDirection(topic));
-        doc.put("is_crypto", isCrypto(topic));
+    var eventType = TOPIC_TO_EVENT_TYPE.getOrDefault(topic, "UNKNOWN");
+    doc.put("event_type", eventType);
+    doc.put("flow_type", deriveFlowType(topic));
+    doc.put("direction", deriveDirection(topic));
+    doc.put("is_crypto", isCrypto(topic));
 
-        extractCommonPayloadFields(record, doc);
-        extractMoneyFields(record, doc);
-        extractCryptoFields(record, doc);
-        extractTransactionReference(record, topic, doc);
+    extractCommonPayloadFields(record, doc);
+    extractMoneyFields(record, doc);
+    extractCryptoFields(record, doc);
+    extractTransactionReference(record, topic, doc);
 
-        return doc;
+    return doc;
+  }
+
+  private static void extractEnvelopeFields(GenericRecord record, Map<String, Object> doc) {
+    var envelope = record.get("envelope");
+    if (envelope instanceof GenericRecord env) {
+      putIfPresent(doc, "ingest_time", env.get("ingest_time"));
+      putIfPresent(doc, "correlation_id", env.get("correlation_id"));
+      putIfPresent(doc, "trace_id", env.get("trace_id"));
     }
+  }
 
-    private static void extractEnvelopeFields(GenericRecord record, Map<String, Object> doc) {
-        var envelope = record.get("envelope");
-        if (envelope instanceof GenericRecord env) {
-            putIfPresent(doc, "ingest_time", env.get("ingest_time"));
-            putIfPresent(doc, "correlation_id", env.get("correlation_id"));
-            putIfPresent(doc, "trace_id", env.get("trace_id"));
-        }
+  private static void extractCommonPayloadFields(GenericRecord record, Map<String, Object> doc) {
+    putStringIfPresent(doc, "customer_id", record.get("customer_id"));
+    putStringIfPresent(doc, "account_id", record.get("account_id"));
+    putStringIfPresent(doc, "internal_status", record.get("internal_status"));
+    putStringIfPresent(doc, "customer_status", record.get("customer_status"));
+    putIfPresent(doc, "is_user_facing", record.get("is_user_facing"));
+    putStringIfPresent(doc, "provider", record.get("provider"));
+    putStringIfPresent(doc, "route", record.get("route"));
+    putStringIfPresent(doc, "description", record.get("description"));
+    putStringIfPresent(doc, "notes", record.get("notes"));
+    putStringIfPresent(doc, "screening_outcome", record.get("screening_outcome"));
+  }
+
+  private static void extractMoneyFields(GenericRecord record, Map<String, Object> doc) {
+    extractMoney(record, "amount", "amount_micros", "currency_code", doc);
+    extractMoney(record, "fee", "fee_amount_micros", "fee_currency_code", doc);
+    extractMoney(record, "source_amount", "source_amount_micros", "source_currency_code", doc);
+    extractMoney(record, "target_amount", "target_amount_micros", "target_currency_code", doc);
+
+    putIfPresent(doc, "fx_rate", record.get("fx_rate"));
+  }
+
+  private static void extractMoney(
+      GenericRecord record,
+      String field,
+      String microsKey,
+      String currencyKey,
+      Map<String, Object> doc) {
+    var money = record.get(field);
+    if (money instanceof GenericRecord moneyRecord) {
+      putIfPresent(doc, microsKey, moneyRecord.get("amount_micros"));
+      putStringIfPresent(doc, currencyKey, moneyRecord.get("currency_code"));
     }
+  }
 
-    private static void extractCommonPayloadFields(GenericRecord record, Map<String, Object> doc) {
-        putStringIfPresent(doc, "customer_id", record.get("customer_id"));
-        putStringIfPresent(doc, "account_id", record.get("account_id"));
-        putStringIfPresent(doc, "internal_status", record.get("internal_status"));
-        putStringIfPresent(doc, "customer_status", record.get("customer_status"));
-        putIfPresent(doc, "is_user_facing", record.get("is_user_facing"));
-        putStringIfPresent(doc, "provider", record.get("provider"));
-        putStringIfPresent(doc, "route", record.get("route"));
-        putStringIfPresent(doc, "description", record.get("description"));
-        putStringIfPresent(doc, "notes", record.get("notes"));
-        putStringIfPresent(doc, "screening_outcome", record.get("screening_outcome"));
+  private static void extractCryptoFields(GenericRecord record, Map<String, Object> doc) {
+    putStringIfPresent(doc, "chain", record.get("chain"));
+    putStringIfPresent(doc, "asset", record.get("asset"));
+    putStringIfPresent(doc, "source_address", record.get("source_address"));
+    putStringIfPresent(doc, "destination_address", record.get("destination_address"));
+    putStringIfPresent(doc, "tx_hash", record.get("tx_hash"));
+    putIfPresent(doc, "confirmations", record.get("confirmations"));
+    putIfPresent(doc, "gas_fee_micros", record.get("gas_fee_micros"));
+    putIfPresent(doc, "block_number", record.get("block_number"));
+    putIfPresent(doc, "block_timestamp", record.get("block_timestamp"));
+
+    extractBeneficiary(record, doc);
+    extractSender(record, doc);
+  }
+
+  private static void extractBeneficiary(GenericRecord record, Map<String, Object> doc) {
+    var beneficiary = record.get("beneficiary");
+    if (beneficiary instanceof GenericRecord party) {
+      putStringIfPresent(doc, "beneficiary_name", party.get("name"));
     }
+  }
 
-    private static void extractMoneyFields(GenericRecord record, Map<String, Object> doc) {
-        extractMoney(record, "amount", "amount_micros", "currency_code", doc);
-        extractMoney(record, "fee", "fee_amount_micros", "fee_currency_code", doc);
-        extractMoney(record, "source_amount", "source_amount_micros", "source_currency_code", doc);
-        extractMoney(record, "target_amount", "target_amount_micros", "target_currency_code", doc);
-
-        putIfPresent(doc, "fx_rate", record.get("fx_rate"));
+  private static void extractSender(GenericRecord record, Map<String, Object> doc) {
+    var sender = record.get("sender");
+    if (sender instanceof GenericRecord party) {
+      putStringIfPresent(doc, "sender_name", party.get("name"));
     }
+  }
 
-    private static void extractMoney(
-            GenericRecord record, String field, String microsKey, String currencyKey, Map<String, Object> doc) {
-        var money = record.get(field);
-        if (money instanceof GenericRecord moneyRecord) {
-            putIfPresent(doc, microsKey, moneyRecord.get("amount_micros"));
-            putStringIfPresent(doc, currencyKey, moneyRecord.get("currency_code"));
-        }
+  private static void extractTransactionReference(
+      GenericRecord record, String topic, Map<String, Object> doc) {
+    var ref = (String) null;
+    if (topic.contains("payout")) {
+      ref = stringOrNull(record.get("payout_reference"));
+    } else if (topic.contains("payin")) {
+      ref = stringOrNull(record.get("payin_reference"));
+    } else if (topic.contains("flow")) {
+      ref = stringOrNull(record.get("flow_id"));
+    } else if (topic.contains("chain.transaction")) {
+      ref = stringOrNull(record.get("tx_hash"));
     }
-
-    private static void extractCryptoFields(GenericRecord record, Map<String, Object> doc) {
-        putStringIfPresent(doc, "chain", record.get("chain"));
-        putStringIfPresent(doc, "asset", record.get("asset"));
-        putStringIfPresent(doc, "source_address", record.get("source_address"));
-        putStringIfPresent(doc, "destination_address", record.get("destination_address"));
-        putStringIfPresent(doc, "tx_hash", record.get("tx_hash"));
-        putIfPresent(doc, "confirmations", record.get("confirmations"));
-        putIfPresent(doc, "gas_fee_micros", record.get("gas_fee_micros"));
-        putIfPresent(doc, "block_number", record.get("block_number"));
-        putIfPresent(doc, "block_timestamp", record.get("block_timestamp"));
-
-        extractBeneficiary(record, doc);
-        extractSender(record, doc);
+    if (ref != null) {
+      doc.put("transaction_reference", ref);
     }
+  }
 
-    private static void extractBeneficiary(GenericRecord record, Map<String, Object> doc) {
-        var beneficiary = record.get("beneficiary");
-        if (beneficiary instanceof GenericRecord party) {
-            putStringIfPresent(doc, "beneficiary_name", party.get("name"));
-        }
-    }
+  private static String deriveFlowType(String topic) {
+    if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
+    if (topic.contains("fiat")) return "FIAT";
+    return "MIXED";
+  }
 
-    private static void extractSender(GenericRecord record, Map<String, Object> doc) {
-        var sender = record.get("sender");
-        if (sender instanceof GenericRecord party) {
-            putStringIfPresent(doc, "sender_name", party.get("name"));
-        }
-    }
+  private static String deriveDirection(String topic) {
+    if (topic.contains("payin")) return "INBOUND";
+    if (topic.contains("payout")) return "OUTBOUND";
+    return "INTERNAL";
+  }
 
-    private static void extractTransactionReference(GenericRecord record, String topic, Map<String, Object> doc) {
-        var ref = (String) null;
-        if (topic.contains("payout")) {
-            ref = stringOrNull(record.get("payout_reference"));
-        } else if (topic.contains("payin")) {
-            ref = stringOrNull(record.get("payin_reference"));
-        } else if (topic.contains("flow")) {
-            ref = stringOrNull(record.get("flow_id"));
-        } else if (topic.contains("chain.transaction")) {
-            ref = stringOrNull(record.get("tx_hash"));
-        }
-        if (ref != null) {
-            doc.put("transaction_reference", ref);
-        }
-    }
+  private static boolean isCrypto(String topic) {
+    return topic.contains("crypto") || topic.contains("chain");
+  }
 
-    private static String deriveFlowType(String topic) {
-        if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
-        if (topic.contains("fiat")) return "FIAT";
-        return "MIXED";
+  private static void putIfPresent(Map<String, Object> doc, String key, Object value) {
+    if (value != null) {
+      doc.put(key, value);
     }
+  }
 
-    private static String deriveDirection(String topic) {
-        if (topic.contains("payin")) return "INBOUND";
-        if (topic.contains("payout")) return "OUTBOUND";
-        return "INTERNAL";
+  private static void putStringIfPresent(Map<String, Object> doc, String key, Object value) {
+    if (value != null) {
+      doc.put(key, value.toString());
     }
+  }
 
-    private static boolean isCrypto(String topic) {
-        return topic.contains("crypto") || topic.contains("chain");
-    }
-
-    private static void putIfPresent(Map<String, Object> doc, String key, Object value) {
-        if (value != null) {
-            doc.put(key, value);
-        }
-    }
-
-    private static void putStringIfPresent(Map<String, Object> doc, String key, Object value) {
-        if (value != null) {
-            doc.put(key, value.toString());
-        }
-    }
-
-    private static String stringOrNull(Object value) {
-        return value != null ? value.toString() : null;
-    }
+  private static String stringOrNull(Object value) {
+    return value != null ? value.toString() : null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/PiiMasker.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/mapper/PiiMasker.java
@@ -2,18 +2,19 @@ package io.stablepay.flink.mapper;
 
 public final class PiiMasker {
 
-    private static final int VISIBLE_PREFIX_LENGTH = 4;
-    private static final String MASK_CHAR = "*";
+  private static final int VISIBLE_PREFIX_LENGTH = 4;
+  private static final String MASK_CHAR = "*";
 
-    private PiiMasker() {}
+  private PiiMasker() {}
 
-    public static String mask(String value) {
-        if (value == null || value.isEmpty()) {
-            return value;
-        }
-        if (value.length() <= VISIBLE_PREFIX_LENGTH) {
-            return MASK_CHAR.repeat(value.length());
-        }
-        return value.substring(0, VISIBLE_PREFIX_LENGTH) + MASK_CHAR.repeat(value.length() - VISIBLE_PREFIX_LENGTH);
+  public static String mask(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
     }
+    if (value.length() <= VISIBLE_PREFIX_LENGTH) {
+      return MASK_CHAR.repeat(value.length());
+    }
+    return value.substring(0, VISIBLE_PREFIX_LENGTH)
+        + MASK_CHAR.repeat(value.length() - VISIBLE_PREFIX_LENGTH);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/model/DlqEnvelope.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/model/DlqEnvelope.java
@@ -11,9 +11,8 @@ public record DlqEnvelope(
     String errorMessage,
     byte[] originalPayloadBytes,
     long failedAt,
-    int retryCount
-) {
-    public DlqEnvelope {
-        originalPayloadBytes = originalPayloadBytes != null ? originalPayloadBytes.clone() : null;
-    }
+    int retryCount) {
+  public DlqEnvelope {
+    originalPayloadBytes = originalPayloadBytes != null ? originalPayloadBytes.clone() : null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/model/DlqEventIds.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/model/DlqEventIds.java
@@ -5,14 +5,19 @@ import java.util.UUID;
 
 public final class DlqEventIds {
 
-    private DlqEventIds() {}
+  private DlqEventIds() {}
 
-    public static String of(DlqEnvelope envelope) {
-        var seed = (envelope.sourceTopic() == null ? "" : envelope.sourceTopic())
-                + "|" + envelope.sourcePartition()
-                + "|" + envelope.sourceOffset()
-                + "|" + envelope.failedAt()
-                + "|" + (envelope.errorClass() == null ? "" : envelope.errorClass());
-        return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
-    }
+  public static String of(DlqEnvelope envelope) {
+    var seed =
+        (envelope.sourceTopic() == null ? "" : envelope.sourceTopic())
+            + "|"
+            + envelope.sourcePartition()
+            + "|"
+            + envelope.sourceOffset()
+            + "|"
+            + envelope.failedAt()
+            + "|"
+            + (envelope.errorClass() == null ? "" : envelope.errorClass());
+    return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/model/ValidatedEvent.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/model/ValidatedEvent.java
@@ -5,15 +5,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
+import lombok.Builder;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
-
-import lombok.Builder;
 
 @Builder(toBuilder = true)
 public record ValidatedEvent(
@@ -26,51 +24,56 @@ public record ValidatedEvent(
     String eventId,
     long eventTimeMillis,
     String flowId,
-    String schemaVersion
-) {
-    private static final ConcurrentMap<String, Schema> SCHEMA_CACHE = new ConcurrentHashMap<>();
+    String schemaVersion) {
+  private static final ConcurrentMap<String, Schema> SCHEMA_CACHE = new ConcurrentHashMap<>();
 
-    public ValidatedEvent {
-        recordBytes = recordBytes != null ? recordBytes.clone() : null;
-    }
+  public ValidatedEvent {
+    recordBytes = recordBytes != null ? recordBytes.clone() : null;
+  }
 
-    public static ValidatedEvent fromRecord(
-            String topic, int sourcePartition, long sourceOffset, String key, GenericRecord record,
-            String eventId, long eventTimeMillis, String flowId, String schemaVersion) {
-        try {
-            var schema = record.getSchema();
-            var out = new ByteArrayOutputStream();
-            var writer = new GenericDatumWriter<GenericRecord>(schema);
-            var encoder = EncoderFactory.get().binaryEncoder(out, null);
-            writer.write(record, encoder);
-            encoder.flush();
-            return ValidatedEvent.builder()
-                    .topic(topic)
-                    .sourcePartition(sourcePartition)
-                    .sourceOffset(sourceOffset)
-                    .key(key)
-                    .recordBytes(out.toByteArray())
-                    .recordSchemaJson(schema.toString())
-                    .eventId(eventId)
-                    .eventTimeMillis(eventTimeMillis)
-                    .flowId(flowId)
-                    .schemaVersion(schemaVersion)
-                    .build();
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to serialize GenericRecord", e);
-        }
+  public static ValidatedEvent fromRecord(
+      String topic,
+      int sourcePartition,
+      long sourceOffset,
+      String key,
+      GenericRecord record,
+      String eventId,
+      long eventTimeMillis,
+      String flowId,
+      String schemaVersion) {
+    try {
+      var schema = record.getSchema();
+      var out = new ByteArrayOutputStream();
+      var writer = new GenericDatumWriter<GenericRecord>(schema);
+      var encoder = EncoderFactory.get().binaryEncoder(out, null);
+      writer.write(record, encoder);
+      encoder.flush();
+      return ValidatedEvent.builder()
+          .topic(topic)
+          .sourcePartition(sourcePartition)
+          .sourceOffset(sourceOffset)
+          .key(key)
+          .recordBytes(out.toByteArray())
+          .recordSchemaJson(schema.toString())
+          .eventId(eventId)
+          .eventTimeMillis(eventTimeMillis)
+          .flowId(flowId)
+          .schemaVersion(schemaVersion)
+          .build();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to serialize GenericRecord", e);
     }
+  }
 
-    public GenericRecord toRecord() {
-        try {
-            var schema = SCHEMA_CACHE.computeIfAbsent(
-                    recordSchemaJson, json -> new Schema.Parser().parse(json));
-            var reader = new GenericDatumReader<GenericRecord>(schema);
-            var decoder = DecoderFactory.get().binaryDecoder(
-                    new ByteArrayInputStream(recordBytes), null);
-            return reader.read(null, decoder);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to deserialize GenericRecord", e);
-        }
+  public GenericRecord toRecord() {
+    try {
+      var schema =
+          SCHEMA_CACHE.computeIfAbsent(recordSchemaJson, json -> new Schema.Parser().parse(json));
+      var reader = new GenericDatumReader<GenericRecord>(schema);
+      var decoder = DecoderFactory.get().binaryDecoder(new ByteArrayInputStream(recordBytes), null);
+      return reader.read(null, decoder);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to deserialize GenericRecord", e);
     }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/model/ValidationResult.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/model/ValidationResult.java
@@ -2,7 +2,7 @@ package io.stablepay.flink.model;
 
 public sealed interface ValidationResult {
 
-    record Valid(ValidatedEvent event) implements ValidationResult {}
+  record Valid(ValidatedEvent event) implements ValidationResult {}
 
-    record Invalid(DlqEnvelope dlqEnvelope) implements ValidationResult {}
+  record Invalid(DlqEnvelope dlqEnvelope) implements ValidationResult {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/process/ValidateAndRouteFunction.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/process/ValidateAndRouteFunction.java
@@ -1,10 +1,5 @@
 package io.stablepay.flink.process;
 
-import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.functions.OpenContext;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
-import org.apache.flink.util.Collector;
-
 import io.stablepay.flink.dlq.DlqMetrics;
 import io.stablepay.flink.dlq.DlqOutputTags;
 import io.stablepay.flink.dlq.DlqRouter;
@@ -12,41 +7,51 @@ import io.stablepay.flink.model.ValidatedEvent;
 import io.stablepay.flink.transition.TransitionValidator;
 import io.stablepay.flink.transition.ValidationOutcome;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
 
 @Slf4j
-public class ValidateAndRouteFunction extends KeyedProcessFunction<String, ValidatedEvent, ValidatedEvent> {
-    private static final long LATE_EVENT_BUFFER_MS = 60_000;
+public class ValidateAndRouteFunction
+    extends KeyedProcessFunction<String, ValidatedEvent, ValidatedEvent> {
+  private static final long LATE_EVENT_BUFFER_MS = 60_000;
 
-    private transient ValueState<String> lastStatusState;
-    private transient DlqMetrics dlqMetrics;
-    private transient boolean strictMode;
+  private transient ValueState<String> lastStatusState;
+  private transient DlqMetrics dlqMetrics;
+  private transient boolean strictMode;
 
-    @Override
-    public void open(OpenContext openContext) throws Exception {
-        lastStatusState = getRuntimeContext().getState(TransitionValidator.lastStatusDescriptor());
-        dlqMetrics = new DlqMetrics(getRuntimeContext());
-        strictMode = TransitionValidator.isStrictMode();
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    lastStatusState = getRuntimeContext().getState(TransitionValidator.lastStatusDescriptor());
+    dlqMetrics = new DlqMetrics(getRuntimeContext());
+    strictMode = TransitionValidator.isStrictMode();
+  }
+
+  @Override
+  public void processElement(ValidatedEvent event, Context ctx, Collector<ValidatedEvent> out)
+      throws Exception {
+    var watermark = ctx.timerService().currentWatermark();
+    if (watermark > Long.MIN_VALUE && event.eventTimeMillis() < watermark - LATE_EVENT_BUFFER_MS) {
+      var dlq = DlqRouter.lateEvent(event, watermark, "Event arrived after watermark buffer");
+      ctx.output(DlqOutputTags.LATE_EVENT, dlq);
+      dlqMetrics.incrementLateEvent();
+      if (strictMode) return;
     }
 
-    @Override
-    public void processElement(ValidatedEvent event, Context ctx, Collector<ValidatedEvent> out) throws Exception {
-        var watermark = ctx.timerService().currentWatermark();
-        if (watermark > Long.MIN_VALUE && event.eventTimeMillis() < watermark - LATE_EVENT_BUFFER_MS) {
-            var dlq = DlqRouter.lateEvent(event, watermark, "Event arrived after watermark buffer");
-            ctx.output(DlqOutputTags.LATE_EVENT, dlq);
-            dlqMetrics.incrementLateEvent();
-            if (strictMode) return;
-        }
-
-        var outcome = TransitionValidator.validate(lastStatusState, event);
-        if (outcome instanceof ValidationOutcome.Invalid invalid) {
-            var dlq = DlqRouter.illegalTransition(event, invalid.fromStatus(), invalid.toStatus());
-            ctx.output(DlqOutputTags.ILLEGAL_TRANSITION, dlq);
-            dlqMetrics.incrementIllegalTransition();
-            log.warn("illegal_transition: topic={} from={} to={}", event.topic(), invalid.fromStatus(), invalid.toStatus());
-            if (strictMode) return;
-        }
-
-        out.collect(event);
+    var outcome = TransitionValidator.validate(lastStatusState, event);
+    if (outcome instanceof ValidationOutcome.Invalid invalid) {
+      var dlq = DlqRouter.illegalTransition(event, invalid.fromStatus(), invalid.toStatus());
+      ctx.output(DlqOutputTags.ILLEGAL_TRANSITION, dlq);
+      dlqMetrics.incrementIllegalTransition();
+      log.warn(
+          "illegal_transition: topic={} from={} to={}",
+          event.topic(),
+          invalid.fromStatus(),
+          invalid.toStatus());
+      if (strictMode) return;
     }
+
+    out.collect(event);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/AggTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/AggTableSinkFactory.java
@@ -1,10 +1,11 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.PartitionSpec;
@@ -16,130 +17,146 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.types.Types;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class AggTableSinkFactory implements Serializable {
 
-    static final Schema VOLUME_HOURLY_SCHEMA = new Schema(
-            List.of(
-                    Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
-                    Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
-                    Types.NestedField.required(3, "flow_type", Types.StringType.get()),
-                    Types.NestedField.required(4, "direction", Types.StringType.get()),
-                    Types.NestedField.required(5, "currency_code", Types.StringType.get()),
-                    Types.NestedField.required(6, "total_amount_micros", Types.LongType.get()),
-                    Types.NestedField.required(7, "transaction_count", Types.LongType.get())),
-            Set.of(1, 3, 4, 5));
+  static final Schema VOLUME_HOURLY_SCHEMA =
+      new Schema(
+          List.of(
+              Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
+              Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
+              Types.NestedField.required(3, "flow_type", Types.StringType.get()),
+              Types.NestedField.required(4, "direction", Types.StringType.get()),
+              Types.NestedField.required(5, "currency_code", Types.StringType.get()),
+              Types.NestedField.required(6, "total_amount_micros", Types.LongType.get()),
+              Types.NestedField.required(7, "transaction_count", Types.LongType.get())),
+          Set.of(1, 3, 4, 5));
 
-    static final List<String> VOLUME_HOURLY_EQUALITY = List.of(
-            "window_start", "flow_type", "direction", "currency_code");
+  static final List<String> VOLUME_HOURLY_EQUALITY =
+      List.of("window_start", "flow_type", "direction", "currency_code");
 
-    static final Schema SUCCESS_RATE_HOURLY_SCHEMA = new Schema(
-            List.of(
-                    Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
-                    Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
-                    Types.NestedField.required(3, "flow_type", Types.StringType.get()),
-                    Types.NestedField.required(4, "total_count", Types.LongType.get()),
-                    Types.NestedField.required(5, "completed_count", Types.LongType.get()),
-                    Types.NestedField.required(6, "failed_count", Types.LongType.get()),
-                    Types.NestedField.required(7, "success_rate", Types.DoubleType.get())),
-            Set.of(1, 3));
+  static final Schema SUCCESS_RATE_HOURLY_SCHEMA =
+      new Schema(
+          List.of(
+              Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
+              Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
+              Types.NestedField.required(3, "flow_type", Types.StringType.get()),
+              Types.NestedField.required(4, "total_count", Types.LongType.get()),
+              Types.NestedField.required(5, "completed_count", Types.LongType.get()),
+              Types.NestedField.required(6, "failed_count", Types.LongType.get()),
+              Types.NestedField.required(7, "success_rate", Types.DoubleType.get())),
+          Set.of(1, 3));
 
-    static final List<String> SUCCESS_RATE_HOURLY_EQUALITY = List.of("window_start", "flow_type");
+  static final List<String> SUCCESS_RATE_HOURLY_EQUALITY = List.of("window_start", "flow_type");
 
-    static final Schema SCREENING_OUTCOMES_DAILY_SCHEMA = new Schema(
-            List.of(
-                    Types.NestedField.required(1, "window_date", Types.DateType.get()),
-                    Types.NestedField.required(2, "outcome", Types.StringType.get()),
-                    Types.NestedField.required(3, "provider", Types.StringType.get()),
-                    Types.NestedField.required(4, "total_count", Types.LongType.get()),
-                    Types.NestedField.required(5, "avg_duration_ms", Types.DoubleType.get()),
-                    Types.NestedField.required(6, "avg_score", Types.DoubleType.get())),
-            Set.of(1, 2, 3));
+  static final Schema SCREENING_OUTCOMES_DAILY_SCHEMA =
+      new Schema(
+          List.of(
+              Types.NestedField.required(1, "window_date", Types.DateType.get()),
+              Types.NestedField.required(2, "outcome", Types.StringType.get()),
+              Types.NestedField.required(3, "provider", Types.StringType.get()),
+              Types.NestedField.required(4, "total_count", Types.LongType.get()),
+              Types.NestedField.required(5, "avg_duration_ms", Types.DoubleType.get()),
+              Types.NestedField.required(6, "avg_score", Types.DoubleType.get())),
+          Set.of(1, 2, 3));
 
-    static final List<String> SCREENING_OUTCOMES_DAILY_EQUALITY = List.of(
-            "window_date", "outcome", "provider");
+  static final List<String> SCREENING_OUTCOMES_DAILY_EQUALITY =
+      List.of("window_date", "outcome", "provider");
 
-    static final Schema DLQ_SUMMARY_HOURLY_SCHEMA = new Schema(
-            List.of(
-                    Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
-                    Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
-                    Types.NestedField.required(3, "error_class", Types.StringType.get()),
-                    Types.NestedField.required(4, "source_topic", Types.StringType.get()),
-                    Types.NestedField.required(5, "event_count", Types.LongType.get()),
-                    Types.NestedField.required(6, "max_retry_count", Types.IntegerType.get())),
-            Set.of(1, 3, 4));
+  static final Schema DLQ_SUMMARY_HOURLY_SCHEMA =
+      new Schema(
+          List.of(
+              Types.NestedField.required(1, "window_start", Types.TimestampType.withZone()),
+              Types.NestedField.required(2, "window_end", Types.TimestampType.withZone()),
+              Types.NestedField.required(3, "error_class", Types.StringType.get()),
+              Types.NestedField.required(4, "source_topic", Types.StringType.get()),
+              Types.NestedField.required(5, "event_count", Types.LongType.get()),
+              Types.NestedField.required(6, "max_retry_count", Types.IntegerType.get())),
+          Set.of(1, 3, 4));
 
-    static final List<String> DLQ_SUMMARY_HOURLY_EQUALITY = List.of(
-            "window_start", "error_class", "source_topic");
+  static final List<String> DLQ_SUMMARY_HOURLY_EQUALITY =
+      List.of("window_start", "error_class", "source_topic");
 
-    static final Schema STUCK_WITHDRAWALS_SCHEMA = new Schema(
-            Types.NestedField.required(1, "snapshot_time", Types.TimestampType.withZone()),
-            Types.NestedField.required(2, "transaction_reference", Types.StringType.get()),
-            Types.NestedField.required(3, "customer_id", Types.StringType.get()),
-            Types.NestedField.required(4, "amount_micros", Types.LongType.get()),
-            Types.NestedField.required(5, "currency_code", Types.StringType.get()),
-            Types.NestedField.required(6, "internal_status", Types.StringType.get()),
-            Types.NestedField.required(7, "event_time", Types.TimestampType.withZone()),
-            Types.NestedField.required(8, "stuck_duration_ms", Types.LongType.get()),
-            Types.NestedField.optional(9, "chain", Types.StringType.get()),
-            Types.NestedField.optional(10, "asset", Types.StringType.get()));
+  static final Schema STUCK_WITHDRAWALS_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "snapshot_time", Types.TimestampType.withZone()),
+          Types.NestedField.required(2, "transaction_reference", Types.StringType.get()),
+          Types.NestedField.required(3, "customer_id", Types.StringType.get()),
+          Types.NestedField.required(4, "amount_micros", Types.LongType.get()),
+          Types.NestedField.required(5, "currency_code", Types.StringType.get()),
+          Types.NestedField.required(6, "internal_status", Types.StringType.get()),
+          Types.NestedField.required(7, "event_time", Types.TimestampType.withZone()),
+          Types.NestedField.required(8, "stuck_duration_ms", Types.LongType.get()),
+          Types.NestedField.optional(9, "chain", Types.StringType.get()),
+          Types.NestedField.optional(10, "asset", Types.StringType.get()));
 
-    private static final Map<String, SchemaAndSpec> TABLE_CONFIGS = Map.of(
-            "agg_volume_hourly", new SchemaAndSpec(VOLUME_HOURLY_SCHEMA,
-                    PartitionSpec.builderFor(VOLUME_HOURLY_SCHEMA).day("window_start").build(),
-                    VOLUME_HOURLY_EQUALITY),
-            "agg_success_rate_hourly", new SchemaAndSpec(SUCCESS_RATE_HOURLY_SCHEMA,
-                    PartitionSpec.builderFor(SUCCESS_RATE_HOURLY_SCHEMA).day("window_start").build(),
-                    SUCCESS_RATE_HOURLY_EQUALITY),
-            "agg_screening_outcomes_daily", new SchemaAndSpec(SCREENING_OUTCOMES_DAILY_SCHEMA,
-                    PartitionSpec.builderFor(SCREENING_OUTCOMES_DAILY_SCHEMA).day("window_date").build(),
-                    SCREENING_OUTCOMES_DAILY_EQUALITY),
-            "agg_dlq_summary_hourly", new SchemaAndSpec(DLQ_SUMMARY_HOURLY_SCHEMA,
-                    PartitionSpec.builderFor(DLQ_SUMMARY_HOURLY_SCHEMA).day("window_start").build(),
-                    DLQ_SUMMARY_HOURLY_EQUALITY),
-            "agg_stuck_withdrawals", new SchemaAndSpec(STUCK_WITHDRAWALS_SCHEMA,
-                    PartitionSpec.unpartitioned(),
-                    List.of()));
+  private static final Map<String, SchemaAndSpec> TABLE_CONFIGS =
+      Map.of(
+          "agg_volume_hourly",
+              new SchemaAndSpec(
+                  VOLUME_HOURLY_SCHEMA,
+                  PartitionSpec.builderFor(VOLUME_HOURLY_SCHEMA).day("window_start").build(),
+                  VOLUME_HOURLY_EQUALITY),
+          "agg_success_rate_hourly",
+              new SchemaAndSpec(
+                  SUCCESS_RATE_HOURLY_SCHEMA,
+                  PartitionSpec.builderFor(SUCCESS_RATE_HOURLY_SCHEMA).day("window_start").build(),
+                  SUCCESS_RATE_HOURLY_EQUALITY),
+          "agg_screening_outcomes_daily",
+              new SchemaAndSpec(
+                  SCREENING_OUTCOMES_DAILY_SCHEMA,
+                  PartitionSpec.builderFor(SCREENING_OUTCOMES_DAILY_SCHEMA)
+                      .day("window_date")
+                      .build(),
+                  SCREENING_OUTCOMES_DAILY_EQUALITY),
+          "agg_dlq_summary_hourly",
+              new SchemaAndSpec(
+                  DLQ_SUMMARY_HOURLY_SCHEMA,
+                  PartitionSpec.builderFor(DLQ_SUMMARY_HOURLY_SCHEMA).day("window_start").build(),
+                  DLQ_SUMMARY_HOURLY_EQUALITY),
+          "agg_stuck_withdrawals",
+              new SchemaAndSpec(
+                  STUCK_WITHDRAWALS_SCHEMA, PartitionSpec.unpartitioned(), List.of()));
 
-    private CatalogLoader createCatalogLoader() {
-        return CatalogLoader.custom(
-                IcebergCatalogConfig.CATALOG_NAME,
-                IcebergCatalogConfig.catalogProperties(),
-                new org.apache.hadoop.conf.Configuration(),
-                "org.apache.iceberg.jdbc.JdbcCatalog");
+  private CatalogLoader createCatalogLoader() {
+    return CatalogLoader.custom(
+        IcebergCatalogConfig.CATALOG_NAME,
+        IcebergCatalogConfig.catalogProperties(),
+        new org.apache.hadoop.conf.Configuration(),
+        "org.apache.iceberg.jdbc.JdbcCatalog");
+  }
+
+  public void ensureAggTablesExist() {
+    var catalog = createCatalogLoader().loadCatalog();
+    var namespace = Namespace.of(IcebergCatalogConfig.AGG_NAMESPACE);
+
+    for (var tableName : IcebergCatalogConfig.AGG_TABLES) {
+      var tableId = TableIdentifier.of(namespace, tableName);
+      if (!catalog.tableExists(tableId)) {
+        var config = TABLE_CONFIGS.get(tableName);
+        catalog.createTable(
+            tableId,
+            config.schema(),
+            config.spec(),
+            Map.of(
+                "format-version", "2",
+                "write.parquet.compression-codec", "zstd"));
+        log.info("Created Iceberg agg table: {}", tableId);
+      }
     }
+  }
 
-    public void ensureAggTablesExist() {
-        var catalog = createCatalogLoader().loadCatalog();
-        var namespace = Namespace.of(IcebergCatalogConfig.AGG_NAMESPACE);
+  public void addSink(DataStream<RowData> stream, String tableName) {
+    var tableId = TableIdentifier.of(Namespace.of(IcebergCatalogConfig.AGG_NAMESPACE), tableName);
+    var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
+    var equalityFields = TABLE_CONFIGS.get(tableName).equalityFields();
 
-        for (var tableName : IcebergCatalogConfig.AGG_TABLES) {
-            var tableId = TableIdentifier.of(namespace, tableName);
-            if (!catalog.tableExists(tableId)) {
-                var config = TABLE_CONFIGS.get(tableName);
-                catalog.createTable(tableId, config.schema(), config.spec(), Map.of(
-                        "format-version", "2",
-                        "write.parquet.compression-codec", "zstd"));
-                log.info("Created Iceberg agg table: {}", tableId);
-            }
-        }
+    var builder = FlinkSink.forRowData(stream).tableLoader(tableLoader);
+    if (!equalityFields.isEmpty()) {
+      builder.upsert(true).equalityFieldColumns(equalityFields);
     }
+    builder.append();
+  }
 
-    public void addSink(DataStream<RowData> stream, String tableName) {
-        var tableId = TableIdentifier.of(
-                Namespace.of(IcebergCatalogConfig.AGG_NAMESPACE), tableName);
-        var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
-        var equalityFields = TABLE_CONFIGS.get(tableName).equalityFields();
-
-        var builder = FlinkSink.forRowData(stream).tableLoader(tableLoader);
-        if (!equalityFields.isEmpty()) {
-            builder.upsert(true).equalityFieldColumns(equalityFields);
-        }
-        builder.append();
-    }
-
-    private record SchemaAndSpec(Schema schema, PartitionSpec spec, List<String> equalityFields) {}
+  private record SchemaAndSpec(Schema schema, PartitionSpec spec, List<String> equalityFields) {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/BulkAction.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/BulkAction.java
@@ -4,11 +4,11 @@ import java.util.Map;
 
 record BulkAction(String eventId, Map<String, Object> document, int retryCount) {
 
-    BulkAction(String eventId, Map<String, Object> document) {
-        this(eventId, document, 0);
-    }
+  BulkAction(String eventId, Map<String, Object> document) {
+    this(eventId, document, 0);
+  }
 
-    BulkAction withRetry() {
-        return new BulkAction(eventId, document, retryCount + 1);
-    }
+  BulkAction withRetry() {
+    return new BulkAction(eventId, document, retryCount + 1);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/BulkResult.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/BulkResult.java
@@ -1,11 +1,11 @@
 package io.stablepay.flink.sink;
 
 import java.util.List;
-
 import lombok.Builder;
 
 record BulkResult(List<FailedDoc> failed) {
 
-    @Builder
-    record FailedDoc(String eventId, int statusCode, String errorType, String errorReason, boolean transient_) {}
+  @Builder
+  record FailedDoc(
+      String eventId, int statusCode, String errorType, String errorReason, boolean transient_) {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqIcebergSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqIcebergSinkFactory.java
@@ -1,8 +1,9 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
 import java.io.Serializable;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.PartitionSpec;
@@ -15,64 +16,60 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.types.Types;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class DlqIcebergSinkFactory implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    static final Schema DLQ_EVENTS_SCHEMA = new Schema(
-            Types.NestedField.required(1, "event_id", Types.StringType.get()),
-            Types.NestedField.required(2, "source_topic", Types.StringType.get()),
-            Types.NestedField.required(3, "source_partition", Types.IntegerType.get()),
-            Types.NestedField.required(4, "source_offset", Types.LongType.get()),
-            Types.NestedField.required(5, "error_class", Types.StringType.get()),
-            Types.NestedField.required(6, "error_message", Types.StringType.get()),
-            Types.NestedField.required(7, "failed_at", Types.TimestampType.withZone()),
-            Types.NestedField.required(8, "retry_count", Types.IntegerType.get()),
-            Types.NestedField.optional(9, "original_payload_json", Types.StringType.get()));
+  static final Schema DLQ_EVENTS_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "event_id", Types.StringType.get()),
+          Types.NestedField.required(2, "source_topic", Types.StringType.get()),
+          Types.NestedField.required(3, "source_partition", Types.IntegerType.get()),
+          Types.NestedField.required(4, "source_offset", Types.LongType.get()),
+          Types.NestedField.required(5, "error_class", Types.StringType.get()),
+          Types.NestedField.required(6, "error_message", Types.StringType.get()),
+          Types.NestedField.required(7, "failed_at", Types.TimestampType.withZone()),
+          Types.NestedField.required(8, "retry_count", Types.IntegerType.get()),
+          Types.NestedField.optional(9, "original_payload_json", Types.StringType.get()));
 
-    static final PartitionSpec DLQ_EVENTS_PARTITION_SPEC =
-            PartitionSpec.builderFor(DLQ_EVENTS_SCHEMA)
-                    .day("failed_at")
-                    .bucket("error_class", 4)
-                    .build();
+  static final PartitionSpec DLQ_EVENTS_PARTITION_SPEC =
+      PartitionSpec.builderFor(DLQ_EVENTS_SCHEMA).day("failed_at").bucket("error_class", 4).build();
 
-    private CatalogLoader createCatalogLoader() {
-        return CatalogLoader.custom(
-                IcebergCatalogConfig.CATALOG_NAME,
-                IcebergCatalogConfig.catalogProperties(),
-                new org.apache.hadoop.conf.Configuration(),
-                "org.apache.iceberg.jdbc.JdbcCatalog");
+  private CatalogLoader createCatalogLoader() {
+    return CatalogLoader.custom(
+        IcebergCatalogConfig.CATALOG_NAME,
+        IcebergCatalogConfig.catalogProperties(),
+        new org.apache.hadoop.conf.Configuration(),
+        "org.apache.iceberg.jdbc.JdbcCatalog");
+  }
+
+  public void ensureDlqTableExists() {
+    var catalog = createCatalogLoader().loadCatalog();
+    var namespace = Namespace.of(IcebergCatalogConfig.DLQ_NAMESPACE);
+
+    if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
+      nsCatalog.createNamespace(namespace);
+      log.info("Created Iceberg namespace: {}", namespace);
     }
 
-    public void ensureDlqTableExists() {
-        var catalog = createCatalogLoader().loadCatalog();
-        var namespace = Namespace.of(IcebergCatalogConfig.DLQ_NAMESPACE);
-
-        if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
-            nsCatalog.createNamespace(namespace);
-            log.info("Created Iceberg namespace: {}", namespace);
-        }
-
-        var tableId = TableIdentifier.of(namespace, "dlq_events");
-        if (!catalog.tableExists(tableId)) {
-            catalog.createTable(tableId, DLQ_EVENTS_SCHEMA, DLQ_EVENTS_PARTITION_SPEC, Map.of(
-                    "format-version", "2",
-                    "write.parquet.compression-codec", "zstd"));
-            log.info("Created Iceberg DLQ table: {}", tableId);
-        }
+    var tableId = TableIdentifier.of(namespace, "dlq_events");
+    if (!catalog.tableExists(tableId)) {
+      catalog.createTable(
+          tableId,
+          DLQ_EVENTS_SCHEMA,
+          DLQ_EVENTS_PARTITION_SPEC,
+          Map.of(
+              "format-version", "2",
+              "write.parquet.compression-codec", "zstd"));
+      log.info("Created Iceberg DLQ table: {}", tableId);
     }
+  }
 
-    public void addSink(DataStream<RowData> stream, String tableName) {
-        var tableId = TableIdentifier.of(
-                Namespace.of(IcebergCatalogConfig.DLQ_NAMESPACE), tableName);
-        var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
+  public void addSink(DataStream<RowData> stream, String tableName) {
+    var tableId = TableIdentifier.of(Namespace.of(IcebergCatalogConfig.DLQ_NAMESPACE), tableName);
+    var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
 
-        FlinkSink.forRowData(stream)
-                .tableLoader(tableLoader)
-                .append();
-    }
+    FlinkSink.forRowData(stream).tableLoader(tableLoader).append();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqOpenSearchSink.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqOpenSearchSink.java
@@ -1,22 +1,20 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.model.DlqEnvelope;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import lombok.RequiredArgsConstructor;
-
 @RequiredArgsConstructor
 public class DlqOpenSearchSink implements Sink<DlqEnvelope> {
 
-    private final String opensearchUrl;
-    private final String indexName;
+  private final String opensearchUrl;
+  private final String indexName;
 
-    @Override
-    public SinkWriter<DlqEnvelope> createWriter(WriterInitContext context) throws IOException {
-        return new DlqOpenSearchSinkWriter(opensearchUrl, indexName);
-    }
+  @Override
+  public SinkWriter<DlqEnvelope> createWriter(WriterInitContext context) throws IOException {
+    return new DlqOpenSearchSinkWriter(opensearchUrl, indexName);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqOpenSearchSinkWriter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/DlqOpenSearchSinkWriter.java
@@ -1,75 +1,81 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.mapper.DlqToOpenSearchDocMapper;
+import io.stablepay.flink.model.DlqEnvelope;
 import java.io.IOException;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.hc.core5.http.HttpHost;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
-import io.stablepay.flink.mapper.DlqToOpenSearchDocMapper;
-import io.stablepay.flink.model.DlqEnvelope;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 class DlqOpenSearchSinkWriter implements SinkWriter<DlqEnvelope> {
 
-    private static final long FLUSH_INTERVAL_MS = 5000;
+  private static final long FLUSH_INTERVAL_MS = 5000;
 
-    private final OpenSearchBulkWriter bulkWriter;
-    private long lastFlushTime;
+  private final OpenSearchBulkWriter bulkWriter;
+  private long lastFlushTime;
 
-    DlqOpenSearchSinkWriter(String opensearchUrl, String indexName) {
-        try {
-            var transport = ApacheHttpClient5TransportBuilder
-                    .builder(HttpHost.create(opensearchUrl))
-                    .setMapper(new JacksonJsonpMapper())
-                    .build();
-            this.bulkWriter = new OpenSearchBulkWriter(new OpenSearchClient(transport), indexName);
-            this.lastFlushTime = System.currentTimeMillis();
-        } catch (java.net.URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid OpenSearch URL: " + opensearchUrl, e);
-        }
+  DlqOpenSearchSinkWriter(String opensearchUrl, String indexName) {
+    try {
+      var transport =
+          ApacheHttpClient5TransportBuilder.builder(HttpHost.create(opensearchUrl))
+              .setMapper(new JacksonJsonpMapper())
+              .build();
+      this.bulkWriter = new OpenSearchBulkWriter(new OpenSearchClient(transport), indexName);
+      this.lastFlushTime = System.currentTimeMillis();
+    } catch (java.net.URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid OpenSearch URL: " + opensearchUrl, e);
     }
+  }
 
-    @Override
-    public void write(DlqEnvelope envelope, Context context) throws IOException, InterruptedException {
-        var doc = DlqToOpenSearchDocMapper.toDocument(envelope);
-        var eventId = doc.getOrDefault("event_id", "unknown").toString();
-        bulkWriter.add(eventId, doc);
+  @Override
+  public void write(DlqEnvelope envelope, Context context)
+      throws IOException, InterruptedException {
+    var doc = DlqToOpenSearchDocMapper.toDocument(envelope);
+    var eventId = doc.getOrDefault("event_id", "unknown").toString();
+    bulkWriter.add(eventId, doc);
 
-        if (System.currentTimeMillis() - lastFlushTime >= FLUSH_INTERVAL_MS) {
-            flushAndHandleErrors();
-        }
+    if (System.currentTimeMillis() - lastFlushTime >= FLUSH_INTERVAL_MS) {
+      flushAndHandleErrors();
     }
+  }
 
-    @Override
-    public void flush(boolean endOfInput) throws IOException, InterruptedException {
-        if (bulkWriter.shouldFlush()) {
-            flushAndHandleErrors();
-        }
+  @Override
+  public void flush(boolean endOfInput) throws IOException, InterruptedException {
+    if (bulkWriter.shouldFlush()) {
+      flushAndHandleErrors();
     }
+  }
 
-    @Override
-    public void close() throws Exception {
-        if (bulkWriter.shouldFlush()) {
-            flushAndHandleErrors();
-        }
+  @Override
+  public void close() throws Exception {
+    if (bulkWriter.shouldFlush()) {
+      flushAndHandleErrors();
     }
+  }
 
-    private void flushAndHandleErrors() throws IOException {
-        var result = bulkWriter.flush();
-        lastFlushTime = System.currentTimeMillis();
+  private void flushAndHandleErrors() throws IOException {
+    var result = bulkWriter.flush();
+    lastFlushTime = System.currentTimeMillis();
 
-        for (var failed : result.failed()) {
-            if (failed.transient_()) {
-                log.warn("dlq_opensearch_transient_failure: eventId={} status={} reason={}",
-                        failed.eventId(), failed.statusCode(), failed.errorReason());
-            } else {
-                log.error("dlq_opensearch_permanent_failure: eventId={} status={} type={} reason={}",
-                        failed.eventId(), failed.statusCode(), failed.errorType(), failed.errorReason());
-            }
-        }
+    for (var failed : result.failed()) {
+      if (failed.transient_()) {
+        log.warn(
+            "dlq_opensearch_transient_failure: eventId={} status={} reason={}",
+            failed.eventId(),
+            failed.statusCode(),
+            failed.errorReason());
+      } else {
+        log.error(
+            "dlq_opensearch_permanent_failure: eventId={} status={} type={} reason={}",
+            failed.eventId(),
+            failed.statusCode(),
+            failed.errorType(),
+            failed.errorReason());
+      }
     }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/FactTableSinkFactory.java
@@ -1,10 +1,11 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.PartitionSpec;
@@ -17,162 +18,165 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.types.Types;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class FactTableSinkFactory implements Serializable {
 
-    static final Schema FACT_TRANSACTIONS_SCHEMA = new Schema(
-            Types.NestedField.required(1, "event_id", Types.StringType.get()),
-            Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
-            Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
-            Types.NestedField.optional(4, "flow_id", Types.StringType.get()),
-            Types.NestedField.optional(5, "correlation_id", Types.StringType.get()),
-            Types.NestedField.optional(6, "trace_id", Types.StringType.get()),
-            Types.NestedField.required(7, "event_type", Types.StringType.get()),
-            Types.NestedField.required(8, "flow_type", Types.StringType.get()),
-            Types.NestedField.required(9, "direction", Types.StringType.get()),
-            Types.NestedField.required(10, "is_crypto", Types.BooleanType.get()),
-            Types.NestedField.optional(11, "is_user_facing", Types.BooleanType.get()),
-            Types.NestedField.optional(12, "transaction_reference", Types.StringType.get()),
-            Types.NestedField.optional(13, "customer_id", Types.StringType.get()),
-            Types.NestedField.optional(14, "account_id", Types.StringType.get()),
-            Types.NestedField.optional(15, "amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(16, "currency_code", Types.StringType.get()),
-            Types.NestedField.optional(17, "fee_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(18, "fee_currency_code", Types.StringType.get()),
-            Types.NestedField.optional(19, "source_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(20, "source_currency_code", Types.StringType.get()),
-            Types.NestedField.optional(21, "target_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(22, "target_currency_code", Types.StringType.get()),
-            Types.NestedField.optional(23, "fx_rate", Types.DoubleType.get()),
-            Types.NestedField.optional(24, "internal_status", Types.StringType.get()),
-            Types.NestedField.optional(25, "customer_status", Types.StringType.get()),
-            Types.NestedField.optional(26, "screening_outcome", Types.StringType.get()),
-            Types.NestedField.optional(27, "chain", Types.StringType.get()),
-            Types.NestedField.optional(28, "asset", Types.StringType.get()),
-            Types.NestedField.optional(29, "source_address", Types.StringType.get()),
-            Types.NestedField.optional(30, "destination_address", Types.StringType.get()),
-            Types.NestedField.optional(31, "tx_hash", Types.StringType.get()),
-            Types.NestedField.optional(32, "confirmations", Types.IntegerType.get()),
-            Types.NestedField.optional(33, "gas_fee_micros", Types.LongType.get()),
-            Types.NestedField.optional(34, "block_number", Types.LongType.get()),
-            Types.NestedField.optional(35, "block_timestamp", Types.TimestampType.withZone()),
-            Types.NestedField.optional(36, "provider", Types.StringType.get()),
-            Types.NestedField.optional(37, "route", Types.StringType.get()),
-            Types.NestedField.optional(38, "beneficiary_name", Types.StringType.get()),
-            Types.NestedField.optional(39, "sender_name", Types.StringType.get()),
-            Types.NestedField.optional(40, "description", Types.StringType.get()),
-            Types.NestedField.optional(41, "notes", Types.StringType.get()));
+  static final Schema FACT_TRANSACTIONS_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "event_id", Types.StringType.get()),
+          Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
+          Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
+          Types.NestedField.optional(4, "flow_id", Types.StringType.get()),
+          Types.NestedField.optional(5, "correlation_id", Types.StringType.get()),
+          Types.NestedField.optional(6, "trace_id", Types.StringType.get()),
+          Types.NestedField.required(7, "event_type", Types.StringType.get()),
+          Types.NestedField.required(8, "flow_type", Types.StringType.get()),
+          Types.NestedField.required(9, "direction", Types.StringType.get()),
+          Types.NestedField.required(10, "is_crypto", Types.BooleanType.get()),
+          Types.NestedField.optional(11, "is_user_facing", Types.BooleanType.get()),
+          Types.NestedField.optional(12, "transaction_reference", Types.StringType.get()),
+          Types.NestedField.optional(13, "customer_id", Types.StringType.get()),
+          Types.NestedField.optional(14, "account_id", Types.StringType.get()),
+          Types.NestedField.optional(15, "amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(16, "currency_code", Types.StringType.get()),
+          Types.NestedField.optional(17, "fee_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(18, "fee_currency_code", Types.StringType.get()),
+          Types.NestedField.optional(19, "source_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(20, "source_currency_code", Types.StringType.get()),
+          Types.NestedField.optional(21, "target_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(22, "target_currency_code", Types.StringType.get()),
+          Types.NestedField.optional(23, "fx_rate", Types.DoubleType.get()),
+          Types.NestedField.optional(24, "internal_status", Types.StringType.get()),
+          Types.NestedField.optional(25, "customer_status", Types.StringType.get()),
+          Types.NestedField.optional(26, "screening_outcome", Types.StringType.get()),
+          Types.NestedField.optional(27, "chain", Types.StringType.get()),
+          Types.NestedField.optional(28, "asset", Types.StringType.get()),
+          Types.NestedField.optional(29, "source_address", Types.StringType.get()),
+          Types.NestedField.optional(30, "destination_address", Types.StringType.get()),
+          Types.NestedField.optional(31, "tx_hash", Types.StringType.get()),
+          Types.NestedField.optional(32, "confirmations", Types.IntegerType.get()),
+          Types.NestedField.optional(33, "gas_fee_micros", Types.LongType.get()),
+          Types.NestedField.optional(34, "block_number", Types.LongType.get()),
+          Types.NestedField.optional(35, "block_timestamp", Types.TimestampType.withZone()),
+          Types.NestedField.optional(36, "provider", Types.StringType.get()),
+          Types.NestedField.optional(37, "route", Types.StringType.get()),
+          Types.NestedField.optional(38, "beneficiary_name", Types.StringType.get()),
+          Types.NestedField.optional(39, "sender_name", Types.StringType.get()),
+          Types.NestedField.optional(40, "description", Types.StringType.get()),
+          Types.NestedField.optional(41, "notes", Types.StringType.get()));
 
-    static final PartitionSpec FACT_TRANSACTIONS_PARTITION_SPEC =
-            PartitionSpec.builderFor(FACT_TRANSACTIONS_SCHEMA)
-                    .day("event_time")
-                    .bucket("customer_id", 16)
-                    .build();
+  static final PartitionSpec FACT_TRANSACTIONS_PARTITION_SPEC =
+      PartitionSpec.builderFor(FACT_TRANSACTIONS_SCHEMA)
+          .day("event_time")
+          .bucket("customer_id", 16)
+          .build();
 
-    static final Schema FACT_FLOWS_SCHEMA = new Schema(
-            Types.NestedField.required(1, "flow_id", Types.StringType.get()),
-            Types.NestedField.optional(2, "customer_id", Types.StringType.get()),
-            Types.NestedField.optional(3, "flow_type", Types.StringType.get()),
-            Types.NestedField.optional(4, "flow_status", Types.StringType.get()),
-            Types.NestedField.required(5, "initiated_at", Types.TimestampType.withZone()),
-            Types.NestedField.optional(6, "completed_at", Types.TimestampType.withZone()),
-            Types.NestedField.optional(7, "last_updated_at", Types.TimestampType.withZone()),
-            Types.NestedField.optional(8, "payin_status", Types.StringType.get()),
-            Types.NestedField.optional(9, "payin_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(10, "payin_currency", Types.StringType.get()),
-            Types.NestedField.optional(11, "payin_reference", Types.StringType.get()),
-            Types.NestedField.optional(12, "trade_status", Types.StringType.get()),
-            Types.NestedField.optional(13, "trade_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(14, "trade_currency", Types.StringType.get()),
-            Types.NestedField.optional(15, "payout_status", Types.StringType.get()),
-            Types.NestedField.optional(16, "payout_amount_micros", Types.LongType.get()),
-            Types.NestedField.optional(17, "payout_currency", Types.StringType.get()),
-            Types.NestedField.optional(18, "payout_reference", Types.StringType.get()),
-            Types.NestedField.optional(19, "total_duration_ms", Types.LongType.get()),
-            Types.NestedField.optional(20, "leg_count", Types.IntegerType.get()));
+  static final Schema FACT_FLOWS_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "flow_id", Types.StringType.get()),
+          Types.NestedField.optional(2, "customer_id", Types.StringType.get()),
+          Types.NestedField.optional(3, "flow_type", Types.StringType.get()),
+          Types.NestedField.optional(4, "flow_status", Types.StringType.get()),
+          Types.NestedField.required(5, "initiated_at", Types.TimestampType.withZone()),
+          Types.NestedField.optional(6, "completed_at", Types.TimestampType.withZone()),
+          Types.NestedField.optional(7, "last_updated_at", Types.TimestampType.withZone()),
+          Types.NestedField.optional(8, "payin_status", Types.StringType.get()),
+          Types.NestedField.optional(9, "payin_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(10, "payin_currency", Types.StringType.get()),
+          Types.NestedField.optional(11, "payin_reference", Types.StringType.get()),
+          Types.NestedField.optional(12, "trade_status", Types.StringType.get()),
+          Types.NestedField.optional(13, "trade_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(14, "trade_currency", Types.StringType.get()),
+          Types.NestedField.optional(15, "payout_status", Types.StringType.get()),
+          Types.NestedField.optional(16, "payout_amount_micros", Types.LongType.get()),
+          Types.NestedField.optional(17, "payout_currency", Types.StringType.get()),
+          Types.NestedField.optional(18, "payout_reference", Types.StringType.get()),
+          Types.NestedField.optional(19, "total_duration_ms", Types.LongType.get()),
+          Types.NestedField.optional(20, "leg_count", Types.IntegerType.get()));
 
-    static final PartitionSpec FACT_FLOWS_PARTITION_SPEC =
-            PartitionSpec.builderFor(FACT_FLOWS_SCHEMA)
-                    .day("initiated_at")
-                    .build();
+  static final PartitionSpec FACT_FLOWS_PARTITION_SPEC =
+      PartitionSpec.builderFor(FACT_FLOWS_SCHEMA).day("initiated_at").build();
 
-    static final Schema FACT_SCREENING_SCHEMA = new Schema(
-            Types.NestedField.required(1, "event_id", Types.StringType.get()),
-            Types.NestedField.optional(2, "screening_id", Types.StringType.get()),
-            Types.NestedField.optional(3, "customer_id", Types.StringType.get()),
-            Types.NestedField.optional(4, "transaction_reference", Types.StringType.get()),
-            Types.NestedField.optional(5, "outcome", Types.StringType.get()),
-            Types.NestedField.optional(6, "provider", Types.StringType.get()),
-            Types.NestedField.optional(7, "rule_triggered", Types.StringType.get()),
-            Types.NestedField.optional(8, "score", Types.DoubleType.get()),
-            Types.NestedField.required(9, "event_time", Types.TimestampType.withZone()),
-            Types.NestedField.optional(10, "duration_ms", Types.LongType.get()));
+  static final Schema FACT_SCREENING_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "event_id", Types.StringType.get()),
+          Types.NestedField.optional(2, "screening_id", Types.StringType.get()),
+          Types.NestedField.optional(3, "customer_id", Types.StringType.get()),
+          Types.NestedField.optional(4, "transaction_reference", Types.StringType.get()),
+          Types.NestedField.optional(5, "outcome", Types.StringType.get()),
+          Types.NestedField.optional(6, "provider", Types.StringType.get()),
+          Types.NestedField.optional(7, "rule_triggered", Types.StringType.get()),
+          Types.NestedField.optional(8, "score", Types.DoubleType.get()),
+          Types.NestedField.required(9, "event_time", Types.TimestampType.withZone()),
+          Types.NestedField.optional(10, "duration_ms", Types.LongType.get()));
 
-    static final PartitionSpec FACT_SCREENING_PARTITION_SPEC =
-            PartitionSpec.builderFor(FACT_SCREENING_SCHEMA)
-                    .day("event_time")
-                    .build();
+  static final PartitionSpec FACT_SCREENING_PARTITION_SPEC =
+      PartitionSpec.builderFor(FACT_SCREENING_SCHEMA).day("event_time").build();
 
-    private static final Map<String, SchemaAndSpec> TABLE_DEFINITIONS = Map.of(
-            "fact_transactions", new SchemaAndSpec(FACT_TRANSACTIONS_SCHEMA, FACT_TRANSACTIONS_PARTITION_SPEC),
-            "fact_flows", new SchemaAndSpec(FACT_FLOWS_SCHEMA, FACT_FLOWS_PARTITION_SPEC),
-            "fact_screening_outcomes", new SchemaAndSpec(FACT_SCREENING_SCHEMA, FACT_SCREENING_PARTITION_SPEC));
+  private static final Map<String, SchemaAndSpec> TABLE_DEFINITIONS =
+      Map.of(
+          "fact_transactions",
+              new SchemaAndSpec(FACT_TRANSACTIONS_SCHEMA, FACT_TRANSACTIONS_PARTITION_SPEC),
+          "fact_flows", new SchemaAndSpec(FACT_FLOWS_SCHEMA, FACT_FLOWS_PARTITION_SPEC),
+          "fact_screening_outcomes",
+              new SchemaAndSpec(FACT_SCREENING_SCHEMA, FACT_SCREENING_PARTITION_SPEC));
 
-    private CatalogLoader createCatalogLoader() {
-        return CatalogLoader.custom(
-                IcebergCatalogConfig.CATALOG_NAME,
-                IcebergCatalogConfig.catalogProperties(),
-                new org.apache.hadoop.conf.Configuration(),
-                "org.apache.iceberg.jdbc.JdbcCatalog");
-    }
+  private CatalogLoader createCatalogLoader() {
+    return CatalogLoader.custom(
+        IcebergCatalogConfig.CATALOG_NAME,
+        IcebergCatalogConfig.catalogProperties(),
+        new org.apache.hadoop.conf.Configuration(),
+        "org.apache.iceberg.jdbc.JdbcCatalog");
+  }
 
-    public void ensureFactTablesExist() {
-        var catalog = createCatalogLoader().loadCatalog();
-        try {
-            var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
+  public void ensureFactTablesExist() {
+    var catalog = createCatalogLoader().loadCatalog();
+    try {
+      var namespace = Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE);
 
-            if (catalog instanceof SupportsNamespaces nsCatalog && !nsCatalog.namespaceExists(namespace)) {
-                nsCatalog.createNamespace(namespace);
-                log.info("Created Iceberg namespace: {}", namespace);
-            }
+      if (catalog instanceof SupportsNamespaces nsCatalog
+          && !nsCatalog.namespaceExists(namespace)) {
+        nsCatalog.createNamespace(namespace);
+        log.info("Created Iceberg namespace: {}", namespace);
+      }
 
-            for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
-                var def = TABLE_DEFINITIONS.get(tableName);
-                if (def == null) {
-                    throw new IllegalStateException(
-                            "No schema definition for fact table '" + tableName + "' — add it to TABLE_DEFINITIONS");
-                }
-                var tableId = TableIdentifier.of(namespace, tableName);
-                if (!catalog.tableExists(tableId)) {
-                    catalog.createTable(tableId, def.schema(), def.spec(), Map.of(
-                            "format-version", "2",
-                            "write.parquet.compression-codec", "zstd"));
-                    log.info("Created Iceberg fact table: {}", tableId);
-                }
-            }
-        } finally {
-            if (catalog instanceof Closeable closeable) {
-                try {
-                    closeable.close();
-                } catch (IOException e) {
-                    log.warn("Failed to close Iceberg catalog", e);
-                }
-            }
+      for (var tableName : IcebergCatalogConfig.FACT_TABLES) {
+        var def = TABLE_DEFINITIONS.get(tableName);
+        if (def == null) {
+          throw new IllegalStateException(
+              "No schema definition for fact table '"
+                  + tableName
+                  + "' — add it to TABLE_DEFINITIONS");
         }
+        var tableId = TableIdentifier.of(namespace, tableName);
+        if (!catalog.tableExists(tableId)) {
+          catalog.createTable(
+              tableId,
+              def.schema(),
+              def.spec(),
+              Map.of(
+                  "format-version", "2",
+                  "write.parquet.compression-codec", "zstd"));
+          log.info("Created Iceberg fact table: {}", tableId);
+        }
+      }
+    } finally {
+      if (catalog instanceof Closeable closeable) {
+        try {
+          closeable.close();
+        } catch (IOException e) {
+          log.warn("Failed to close Iceberg catalog", e);
+        }
+      }
     }
+  }
 
-    public void addSink(DataStream<RowData> stream, String tableName) {
-        var tableId = TableIdentifier.of(
-                Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE), tableName);
-        var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
+  public void addSink(DataStream<RowData> stream, String tableName) {
+    var tableId = TableIdentifier.of(Namespace.of(IcebergCatalogConfig.FACTS_NAMESPACE), tableName);
+    var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
 
-        FlinkSink.forRowData(stream)
-                .tableLoader(tableLoader)
-                .append();
-    }
+    FlinkSink.forRowData(stream).tableLoader(tableLoader).append();
+  }
 
-    private record SchemaAndSpec(Schema schema, PartitionSpec spec) {}
+  private record SchemaAndSpec(Schema schema, PartitionSpec spec) {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/IcebergSinkFactory.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/IcebergSinkFactory.java
@@ -1,8 +1,9 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.catalog.IcebergCatalogConfig;
 import java.io.Serializable;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.PartitionSpec;
@@ -14,80 +15,77 @@ import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.sink.FlinkSink;
 import org.apache.iceberg.types.Types;
 
-import io.stablepay.flink.catalog.IcebergCatalogConfig;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 public class IcebergSinkFactory implements Serializable {
 
-    private static final Schema COMMON_SCHEMA = new Schema(
-            Types.NestedField.required(1, "event_id", Types.StringType.get()),
-            Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
-            Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
-            Types.NestedField.optional(4, "schema_version", Types.StringType.get()),
-            Types.NestedField.optional(5, "flow_id", Types.StringType.get()),
-            Types.NestedField.optional(6, "correlation_id", Types.StringType.get()),
-            Types.NestedField.optional(7, "trace_id", Types.StringType.get()),
-            Types.NestedField.required(8, "topic", Types.StringType.get()),
-            Types.NestedField.optional(9, "key", Types.StringType.get()),
-            Types.NestedField.required(10, "payload_json", Types.StringType.get()));
+  private static final Schema COMMON_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "event_id", Types.StringType.get()),
+          Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
+          Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
+          Types.NestedField.optional(4, "schema_version", Types.StringType.get()),
+          Types.NestedField.optional(5, "flow_id", Types.StringType.get()),
+          Types.NestedField.optional(6, "correlation_id", Types.StringType.get()),
+          Types.NestedField.optional(7, "trace_id", Types.StringType.get()),
+          Types.NestedField.required(8, "topic", Types.StringType.get()),
+          Types.NestedField.optional(9, "key", Types.StringType.get()),
+          Types.NestedField.required(10, "payload_json", Types.StringType.get()));
 
-    private static final PartitionSpec DEFAULT_PARTITION_SPEC = PartitionSpec.builderFor(COMMON_SCHEMA)
-            .day("event_time")
-            .build();
+  private static final PartitionSpec DEFAULT_PARTITION_SPEC =
+      PartitionSpec.builderFor(COMMON_SCHEMA).day("event_time").build();
 
-    private static final Schema CHAIN_TX_SCHEMA = new Schema(
-            Types.NestedField.required(1, "event_id", Types.StringType.get()),
-            Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
-            Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
-            Types.NestedField.optional(4, "schema_version", Types.StringType.get()),
-            Types.NestedField.optional(5, "flow_id", Types.StringType.get()),
-            Types.NestedField.optional(6, "correlation_id", Types.StringType.get()),
-            Types.NestedField.optional(7, "trace_id", Types.StringType.get()),
-            Types.NestedField.required(8, "topic", Types.StringType.get()),
-            Types.NestedField.optional(9, "key", Types.StringType.get()),
-            Types.NestedField.required(10, "payload_json", Types.StringType.get()),
-            Types.NestedField.required(11, "tx_hash", Types.StringType.get()));
+  private static final Schema CHAIN_TX_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "event_id", Types.StringType.get()),
+          Types.NestedField.required(2, "event_time", Types.TimestampType.withZone()),
+          Types.NestedField.required(3, "ingest_time", Types.TimestampType.withZone()),
+          Types.NestedField.optional(4, "schema_version", Types.StringType.get()),
+          Types.NestedField.optional(5, "flow_id", Types.StringType.get()),
+          Types.NestedField.optional(6, "correlation_id", Types.StringType.get()),
+          Types.NestedField.optional(7, "trace_id", Types.StringType.get()),
+          Types.NestedField.required(8, "topic", Types.StringType.get()),
+          Types.NestedField.optional(9, "key", Types.StringType.get()),
+          Types.NestedField.required(10, "payload_json", Types.StringType.get()),
+          Types.NestedField.required(11, "tx_hash", Types.StringType.get()));
 
-    private static final PartitionSpec CHAIN_TX_PARTITION_SPEC = PartitionSpec.builderFor(CHAIN_TX_SCHEMA)
-            .day("event_time")
-            .bucket("tx_hash", 8)
-            .build();
+  private static final PartitionSpec CHAIN_TX_PARTITION_SPEC =
+      PartitionSpec.builderFor(CHAIN_TX_SCHEMA).day("event_time").bucket("tx_hash", 8).build();
 
-    private CatalogLoader createCatalogLoader() {
-        return CatalogLoader.custom(
-                IcebergCatalogConfig.CATALOG_NAME,
-                IcebergCatalogConfig.catalogProperties(),
-                new org.apache.hadoop.conf.Configuration(),
-                "org.apache.iceberg.jdbc.JdbcCatalog");
+  private CatalogLoader createCatalogLoader() {
+    return CatalogLoader.custom(
+        IcebergCatalogConfig.CATALOG_NAME,
+        IcebergCatalogConfig.catalogProperties(),
+        new org.apache.hadoop.conf.Configuration(),
+        "org.apache.iceberg.jdbc.JdbcCatalog");
+  }
+
+  public void ensureTablesExist() {
+    var catalog = createCatalogLoader().loadCatalog();
+    var namespace = Namespace.of(IcebergCatalogConfig.RAW_NAMESPACE);
+
+    for (var tableName : IcebergCatalogConfig.RAW_TABLES) {
+      var tableId = TableIdentifier.of(namespace, tableName);
+      if (!catalog.tableExists(tableId)) {
+        var isChainTx = "raw_chain_transaction".equals(tableName);
+        var schema = isChainTx ? CHAIN_TX_SCHEMA : COMMON_SCHEMA;
+        var spec = isChainTx ? CHAIN_TX_PARTITION_SPEC : DEFAULT_PARTITION_SPEC;
+
+        catalog.createTable(
+            tableId,
+            schema,
+            spec,
+            Map.of(
+                "format-version", "2",
+                "write.parquet.compression-codec", "zstd"));
+        log.info("Created Iceberg table: {}", tableId);
+      }
     }
+  }
 
-    public void ensureTablesExist() {
-        var catalog = createCatalogLoader().loadCatalog();
-        var namespace = Namespace.of(IcebergCatalogConfig.RAW_NAMESPACE);
+  public void addSink(DataStream<RowData> stream, String tableName) {
+    var tableId = TableIdentifier.of(Namespace.of(IcebergCatalogConfig.RAW_NAMESPACE), tableName);
+    var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
 
-        for (var tableName : IcebergCatalogConfig.RAW_TABLES) {
-            var tableId = TableIdentifier.of(namespace, tableName);
-            if (!catalog.tableExists(tableId)) {
-                var isChainTx = "raw_chain_transaction".equals(tableName);
-                var schema = isChainTx ? CHAIN_TX_SCHEMA : COMMON_SCHEMA;
-                var spec = isChainTx ? CHAIN_TX_PARTITION_SPEC : DEFAULT_PARTITION_SPEC;
-
-                catalog.createTable(tableId, schema, spec, Map.of(
-                        "format-version", "2",
-                        "write.parquet.compression-codec", "zstd"));
-                log.info("Created Iceberg table: {}", tableId);
-            }
-        }
-    }
-
-    public void addSink(DataStream<RowData> stream, String tableName) {
-        var tableId = TableIdentifier.of(
-                Namespace.of(IcebergCatalogConfig.RAW_NAMESPACE), tableName);
-        var tableLoader = TableLoader.fromCatalog(createCatalogLoader(), tableId);
-
-        FlinkSink.forRowData(stream)
-                .tableLoader(tableLoader)
-                .append();
-    }
+    FlinkSink.forRowData(stream).tableLoader(tableLoader).append();
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchAsyncSink.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchAsyncSink.java
@@ -1,26 +1,24 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 
-import io.stablepay.flink.model.ValidatedEvent;
-import lombok.RequiredArgsConstructor;
-
 @RequiredArgsConstructor
 public class OpenSearchAsyncSink implements Sink<ValidatedEvent> {
 
-    private final String opensearchUrl;
-    private final String indexName;
+  private final String opensearchUrl;
+  private final String indexName;
 
-    public OpenSearchAsyncSink(String opensearchUrl) {
-        this(opensearchUrl, "transactions-write");
-    }
+  public OpenSearchAsyncSink(String opensearchUrl) {
+    this(opensearchUrl, "transactions-write");
+  }
 
-    @Override
-    public SinkWriter<ValidatedEvent> createWriter(WriterInitContext context) throws IOException {
-        return new OpenSearchSinkWriter(opensearchUrl, indexName);
-    }
+  @Override
+  public SinkWriter<ValidatedEvent> createWriter(WriterInitContext context) throws IOException {
+    return new OpenSearchSinkWriter(opensearchUrl, indexName);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchBulkWriter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchBulkWriter.java
@@ -4,110 +4,113 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.BulkResponse;
-import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
 
 @Slf4j
 @RequiredArgsConstructor
 public class OpenSearchBulkWriter {
 
-    private static final int MAX_DOCS = 1000;
-    private static final long MAX_SIZE_BYTES = 5L * 1024 * 1024;
-    private static final int MAX_RETRIES = 3;
+  private static final int MAX_DOCS = 1000;
+  private static final long MAX_SIZE_BYTES = 5L * 1024 * 1024;
+  private static final int MAX_RETRIES = 3;
 
-    private final OpenSearchClient client;
-    private final String indexName;
-    private final List<BulkAction> buffer = new ArrayList<>();
-    private long currentSizeEstimate;
+  private final OpenSearchClient client;
+  private final String indexName;
+  private final List<BulkAction> buffer = new ArrayList<>();
+  private long currentSizeEstimate;
 
-    public void add(String eventId, Map<String, Object> document) throws IOException {
-        buffer.add(new BulkAction(eventId, document));
-        currentSizeEstimate += estimateSize(document);
+  public void add(String eventId, Map<String, Object> document) throws IOException {
+    buffer.add(new BulkAction(eventId, document));
+    currentSizeEstimate += estimateSize(document);
 
-        if (buffer.size() >= MAX_DOCS || currentSizeEstimate >= MAX_SIZE_BYTES) {
-            flush();
-        }
+    if (buffer.size() >= MAX_DOCS || currentSizeEstimate >= MAX_SIZE_BYTES) {
+      flush();
+    }
+  }
+
+  public boolean shouldFlush() {
+    return !buffer.isEmpty();
+  }
+
+  public BulkResult flush() throws IOException {
+    if (buffer.isEmpty()) {
+      return new BulkResult(List.of());
     }
 
-    public boolean shouldFlush() {
-        return !buffer.isEmpty();
-    }
+    var permanentFailures = new ArrayList<BulkResult.FailedDoc>();
+    var pending = new ArrayList<>(buffer);
+    buffer.clear();
+    currentSizeEstimate = 0;
 
-    public BulkResult flush() throws IOException {
-        if (buffer.isEmpty()) {
-            return new BulkResult(List.of());
-        }
+    while (!pending.isEmpty()) {
+      var bulkBuilder = new BulkRequest.Builder();
+      for (var action : pending) {
+        bulkBuilder.operations(
+            op ->
+                op.index(
+                    idx -> idx.index(indexName).id(action.eventId()).document(action.document())));
+      }
 
-        var permanentFailures = new ArrayList<BulkResult.FailedDoc>();
-        var pending = new ArrayList<>(buffer);
-        buffer.clear();
-        currentSizeEstimate = 0;
+      var response = client.bulk(bulkBuilder.build());
+      var retryable = new ArrayList<BulkAction>();
 
-        while (!pending.isEmpty()) {
-            var bulkBuilder = new BulkRequest.Builder();
-            for (var action : pending) {
-                bulkBuilder.operations(op -> op
-                        .index(idx -> idx
-                                .index(indexName)
-                                .id(action.eventId())
-                                .document(action.document())));
-            }
+      if (response.errors()) {
+        for (int i = 0; i < response.items().size(); i++) {
+          var item = response.items().get(i);
+          if (item.error() != null) {
+            var status = item.status();
+            var isTransient = status == 429 || status == 503;
+            var original = pending.get(i);
 
-            var response = client.bulk(bulkBuilder.build());
-            var retryable = new ArrayList<BulkAction>();
-
-            if (response.errors()) {
-                for (int i = 0; i < response.items().size(); i++) {
-                    var item = response.items().get(i);
-                    if (item.error() != null) {
-                        var status = item.status();
-                        var isTransient = status == 429 || status == 503;
-                        var original = pending.get(i);
-
-                        if (isTransient && original.retryCount() < MAX_RETRIES) {
-                            retryable.add(original.withRetry());
-                            log.warn("opensearch_transient_failure: eventId={} status={} retry={}/{}",
-                                    item.id(), status, original.retryCount() + 1, MAX_RETRIES);
-                        } else {
-                            permanentFailures.add(BulkResult.FailedDoc.builder()
-                                    .eventId(item.id())
-                                    .statusCode(status)
-                                    .errorType(item.error().type())
-                                    .errorReason(item.error().reason())
-                                    .transient_(isTransient)
-                                    .build());
-                        }
-                    }
-                }
-                log.warn("opensearch_bulk_errors: count={} retryable={} permanent={}",
-                        permanentFailures.size() + retryable.size(), retryable.size(), permanentFailures.size());
-            }
-
-            pending = retryable;
-        }
-
-        return new BulkResult(permanentFailures);
-    }
-
-    private static long estimateSize(Map<String, Object> doc) {
-        var size = 2L;
-        for (var entry : doc.entrySet()) {
-            size += entry.getKey().length() + 4;
-            var val = entry.getValue();
-            if (val instanceof String s) {
-                size += s.length() + 2;
-            } else if (val != null) {
-                size += 20;
+            if (isTransient && original.retryCount() < MAX_RETRIES) {
+              retryable.add(original.withRetry());
+              log.warn(
+                  "opensearch_transient_failure: eventId={} status={} retry={}/{}",
+                  item.id(),
+                  status,
+                  original.retryCount() + 1,
+                  MAX_RETRIES);
             } else {
-                size += 4;
+              permanentFailures.add(
+                  BulkResult.FailedDoc.builder()
+                      .eventId(item.id())
+                      .statusCode(status)
+                      .errorType(item.error().type())
+                      .errorReason(item.error().reason())
+                      .transient_(isTransient)
+                      .build());
             }
+          }
         }
-        return size;
+        log.warn(
+            "opensearch_bulk_errors: count={} retryable={} permanent={}",
+            permanentFailures.size() + retryable.size(),
+            retryable.size(),
+            permanentFailures.size());
+      }
+
+      pending = retryable;
     }
+
+    return new BulkResult(permanentFailures);
+  }
+
+  private static long estimateSize(Map<String, Object> doc) {
+    var size = 2L;
+    for (var entry : doc.entrySet()) {
+      size += entry.getKey().length() + 4;
+      var val = entry.getValue();
+      if (val instanceof String s) {
+        size += s.length() + 2;
+      } else if (val != null) {
+        size += 20;
+      } else {
+        size += 4;
+      }
+    }
+    return size;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchSinkWriter.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/sink/OpenSearchSinkWriter.java
@@ -1,75 +1,80 @@
 package io.stablepay.flink.sink;
 
+import io.stablepay.flink.mapper.EventToOpenSearchDocMapper;
+import io.stablepay.flink.model.ValidatedEvent;
 import java.io.IOException;
-import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.hc.core5.http.HttpHost;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
-import io.stablepay.flink.mapper.EventToOpenSearchDocMapper;
-import io.stablepay.flink.model.ValidatedEvent;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 class OpenSearchSinkWriter implements SinkWriter<ValidatedEvent> {
 
-    private static final long FLUSH_INTERVAL_MS = 5000;
+  private static final long FLUSH_INTERVAL_MS = 5000;
 
-    private final OpenSearchBulkWriter bulkWriter;
-    private long lastFlushTime;
+  private final OpenSearchBulkWriter bulkWriter;
+  private long lastFlushTime;
 
-    OpenSearchSinkWriter(String opensearchUrl, String indexName) {
-        try {
-            var transport = ApacheHttpClient5TransportBuilder
-                    .builder(HttpHost.create(opensearchUrl))
-                    .setMapper(new JacksonJsonpMapper())
-                    .build();
-            this.bulkWriter = new OpenSearchBulkWriter(new OpenSearchClient(transport), indexName);
-            this.lastFlushTime = System.currentTimeMillis();
-        } catch (java.net.URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid OpenSearch URL: " + opensearchUrl, e);
-        }
+  OpenSearchSinkWriter(String opensearchUrl, String indexName) {
+    try {
+      var transport =
+          ApacheHttpClient5TransportBuilder.builder(HttpHost.create(opensearchUrl))
+              .setMapper(new JacksonJsonpMapper())
+              .build();
+      this.bulkWriter = new OpenSearchBulkWriter(new OpenSearchClient(transport), indexName);
+      this.lastFlushTime = System.currentTimeMillis();
+    } catch (java.net.URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid OpenSearch URL: " + opensearchUrl, e);
     }
+  }
 
-    @Override
-    public void write(ValidatedEvent event, Context context) throws IOException, InterruptedException {
-        var doc = EventToOpenSearchDocMapper.toDocument(event);
-        bulkWriter.add(event.eventId(), doc);
+  @Override
+  public void write(ValidatedEvent event, Context context)
+      throws IOException, InterruptedException {
+    var doc = EventToOpenSearchDocMapper.toDocument(event);
+    bulkWriter.add(event.eventId(), doc);
 
-        if (System.currentTimeMillis() - lastFlushTime >= FLUSH_INTERVAL_MS) {
-            flushAndHandleErrors();
-        }
+    if (System.currentTimeMillis() - lastFlushTime >= FLUSH_INTERVAL_MS) {
+      flushAndHandleErrors();
     }
+  }
 
-    @Override
-    public void flush(boolean endOfInput) throws IOException, InterruptedException {
-        if (bulkWriter.shouldFlush()) {
-            flushAndHandleErrors();
-        }
+  @Override
+  public void flush(boolean endOfInput) throws IOException, InterruptedException {
+    if (bulkWriter.shouldFlush()) {
+      flushAndHandleErrors();
     }
+  }
 
-    @Override
-    public void close() throws Exception {
-        if (bulkWriter.shouldFlush()) {
-            flushAndHandleErrors();
-        }
+  @Override
+  public void close() throws Exception {
+    if (bulkWriter.shouldFlush()) {
+      flushAndHandleErrors();
     }
+  }
 
-    private void flushAndHandleErrors() throws IOException {
-        var result = bulkWriter.flush();
-        lastFlushTime = System.currentTimeMillis();
+  private void flushAndHandleErrors() throws IOException {
+    var result = bulkWriter.flush();
+    lastFlushTime = System.currentTimeMillis();
 
-        for (var failed : result.failed()) {
-            if (failed.transient_()) {
-                log.warn("opensearch_transient_failure: eventId={} status={} reason={}",
-                        failed.eventId(), failed.statusCode(), failed.errorReason());
-            } else {
-                log.error("opensearch_permanent_failure: eventId={} status={} type={} reason={}",
-                        failed.eventId(), failed.statusCode(), failed.errorType(), failed.errorReason());
-            }
-        }
+    for (var failed : result.failed()) {
+      if (failed.transient_()) {
+        log.warn(
+            "opensearch_transient_failure: eventId={} status={} reason={}",
+            failed.eventId(),
+            failed.statusCode(),
+            failed.errorReason());
+      } else {
+        log.error(
+            "opensearch_permanent_failure: eventId={} status={} type={} reason={}",
+            failed.eventId(),
+            failed.statusCode(),
+            failed.errorType(),
+            failed.errorReason());
+      }
     }
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/topic/TopicDerivation.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/topic/TopicDerivation.java
@@ -2,17 +2,17 @@ package io.stablepay.flink.topic;
 
 public final class TopicDerivation {
 
-    private TopicDerivation() {}
+  private TopicDerivation() {}
 
-    public static String deriveFlowType(String topic) {
-        if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
-        if (topic.contains("fiat")) return "FIAT";
-        return "MIXED";
-    }
+  public static String deriveFlowType(String topic) {
+    if (topic.contains("crypto") || topic.contains("chain")) return "CRYPTO";
+    if (topic.contains("fiat")) return "FIAT";
+    return "MIXED";
+  }
 
-    public static String deriveDirection(String topic) {
-        if (topic.contains("payin")) return "INBOUND";
-        if (topic.contains("payout")) return "OUTBOUND";
-        return "INTERNAL";
-    }
+  public static String deriveDirection(String topic) {
+    if (topic.contains("payin")) return "INBOUND";
+    if (topic.contains("payout")) return "OUTBOUND";
+    return "INTERNAL";
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/TransitionGraph.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/TransitionGraph.java
@@ -5,121 +5,136 @@ import java.util.Set;
 
 public final class TransitionGraph {
 
-    private TransitionGraph() {}
+  private TransitionGraph() {}
 
-    private static final Map<String, Set<String>> FIAT_PAYOUT = Map.ofEntries(
-            Map.entry("INITIATED", Set.of("PENDING_APPROVAL", "CANCELLED")),
-            Map.entry("PENDING_APPROVAL", Set.of("FIRST_APPROVAL", "CANCELLED", "EXPIRED")),
-            Map.entry("FIRST_APPROVAL", Set.of("PENDING_SECOND_APPROVAL", "APPROVED")),
-            Map.entry("PENDING_SECOND_APPROVAL", Set.of("APPROVED", "CANCELLED", "EXPIRED")),
-            Map.entry("APPROVED", Set.of("PENDING_SCREENING")),
-            Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
-            Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_HOLD", "SCREENING_RFI", "SCREENING_RELEASED", "SCREENING_REJECTED", "SCREENING_SEIZED")),
-            Map.entry("SCREENING_HOLD", Set.of("SCREENING_RELEASED", "SCREENING_REJECTED", "SCREENING_SEIZED")),
-            Map.entry("SCREENING_RFI", Set.of("SCREENING_RELEASED", "SCREENING_REJECTED")),
-            Map.entry("SCREENING_RELEASED", Set.of("PENDING_PARTNER_ROUTING")),
-            Map.entry("SCREENING_REJECTED", Set.of("FAILED", "CONFISCATED")),
-            Map.entry("SCREENING_SEIZED", Set.of("CONFISCATED")),
-            Map.entry("PENDING_PARTNER_ROUTING", Set.of("PARTNER_ASSIGNED")),
-            Map.entry("PARTNER_ASSIGNED", Set.of("PENDING_EXECUTION")),
-            Map.entry("PENDING_EXECUTION", Set.of("EXECUTING")),
-            Map.entry("EXECUTING", Set.of("SENT_TO_PARTNER", "FAILED")),
-            Map.entry("SENT_TO_PARTNER", Set.of("PARTNER_ACKNOWLEDGED", "FAILED")),
-            Map.entry("PARTNER_ACKNOWLEDGED", Set.of("PENDING_CONFIRMATION")),
-            Map.entry("PENDING_CONFIRMATION", Set.of("CONFIRMED", "FAILED")),
-            Map.entry("CONFIRMED", Set.of("COMPLETED")),
-            Map.entry("COMPLETED", Set.of("RETURNED", "REFUND_INITIATED")),
-            Map.entry("FAILED", Set.of("MANUAL_REVIEW", "LEDGER_SUSPENSE")),
-            Map.entry("RETURNED", Set.of()),
-            Map.entry("REFUND_INITIATED", Set.of("REFUND_PENDING")),
-            Map.entry("REFUND_PENDING", Set.of("REFUND_COMPLETED")),
-            Map.entry("REFUND_COMPLETED", Set.of()),
-            Map.entry("CONFISCATED", Set.of()),
-            Map.entry("SUSPENDED", Set.of()),
-            Map.entry("LEDGER_SUSPENSE", Set.of("MANUAL_REVIEW")),
-            Map.entry("MANUAL_REVIEW", Set.of("COMPLETED", "FAILED")),
-            Map.entry("CANCELLED", Set.of()),
-            Map.entry("EXPIRED", Set.of()));
+  private static final Map<String, Set<String>> FIAT_PAYOUT =
+      Map.ofEntries(
+          Map.entry("INITIATED", Set.of("PENDING_APPROVAL", "CANCELLED")),
+          Map.entry("PENDING_APPROVAL", Set.of("FIRST_APPROVAL", "CANCELLED", "EXPIRED")),
+          Map.entry("FIRST_APPROVAL", Set.of("PENDING_SECOND_APPROVAL", "APPROVED")),
+          Map.entry("PENDING_SECOND_APPROVAL", Set.of("APPROVED", "CANCELLED", "EXPIRED")),
+          Map.entry("APPROVED", Set.of("PENDING_SCREENING")),
+          Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
+          Map.entry(
+              "SCREENING_IN_PROGRESS",
+              Set.of(
+                  "SCREENING_HOLD",
+                  "SCREENING_RFI",
+                  "SCREENING_RELEASED",
+                  "SCREENING_REJECTED",
+                  "SCREENING_SEIZED")),
+          Map.entry(
+              "SCREENING_HOLD",
+              Set.of("SCREENING_RELEASED", "SCREENING_REJECTED", "SCREENING_SEIZED")),
+          Map.entry("SCREENING_RFI", Set.of("SCREENING_RELEASED", "SCREENING_REJECTED")),
+          Map.entry("SCREENING_RELEASED", Set.of("PENDING_PARTNER_ROUTING")),
+          Map.entry("SCREENING_REJECTED", Set.of("FAILED", "CONFISCATED")),
+          Map.entry("SCREENING_SEIZED", Set.of("CONFISCATED")),
+          Map.entry("PENDING_PARTNER_ROUTING", Set.of("PARTNER_ASSIGNED")),
+          Map.entry("PARTNER_ASSIGNED", Set.of("PENDING_EXECUTION")),
+          Map.entry("PENDING_EXECUTION", Set.of("EXECUTING")),
+          Map.entry("EXECUTING", Set.of("SENT_TO_PARTNER", "FAILED")),
+          Map.entry("SENT_TO_PARTNER", Set.of("PARTNER_ACKNOWLEDGED", "FAILED")),
+          Map.entry("PARTNER_ACKNOWLEDGED", Set.of("PENDING_CONFIRMATION")),
+          Map.entry("PENDING_CONFIRMATION", Set.of("CONFIRMED", "FAILED")),
+          Map.entry("CONFIRMED", Set.of("COMPLETED")),
+          Map.entry("COMPLETED", Set.of("RETURNED", "REFUND_INITIATED")),
+          Map.entry("FAILED", Set.of("MANUAL_REVIEW", "LEDGER_SUSPENSE")),
+          Map.entry("RETURNED", Set.of()),
+          Map.entry("REFUND_INITIATED", Set.of("REFUND_PENDING")),
+          Map.entry("REFUND_PENDING", Set.of("REFUND_COMPLETED")),
+          Map.entry("REFUND_COMPLETED", Set.of()),
+          Map.entry("CONFISCATED", Set.of()),
+          Map.entry("SUSPENDED", Set.of()),
+          Map.entry("LEDGER_SUSPENSE", Set.of("MANUAL_REVIEW")),
+          Map.entry("MANUAL_REVIEW", Set.of("COMPLETED", "FAILED")),
+          Map.entry("CANCELLED", Set.of()),
+          Map.entry("EXPIRED", Set.of()));
 
-    private static final Map<String, Set<String>> CRYPTO_PAYOUT = Map.ofEntries(
-            Map.entry("INITIATED", Set.of("PENDING_APPROVAL")),
-            Map.entry("PENDING_APPROVAL", Set.of("APPROVED", "CANCELLED")),
-            Map.entry("APPROVED", Set.of("PENDING_SCREENING")),
-            Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
-            Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
-            Map.entry("SCREENING_CLEARED", Set.of("PENDING_SIGNING")),
-            Map.entry("SCREENING_FLAGGED", Set.of("FAILED", "CONFISCATED")),
-            Map.entry("PENDING_SIGNING", Set.of("SIGNING_IN_PROGRESS")),
-            Map.entry("SIGNING_IN_PROGRESS", Set.of("SIGNED", "FAILED")),
-            Map.entry("SIGNED", Set.of("BROADCASTING")),
-            Map.entry("BROADCASTING", Set.of("BROADCAST", "FAILED")),
-            Map.entry("BROADCAST", Set.of("CONFIRMING", "STUCK")),
-            Map.entry("CONFIRMING", Set.of("CONFIRMED")),
-            Map.entry("CONFIRMED", Set.of("COMPLETED")),
-            Map.entry("COMPLETED", Set.of()),
-            Map.entry("STUCK", Set.of("RBF_INITIATED")),
-            Map.entry("RBF_INITIATED", Set.of("RBF_BROADCAST")),
-            Map.entry("RBF_BROADCAST", Set.of("REPLACED", "FAILED")),
-            Map.entry("REPLACED", Set.of("CONFIRMING")),
-            Map.entry("FAILED", Set.of()),
-            Map.entry("CANCELLED", Set.of()),
-            Map.entry("CONFISCATED", Set.of()));
+  private static final Map<String, Set<String>> CRYPTO_PAYOUT =
+      Map.ofEntries(
+          Map.entry("INITIATED", Set.of("PENDING_APPROVAL")),
+          Map.entry("PENDING_APPROVAL", Set.of("APPROVED", "CANCELLED")),
+          Map.entry("APPROVED", Set.of("PENDING_SCREENING")),
+          Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
+          Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
+          Map.entry("SCREENING_CLEARED", Set.of("PENDING_SIGNING")),
+          Map.entry("SCREENING_FLAGGED", Set.of("FAILED", "CONFISCATED")),
+          Map.entry("PENDING_SIGNING", Set.of("SIGNING_IN_PROGRESS")),
+          Map.entry("SIGNING_IN_PROGRESS", Set.of("SIGNED", "FAILED")),
+          Map.entry("SIGNED", Set.of("BROADCASTING")),
+          Map.entry("BROADCASTING", Set.of("BROADCAST", "FAILED")),
+          Map.entry("BROADCAST", Set.of("CONFIRMING", "STUCK")),
+          Map.entry("CONFIRMING", Set.of("CONFIRMED")),
+          Map.entry("CONFIRMED", Set.of("COMPLETED")),
+          Map.entry("COMPLETED", Set.of()),
+          Map.entry("STUCK", Set.of("RBF_INITIATED")),
+          Map.entry("RBF_INITIATED", Set.of("RBF_BROADCAST")),
+          Map.entry("RBF_BROADCAST", Set.of("REPLACED", "FAILED")),
+          Map.entry("REPLACED", Set.of("CONFIRMING")),
+          Map.entry("FAILED", Set.of()),
+          Map.entry("CANCELLED", Set.of()),
+          Map.entry("CONFISCATED", Set.of()));
 
-    private static final Map<String, Set<String>> FIAT_PAYIN = Map.ofEntries(
-            Map.entry("DETECTED", Set.of("PENDING_SCREENING")),
-            Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
-            Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
-            Map.entry("SCREENING_CLEARED", Set.of("MATCHED")),
-            Map.entry("SCREENING_FLAGGED", Set.of("FAILED", "SUSPENDED")),
-            Map.entry("MATCHED", Set.of("PENDING_ALLOCATION")),
-            Map.entry("PENDING_ALLOCATION", Set.of("ALLOCATED")),
-            Map.entry("ALLOCATED", Set.of("COMPLETED")),
-            Map.entry("COMPLETED", Set.of()),
-            Map.entry("FAILED", Set.of()),
-            Map.entry("SUSPENDED", Set.of()),
-            Map.entry("RETURNED", Set.of()),
-            Map.entry("UNMATCHED", Set.of("MATCHED", "RETURNED")));
+  private static final Map<String, Set<String>> FIAT_PAYIN =
+      Map.ofEntries(
+          Map.entry("DETECTED", Set.of("PENDING_SCREENING")),
+          Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
+          Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
+          Map.entry("SCREENING_CLEARED", Set.of("MATCHED")),
+          Map.entry("SCREENING_FLAGGED", Set.of("FAILED", "SUSPENDED")),
+          Map.entry("MATCHED", Set.of("PENDING_ALLOCATION")),
+          Map.entry("PENDING_ALLOCATION", Set.of("ALLOCATED")),
+          Map.entry("ALLOCATED", Set.of("COMPLETED")),
+          Map.entry("COMPLETED", Set.of()),
+          Map.entry("FAILED", Set.of()),
+          Map.entry("SUSPENDED", Set.of()),
+          Map.entry("RETURNED", Set.of()),
+          Map.entry("UNMATCHED", Set.of("MATCHED", "RETURNED")));
 
-    private static final Map<String, Set<String>> CRYPTO_PAYIN = Map.ofEntries(
-            Map.entry("DETECTED", Set.of("PENDING_SCREENING")),
-            Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
-            Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
-            Map.entry("SCREENING_CLEARED", Set.of("CONFIRMING")),
-            Map.entry("SCREENING_FLAGGED", Set.of("FAILED")),
-            Map.entry("CONFIRMING", Set.of("CONFIRMED")),
-            Map.entry("CONFIRMED", Set.of("CREDITED")),
-            Map.entry("CREDITED", Set.of("COMPLETED")),
-            Map.entry("COMPLETED", Set.of()),
-            Map.entry("FAILED", Set.of()),
-            Map.entry("DROPPED", Set.of()));
+  private static final Map<String, Set<String>> CRYPTO_PAYIN =
+      Map.ofEntries(
+          Map.entry("DETECTED", Set.of("PENDING_SCREENING")),
+          Map.entry("PENDING_SCREENING", Set.of("SCREENING_IN_PROGRESS")),
+          Map.entry("SCREENING_IN_PROGRESS", Set.of("SCREENING_CLEARED", "SCREENING_FLAGGED")),
+          Map.entry("SCREENING_CLEARED", Set.of("CONFIRMING")),
+          Map.entry("SCREENING_FLAGGED", Set.of("FAILED")),
+          Map.entry("CONFIRMING", Set.of("CONFIRMED")),
+          Map.entry("CONFIRMED", Set.of("CREDITED")),
+          Map.entry("CREDITED", Set.of("COMPLETED")),
+          Map.entry("COMPLETED", Set.of()),
+          Map.entry("FAILED", Set.of()),
+          Map.entry("DROPPED", Set.of()));
 
-    private static final Map<String, Set<String>> CHAIN_TRANSACTION = Map.ofEntries(
-            Map.entry("PENDING", Set.of("BROADCAST")),
-            Map.entry("BROADCAST", Set.of("CONFIRMING", "STUCK")),
-            Map.entry("CONFIRMING", Set.of("CONFIRMED")),
-            Map.entry("CONFIRMED", Set.of()),
-            Map.entry("FAILED", Set.of()),
-            Map.entry("DROPPED", Set.of()),
-            Map.entry("STUCK", Set.of("RBF_ATTEMPTED")),
-            Map.entry("RBF_ATTEMPTED", Set.of("REPLACED", "FAILED")),
-            Map.entry("REPLACED", Set.of("CONFIRMING")));
+  private static final Map<String, Set<String>> CHAIN_TRANSACTION =
+      Map.ofEntries(
+          Map.entry("PENDING", Set.of("BROADCAST")),
+          Map.entry("BROADCAST", Set.of("CONFIRMING", "STUCK")),
+          Map.entry("CONFIRMING", Set.of("CONFIRMED")),
+          Map.entry("CONFIRMED", Set.of()),
+          Map.entry("FAILED", Set.of()),
+          Map.entry("DROPPED", Set.of()),
+          Map.entry("STUCK", Set.of("RBF_ATTEMPTED")),
+          Map.entry("RBF_ATTEMPTED", Set.of("REPLACED", "FAILED")),
+          Map.entry("REPLACED", Set.of("CONFIRMING")));
 
-    private static final Map<String, Map<String, Set<String>>> ALL_GRAPHS = Map.of(
-            "payment.payout.fiat.v1", FIAT_PAYOUT,
-            "payment.payout.crypto.v1", CRYPTO_PAYOUT,
-            "payment.payin.fiat.v1", FIAT_PAYIN,
-            "payment.payin.crypto.v1", CRYPTO_PAYIN,
-            "chain.transaction.v1", CHAIN_TRANSACTION);
+  private static final Map<String, Map<String, Set<String>>> ALL_GRAPHS =
+      Map.of(
+          "payment.payout.fiat.v1", FIAT_PAYOUT,
+          "payment.payout.crypto.v1", CRYPTO_PAYOUT,
+          "payment.payin.fiat.v1", FIAT_PAYIN,
+          "payment.payin.crypto.v1", CRYPTO_PAYIN,
+          "chain.transaction.v1", CHAIN_TRANSACTION);
 
-    public static boolean isValidTransition(String topic, String fromStatus, String toStatus) {
-        var graph = ALL_GRAPHS.get(topic);
-        if (graph == null) {
-            return true;
-        }
-        var validTargets = graph.get(fromStatus);
-        if (validTargets == null) {
-            return true;
-        }
-        return validTargets.contains(toStatus);
+  public static boolean isValidTransition(String topic, String fromStatus, String toStatus) {
+    var graph = ALL_GRAPHS.get(topic);
+    if (graph == null) {
+      return true;
     }
+    var validTargets = graph.get(fromStatus);
+    if (validTargets == null) {
+      return true;
+    }
+    return validTargets.contains(toStatus);
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/TransitionValidator.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/TransitionValidator.java
@@ -1,57 +1,56 @@
 package io.stablepay.flink.transition;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 public class TransitionValidator {
 
-    private static final String ENV_STRICT_TRANSITIONS = "STBLPAY_FLINK_STRICT_TRANSITIONS";
+  private static final String ENV_STRICT_TRANSITIONS = "STBLPAY_FLINK_STRICT_TRANSITIONS";
 
-    public static boolean isStrictMode() {
-        return "true".equalsIgnoreCase(System.getenv().getOrDefault(ENV_STRICT_TRANSITIONS, "false"));
+  public static boolean isStrictMode() {
+    return "true".equalsIgnoreCase(System.getenv().getOrDefault(ENV_STRICT_TRANSITIONS, "false"));
+  }
+
+  public static ValueStateDescriptor<String> lastStatusDescriptor() {
+    return new ValueStateDescriptor<>("last-status", Types.STRING);
+  }
+
+  public static ValidationOutcome validate(ValueState<String> lastStatusState, ValidatedEvent event)
+      throws Exception {
+    var currentStatus = extractStatus(event);
+    if (currentStatus == null) {
+      return new ValidationOutcome.Valid(null, null);
     }
 
-    public static ValueStateDescriptor<String> lastStatusDescriptor() {
-        return new ValueStateDescriptor<>("last-status", Types.STRING);
+    var lastStatus = lastStatusState.value();
+
+    if (lastStatus == null) {
+      lastStatusState.update(currentStatus);
+      return new ValidationOutcome.FirstEvent(currentStatus);
     }
 
-    public static ValidationOutcome validate(ValueState<String> lastStatusState, ValidatedEvent event)
-            throws Exception {
-        var currentStatus = extractStatus(event);
-        if (currentStatus == null) {
-            return new ValidationOutcome.Valid(null, null);
-        }
-
-        var lastStatus = lastStatusState.value();
-
-        if (lastStatus == null) {
-            lastStatusState.update(currentStatus);
-            return new ValidationOutcome.FirstEvent(currentStatus);
-        }
-
-        if (lastStatus.equals(currentStatus)) {
-            return new ValidationOutcome.Valid(lastStatus, currentStatus);
-        }
-
-        var valid = TransitionGraph.isValidTransition(event.topic(), lastStatus, currentStatus);
-        if (valid) {
-            lastStatusState.update(currentStatus);
-            return new ValidationOutcome.Valid(lastStatus, currentStatus);
-        }
-        return new ValidationOutcome.Invalid(lastStatus, currentStatus);
+    if (lastStatus.equals(currentStatus)) {
+      return new ValidationOutcome.Valid(lastStatus, currentStatus);
     }
 
-    private static String extractStatus(ValidatedEvent event) {
-        var record = event.toRecord();
-        var status = record.get("internal_status");
-        if (status != null) return status.toString();
-        status = record.get("status");
-        if (status != null) return status.toString();
-        status = record.get("flow_status");
-        if (status != null) return status.toString();
-        return null;
+    var valid = TransitionGraph.isValidTransition(event.topic(), lastStatus, currentStatus);
+    if (valid) {
+      lastStatusState.update(currentStatus);
+      return new ValidationOutcome.Valid(lastStatus, currentStatus);
     }
+    return new ValidationOutcome.Invalid(lastStatus, currentStatus);
+  }
+
+  private static String extractStatus(ValidatedEvent event) {
+    var record = event.toRecord();
+    var status = record.get("internal_status");
+    if (status != null) return status.toString();
+    status = record.get("status");
+    if (status != null) return status.toString();
+    status = record.get("flow_status");
+    if (status != null) return status.toString();
+    return null;
+  }
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/ValidationOutcome.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/transition/ValidationOutcome.java
@@ -2,9 +2,9 @@ package io.stablepay.flink.transition;
 
 public sealed interface ValidationOutcome {
 
-    record Valid(String fromStatus, String toStatus) implements ValidationOutcome {}
+  record Valid(String fromStatus, String toStatus) implements ValidationOutcome {}
 
-    record Invalid(String fromStatus, String toStatus) implements ValidationOutcome {}
+  record Invalid(String fromStatus, String toStatus) implements ValidationOutcome {}
 
-    record FirstEvent(String toStatus) implements ValidationOutcome {}
+  record FirstEvent(String toStatus) implements ValidationOutcome {}
 }

--- a/apps/flink-jobs/src/main/java/io/stablepay/flink/watermark/EnvelopeTimestampAssigner.java
+++ b/apps/flink-jobs/src/main/java/io/stablepay/flink/watermark/EnvelopeTimestampAssigner.java
@@ -1,13 +1,12 @@
 package io.stablepay.flink.watermark;
 
-import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
-
 import io.stablepay.flink.model.ValidatedEvent;
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
 
 public class EnvelopeTimestampAssigner implements SerializableTimestampAssigner<ValidatedEvent> {
 
-    @Override
-    public long extractTimestamp(ValidatedEvent event, long recordTimestamp) {
-        return event.eventTimeMillis();
-    }
+  @Override
+  public long extractTimestamp(ValidatedEvent event, long recordTimestamp) {
+    return event.eventTimeMillis();
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/FactFlowsMergeJobTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/FactFlowsMergeJobTest.java
@@ -7,108 +7,108 @@ import org.junit.jupiter.api.Test;
 
 class FactFlowsMergeJobTest {
 
-    @Nested
-    class EscapeSql {
+  @Nested
+  class EscapeSql {
 
-        @Test
-        void shouldEscapeSingleQuotes() {
-            // when
-            var result = FactFlowsMergeJob.escapeSql("it's a test");
+    @Test
+    void shouldEscapeSingleQuotes() {
+      // when
+      var result = FactFlowsMergeJob.escapeSql("it's a test");
 
-            // then
-            assertThat(result).isEqualTo("it''s a test");
-        }
-
-        @Test
-        void shouldReturnEmptyStringForNull() {
-            // when
-            var result = FactFlowsMergeJob.escapeSql(null);
-
-            // then
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void shouldReturnValueUnchangedWhenNoQuotes() {
-            // when
-            var result = FactFlowsMergeJob.escapeSql("jdbc:postgresql://host:5432/db");
-
-            // then
-            assertThat(result).isEqualTo("jdbc:postgresql://host:5432/db");
-        }
-
-        @Test
-        void shouldEscapeMultipleSingleQuotes() {
-            // when
-            var result = FactFlowsMergeJob.escapeSql("a'b'c");
-
-            // then
-            assertThat(result).isEqualTo("a''b''c");
-        }
+      // then
+      assertThat(result).isEqualTo("it''s a test");
     }
 
-    @Nested
-    class BuildInsertOverwriteSql {
+    @Test
+    void shouldReturnEmptyStringForNull() {
+      // when
+      var result = FactFlowsMergeJob.escapeSql(null);
 
-        @Test
-        void shouldTargetFactFlowsTable() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("INSERT OVERWRITE facts.fact_flows");
-        }
-
-        @Test
-        void shouldJoinOnFlowId() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("ON f.flow_id = aggs.flow_id");
-            assertThat(sql).contains("ON f.flow_id = pi.flow_id");
-            assertThat(sql).contains("ON f.flow_id = tr.flow_id");
-            assertThat(sql).contains("ON f.flow_id = po.flow_id");
-        }
-
-        @Test
-        void shouldIncludeBothFiatAndCryptoPayinSources() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("raw.raw_payment_payin_fiat");
-            assertThat(sql).contains("raw.raw_payment_payin_crypto");
-        }
-
-        @Test
-        void shouldIncludeBothFiatAndCryptoPayoutSources() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("raw.raw_payment_payout_fiat");
-            assertThat(sql).contains("raw.raw_payment_payout_crypto");
-        }
-
-        @Test
-        void shouldUseDeterministicRowNumberForLatestRow() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("ROW_NUMBER()");
-            assertThat(sql).contains("ORDER BY event_time DESC");
-            assertThat(sql).doesNotContain("LAST_VALUE");
-        }
-
-        @Test
-        void shouldComputeTotalDurationMs() {
-            // when
-            var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
-
-            // then
-            assertThat(sql).contains("TIMESTAMPDIFF(SECOND, aggs.initiated_at, aggs.completed_at)");
-        }
+      // then
+      assertThat(result).isEmpty();
     }
+
+    @Test
+    void shouldReturnValueUnchangedWhenNoQuotes() {
+      // when
+      var result = FactFlowsMergeJob.escapeSql("jdbc:postgresql://host:5432/db");
+
+      // then
+      assertThat(result).isEqualTo("jdbc:postgresql://host:5432/db");
+    }
+
+    @Test
+    void shouldEscapeMultipleSingleQuotes() {
+      // when
+      var result = FactFlowsMergeJob.escapeSql("a'b'c");
+
+      // then
+      assertThat(result).isEqualTo("a''b''c");
+    }
+  }
+
+  @Nested
+  class BuildInsertOverwriteSql {
+
+    @Test
+    void shouldTargetFactFlowsTable() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("INSERT OVERWRITE facts.fact_flows");
+    }
+
+    @Test
+    void shouldJoinOnFlowId() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("ON f.flow_id = aggs.flow_id");
+      assertThat(sql).contains("ON f.flow_id = pi.flow_id");
+      assertThat(sql).contains("ON f.flow_id = tr.flow_id");
+      assertThat(sql).contains("ON f.flow_id = po.flow_id");
+    }
+
+    @Test
+    void shouldIncludeBothFiatAndCryptoPayinSources() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("raw.raw_payment_payin_fiat");
+      assertThat(sql).contains("raw.raw_payment_payin_crypto");
+    }
+
+    @Test
+    void shouldIncludeBothFiatAndCryptoPayoutSources() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("raw.raw_payment_payout_fiat");
+      assertThat(sql).contains("raw.raw_payment_payout_crypto");
+    }
+
+    @Test
+    void shouldUseDeterministicRowNumberForLatestRow() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("ROW_NUMBER()");
+      assertThat(sql).contains("ORDER BY event_time DESC");
+      assertThat(sql).doesNotContain("LAST_VALUE");
+    }
+
+    @Test
+    void shouldComputeTotalDurationMs() {
+      // when
+      var sql = FactFlowsMergeJob.buildInsertOverwriteSql();
+
+      // then
+      assertThat(sql).contains("TIMESTAMPDIFF(SECOND, aggs.initiated_at, aggs.completed_at)");
+    }
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/DlqSummaryAggregatorTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/DlqSummaryAggregatorTest.java
@@ -2,43 +2,43 @@ package io.stablepay.flink.agg;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.stablepay.flink.model.DlqEnvelope;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.junit.jupiter.api.Test;
 
-import io.stablepay.flink.model.DlqEnvelope;
-
 class DlqSummaryAggregatorTest {
 
-    @Test
-    void shouldCountEventsAndTrackMaxRetry() {
-        // given
-        var aggregator = new DlqSummaryAggregator();
-        var envelope1 = DlqEnvelope.builder()
-                .sourceTopic("payment.payout.fiat.v1")
-                .sourcePartition(0)
-                .sourceOffset(1L)
-                .errorClass("SchemaValidationException")
-                .errorMessage("invalid")
-                .failedAt(1_711_000_000_000L)
-                .retryCount(2)
-                .build();
-        var envelope2 = envelope1.toBuilder().retryCount(5).build();
+  @Test
+  void shouldCountEventsAndTrackMaxRetry() {
+    // given
+    var aggregator = new DlqSummaryAggregator();
+    var envelope1 =
+        DlqEnvelope.builder()
+            .sourceTopic("payment.payout.fiat.v1")
+            .sourcePartition(0)
+            .sourceOffset(1L)
+            .errorClass("SchemaValidationException")
+            .errorMessage("invalid")
+            .failedAt(1_711_000_000_000L)
+            .retryCount(2)
+            .build();
+    var envelope2 = envelope1.toBuilder().retryCount(5).build();
 
-        // when
-        var acc = aggregator.createAccumulator();
-        acc = aggregator.add(envelope1, acc);
-        acc = aggregator.add(envelope2, acc);
-        var result = (GenericRowData) aggregator.getResult(acc);
+    // when
+    var acc = aggregator.createAccumulator();
+    acc = aggregator.add(envelope1, acc);
+    acc = aggregator.add(envelope2, acc);
+    var result = (GenericRowData) aggregator.getResult(acc);
 
-        // then
-        var expected = new GenericRowData(6);
-        expected.setField(0, null);
-        expected.setField(1, null);
-        expected.setField(2, StringData.fromString("SchemaValidationException"));
-        expected.setField(3, StringData.fromString("payment.payout.fiat.v1"));
-        expected.setField(4, 2L);
-        expected.setField(5, 5);
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    var expected = new GenericRowData(6);
+    expected.setField(0, null);
+    expected.setField(1, null);
+    expected.setField(2, StringData.fromString("SchemaValidationException"));
+    expected.setField(3, StringData.fromString("payment.payout.fiat.v1"));
+    expected.setField(4, 2L);
+    expected.setField(5, 5);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/ScreeningOutcomesAggregatorTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/ScreeningOutcomesAggregatorTest.java
@@ -9,27 +9,27 @@ import org.junit.jupiter.api.Test;
 
 class ScreeningOutcomesAggregatorTest {
 
-    @Test
-    void shouldReadAvroFieldsAndComputeAverages() {
-        // given
-        var aggregator = new ScreeningOutcomesAggregator();
-        var event1 = screeningEvent("CLEARED", "ACME", 0.10, 1_000L, 1_500L);
-        var event2 = screeningEvent("CLEARED", "ACME", 0.30, 2_000L, 3_000L);
+  @Test
+  void shouldReadAvroFieldsAndComputeAverages() {
+    // given
+    var aggregator = new ScreeningOutcomesAggregator();
+    var event1 = screeningEvent("CLEARED", "ACME", 0.10, 1_000L, 1_500L);
+    var event2 = screeningEvent("CLEARED", "ACME", 0.30, 2_000L, 3_000L);
 
-        // when
-        var acc = aggregator.createAccumulator();
-        acc = aggregator.add(event1, acc);
-        acc = aggregator.add(event2, acc);
-        var result = (GenericRowData) aggregator.getResult(acc);
+    // when
+    var acc = aggregator.createAccumulator();
+    acc = aggregator.add(event1, acc);
+    acc = aggregator.add(event2, acc);
+    var result = (GenericRowData) aggregator.getResult(acc);
 
-        // then
-        var expected = new GenericRowData(6);
-        expected.setField(0, null);
-        expected.setField(1, StringData.fromString("CLEARED"));
-        expected.setField(2, StringData.fromString("ACME"));
-        expected.setField(3, 2L);
-        expected.setField(4, 750.0);
-        expected.setField(5, 0.20);
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    var expected = new GenericRowData(6);
+    expected.setField(0, null);
+    expected.setField(1, StringData.fromString("CLEARED"));
+    expected.setField(2, StringData.fromString("ACME"));
+    expected.setField(3, 2L);
+    expected.setField(4, 750.0);
+    expected.setField(5, 0.20);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/SuccessRateAggregatorTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/SuccessRateAggregatorTest.java
@@ -9,51 +9,52 @@ import org.junit.jupiter.api.Test;
 
 class SuccessRateAggregatorTest {
 
-    @Test
-    void shouldClassifyTerminalStatusesAndComputeSuccessRate() {
-        // given
-        var aggregator = new SuccessRateAggregator();
-        var completed = fiatPayoutEvent(100L, "USD", "COMPLETED");
-        var failed = fiatPayoutEvent(100L, "USD", "FAILED");
-        var rejected = fiatPayoutEvent(100L, "USD", "REJECTED");
-        var pending = fiatPayoutEvent(100L, "USD", "PENDING");
+  @Test
+  void shouldClassifyTerminalStatusesAndComputeSuccessRate() {
+    // given
+    var aggregator = new SuccessRateAggregator();
+    var completed = fiatPayoutEvent(100L, "USD", "COMPLETED");
+    var failed = fiatPayoutEvent(100L, "USD", "FAILED");
+    var rejected = fiatPayoutEvent(100L, "USD", "REJECTED");
+    var pending = fiatPayoutEvent(100L, "USD", "PENDING");
 
-        // when
-        var acc = aggregator.createAccumulator();
-        for (var event : new io.stablepay.flink.model.ValidatedEvent[] {completed, failed, rejected, pending}) {
-            acc = aggregator.add(event, acc);
-        }
-        var result = (GenericRowData) aggregator.getResult(acc);
-
-        // then
-        var expected = new GenericRowData(7);
-        expected.setField(0, null);
-        expected.setField(1, null);
-        expected.setField(2, StringData.fromString("FIAT"));
-        expected.setField(3, 4L);
-        expected.setField(4, 1L);
-        expected.setField(5, 2L);
-        expected.setField(6, 0.25);
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    // when
+    var acc = aggregator.createAccumulator();
+    for (var event :
+        new io.stablepay.flink.model.ValidatedEvent[] {completed, failed, rejected, pending}) {
+      acc = aggregator.add(event, acc);
     }
+    var result = (GenericRowData) aggregator.getResult(acc);
 
-    @Test
-    void shouldEmitZeroSuccessRateForEmptyAccumulator() {
-        // given
-        var aggregator = new SuccessRateAggregator();
+    // then
+    var expected = new GenericRowData(7);
+    expected.setField(0, null);
+    expected.setField(1, null);
+    expected.setField(2, StringData.fromString("FIAT"));
+    expected.setField(3, 4L);
+    expected.setField(4, 1L);
+    expected.setField(5, 2L);
+    expected.setField(6, 0.25);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
 
-        // when
-        var result = (GenericRowData) aggregator.getResult(aggregator.createAccumulator());
+  @Test
+  void shouldEmitZeroSuccessRateForEmptyAccumulator() {
+    // given
+    var aggregator = new SuccessRateAggregator();
 
-        // then
-        var expected = new GenericRowData(7);
-        expected.setField(0, null);
-        expected.setField(1, null);
-        expected.setField(2, StringData.fromString("UNKNOWN"));
-        expected.setField(3, 0L);
-        expected.setField(4, 0L);
-        expected.setField(5, 0L);
-        expected.setField(6, 0.0);
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // when
+    var result = (GenericRowData) aggregator.getResult(aggregator.createAccumulator());
+
+    // then
+    var expected = new GenericRowData(7);
+    expected.setField(0, null);
+    expected.setField(1, null);
+    expected.setField(2, StringData.fromString("UNKNOWN"));
+    expected.setField(3, 0L);
+    expected.setField(4, 0L);
+    expected.setField(5, 0L);
+    expected.setField(6, 0.0);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/VolumeAggregatorTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/agg/VolumeAggregatorTest.java
@@ -9,51 +9,52 @@ import org.junit.jupiter.api.Test;
 
 class VolumeAggregatorTest {
 
-    @Test
-    void shouldAggregateAmountAndCountAcrossEvents() {
-        // given
-        var aggregator = new VolumeAggregator();
-        var event1 = fiatPayoutEvent(1_000_000L, "USD", "COMPLETED");
-        var event2 = fiatPayoutEvent(2_500_000L, "USD", "FAILED");
+  @Test
+  void shouldAggregateAmountAndCountAcrossEvents() {
+    // given
+    var aggregator = new VolumeAggregator();
+    var event1 = fiatPayoutEvent(1_000_000L, "USD", "COMPLETED");
+    var event2 = fiatPayoutEvent(2_500_000L, "USD", "FAILED");
 
-        // when
-        var acc = aggregator.createAccumulator();
-        acc = aggregator.add(event1, acc);
-        acc = aggregator.add(event2, acc);
-        var result = (GenericRowData) aggregator.getResult(acc);
+    // when
+    var acc = aggregator.createAccumulator();
+    acc = aggregator.add(event1, acc);
+    acc = aggregator.add(event2, acc);
+    var result = (GenericRowData) aggregator.getResult(acc);
 
-        // then
-        var expected = new GenericRowData(7);
-        expected.setField(0, null);
-        expected.setField(1, null);
-        expected.setField(2, StringData.fromString("FIAT"));
-        expected.setField(3, StringData.fromString("OUTBOUND"));
-        expected.setField(4, StringData.fromString("USD"));
-        expected.setField(5, 3_500_000L);
-        expected.setField(6, 2L);
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    var expected = new GenericRowData(7);
+    expected.setField(0, null);
+    expected.setField(1, null);
+    expected.setField(2, StringData.fromString("FIAT"));
+    expected.setField(3, StringData.fromString("OUTBOUND"));
+    expected.setField(4, StringData.fromString("USD"));
+    expected.setField(5, 3_500_000L);
+    expected.setField(6, 2L);
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
 
-    @Test
-    void shouldMergeAccumulatorsAndPreferKnownKeyingFields() {
-        // given
-        var aggregator = new VolumeAggregator();
-        var populated = aggregator.add(
-                fiatPayoutEvent(1_000_000L, "EUR", "COMPLETED"),
-                aggregator.createAccumulator());
-        var empty = aggregator.createAccumulator();
+  @Test
+  void shouldMergeAccumulatorsAndPreferKnownKeyingFields() {
+    // given
+    var aggregator = new VolumeAggregator();
+    var populated =
+        aggregator.add(
+            fiatPayoutEvent(1_000_000L, "EUR", "COMPLETED"), aggregator.createAccumulator());
+    var empty = aggregator.createAccumulator();
 
-        // when
-        var merged = aggregator.merge(empty, populated);
+    // when
+    var merged = aggregator.merge(empty, populated);
 
-        // then
-        var expected = VolumeAccumulator.builder()
-                .totalAmountMicros(1_000_000L)
-                .transactionCount(1L)
-                .flowType("FIAT")
-                .direction("OUTBOUND")
-                .currencyCode("EUR")
-                .build();
-        assertThat(merged).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    var expected =
+        VolumeAccumulator.builder()
+            .totalAmountMicros(1_000_000L)
+            .transactionCount(1L)
+            .flowType("FIAT")
+            .direction("OUTBOUND")
+            .currencyCode("EUR")
+            .build();
+    assertThat(merged).usingRecursiveComparison().isEqualTo(expected);
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/deser/DlqDeserializerTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/deser/DlqDeserializerTest.java
@@ -2,89 +2,107 @@ package io.stablepay.flink.deser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.flink.model.DlqEnvelope;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
 
-import io.stablepay.flink.model.DlqEnvelope;
-
 class DlqDeserializerTest {
 
-    @Test
-    void shouldDeserializeJsonPayloadIntoDlqEnvelope() throws Exception {
-        // given
-        var deserializer = new DlqDeserializer();
-        var payload = new ObjectMapper().writeValueAsBytes(java.util.Map.of(
-                "source_topic", "payment.payout.fiat.v1",
-                "source_partition", 3,
-                "source_offset", 42L,
-                "error_class", "SchemaValidationException",
-                "error_message", "invalid",
-                "failed_at", 1_711_000_000_000L,
-                "retry_count", 2));
-        var record = new ConsumerRecord<byte[], byte[]>("dlq.schema-invalid.v1", 0, 0L, null, payload);
-        var collected = new ArrayList<DlqEnvelope>();
-        Collector<DlqEnvelope> collector = collectingCollector(collected);
+  @Test
+  void shouldDeserializeJsonPayloadIntoDlqEnvelope() throws Exception {
+    // given
+    var deserializer = new DlqDeserializer();
+    var payload =
+        new ObjectMapper()
+            .writeValueAsBytes(
+                java.util.Map.of(
+                    "source_topic",
+                    "payment.payout.fiat.v1",
+                    "source_partition",
+                    3,
+                    "source_offset",
+                    42L,
+                    "error_class",
+                    "SchemaValidationException",
+                    "error_message",
+                    "invalid",
+                    "failed_at",
+                    1_711_000_000_000L,
+                    "retry_count",
+                    2));
+    var record = new ConsumerRecord<byte[], byte[]>("dlq.schema-invalid.v1", 0, 0L, null, payload);
+    var collected = new ArrayList<DlqEnvelope>();
+    Collector<DlqEnvelope> collector = collectingCollector(collected);
 
-        // when
-        deserializer.deserialize(record, collector);
+    // when
+    deserializer.deserialize(record, collector);
 
-        // then
-        var expected = DlqEnvelope.builder()
-                .sourceTopic("payment.payout.fiat.v1")
-                .sourcePartition(3)
-                .sourceOffset(42L)
-                .errorClass("SchemaValidationException")
-                .errorMessage("invalid")
-                .failedAt(1_711_000_000_000L)
-                .retryCount(2)
-                .build();
-        assertThat(collected).usingRecursiveFieldByFieldElementComparator().containsExactly(expected);
-    }
+    // then
+    var expected =
+        DlqEnvelope.builder()
+            .sourceTopic("payment.payout.fiat.v1")
+            .sourcePartition(3)
+            .sourceOffset(42L)
+            .errorClass("SchemaValidationException")
+            .errorMessage("invalid")
+            .failedAt(1_711_000_000_000L)
+            .retryCount(2)
+            .build();
+    assertThat(collected).usingRecursiveFieldByFieldElementComparator().containsExactly(expected);
+  }
 
-    @Test
-    void shouldEmitFallbackEnvelopeWhenPayloadIsNotValidJson() throws Exception {
-        // given
-        var deserializer = new DlqDeserializer();
-        var payload = "not-json".getBytes();
-        var record = new ConsumerRecord<byte[], byte[]>(
-                "dlq.schema-invalid.v1", 5, 99L, 1_711_500_000_000L,
-                org.apache.kafka.common.record.TimestampType.CREATE_TIME,
-                0, payload.length, null, payload,
-                new org.apache.kafka.common.header.internals.RecordHeaders(), java.util.Optional.empty());
-        var collected = new ArrayList<DlqEnvelope>();
-        Collector<DlqEnvelope> collector = collectingCollector(collected);
+  @Test
+  void shouldEmitFallbackEnvelopeWhenPayloadIsNotValidJson() throws Exception {
+    // given
+    var deserializer = new DlqDeserializer();
+    var payload = "not-json".getBytes();
+    var record =
+        new ConsumerRecord<byte[], byte[]>(
+            "dlq.schema-invalid.v1",
+            5,
+            99L,
+            1_711_500_000_000L,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME,
+            0,
+            payload.length,
+            null,
+            payload,
+            new org.apache.kafka.common.header.internals.RecordHeaders(),
+            java.util.Optional.empty());
+    var collected = new ArrayList<DlqEnvelope>();
+    Collector<DlqEnvelope> collector = collectingCollector(collected);
 
-        // when
-        deserializer.deserialize(record, collector);
+    // when
+    deserializer.deserialize(record, collector);
 
-        // then
-        var expected = DlqEnvelope.builder()
-                .sourceTopic("dlq.schema-invalid.v1")
-                .sourcePartition(5)
-                .sourceOffset(99L)
-                .errorClass(DlqDeserializer.DESERIALIZATION_FAILED)
-                .errorMessage("JsonParseException")
-                .originalPayloadBytes(payload)
-                .failedAt(1_711_500_000_000L)
-                .retryCount(0)
-                .build();
-        assertThat(collected).usingRecursiveFieldByFieldElementComparator().containsExactly(expected);
-    }
+    // then
+    var expected =
+        DlqEnvelope.builder()
+            .sourceTopic("dlq.schema-invalid.v1")
+            .sourcePartition(5)
+            .sourceOffset(99L)
+            .errorClass(DlqDeserializer.DESERIALIZATION_FAILED)
+            .errorMessage("JsonParseException")
+            .originalPayloadBytes(payload)
+            .failedAt(1_711_500_000_000L)
+            .retryCount(0)
+            .build();
+    assertThat(collected).usingRecursiveFieldByFieldElementComparator().containsExactly(expected);
+  }
 
-    private static Collector<DlqEnvelope> collectingCollector(List<DlqEnvelope> sink) {
-        return new Collector<>() {
-            @Override
-            public void collect(DlqEnvelope record) {
-                sink.add(record);
-            }
+  private static Collector<DlqEnvelope> collectingCollector(List<DlqEnvelope> sink) {
+    return new Collector<>() {
+      @Override
+      public void collect(DlqEnvelope record) {
+        sink.add(record);
+      }
 
-            @Override
-            public void close() {}
-        };
-    }
+      @Override
+      public void close() {}
+    };
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/AggFixtures.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/AggFixtures.java
@@ -1,85 +1,113 @@
 package io.stablepay.flink.fixtures;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class AggFixtures {
 
-    public static final long SOME_EVENT_TIME_MILLIS = 1_711_000_000_000L;
-    public static final long SOME_INGEST_TIME_MILLIS = 1_711_000_000_500L;
-    public static final String SOME_EVENT_ID = "evt-001";
-    public static final String SOME_FLOW_ID = "flow-001";
-    public static final String SOME_SCHEMA_VERSION = "1.0.0";
+  public static final long SOME_EVENT_TIME_MILLIS = 1_711_000_000_000L;
+  public static final long SOME_INGEST_TIME_MILLIS = 1_711_000_000_500L;
+  public static final String SOME_EVENT_ID = "evt-001";
+  public static final String SOME_FLOW_ID = "flow-001";
+  public static final String SOME_SCHEMA_VERSION = "1.0.0";
 
-    private static final Schema MONEY_SCHEMA = SchemaBuilder.money();
-    private static final Schema ENVELOPE_SCHEMA = SchemaBuilder.envelope();
-    private static final Schema PAYOUT_FIAT_SCHEMA = SchemaBuilder.payoutFiat(ENVELOPE_SCHEMA, MONEY_SCHEMA);
-    private static final Schema PAYOUT_CRYPTO_SCHEMA = SchemaBuilder.payoutCrypto(ENVELOPE_SCHEMA, MONEY_SCHEMA);
-    private static final Schema SCREENING_SCHEMA = SchemaBuilder.screening(ENVELOPE_SCHEMA);
+  private static final Schema MONEY_SCHEMA = SchemaBuilder.money();
+  private static final Schema ENVELOPE_SCHEMA = SchemaBuilder.envelope();
+  private static final Schema PAYOUT_FIAT_SCHEMA =
+      SchemaBuilder.payoutFiat(ENVELOPE_SCHEMA, MONEY_SCHEMA);
+  private static final Schema PAYOUT_CRYPTO_SCHEMA =
+      SchemaBuilder.payoutCrypto(ENVELOPE_SCHEMA, MONEY_SCHEMA);
+  private static final Schema SCREENING_SCHEMA = SchemaBuilder.screening(ENVELOPE_SCHEMA);
 
-    private AggFixtures() {}
+  private AggFixtures() {}
 
-    public static ValidatedEvent fiatPayoutEvent(long amountMicros, String currency, String internalStatus) {
-        var envelope = envelope();
-        var money = new GenericRecordBuilder(MONEY_SCHEMA)
-                .set("amount_micros", amountMicros)
-                .set("currency_code", currency)
-                .build();
-        var record = new GenericRecordBuilder(PAYOUT_FIAT_SCHEMA)
-                .set("envelope", envelope)
-                .set("amount", money)
-                .set("internal_status", internalStatus)
-                .build();
-        return ValidatedEvent.fromRecord(
-                "payment.payout.fiat.v1", 0, 0L, "key-1", record,
-                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
-    }
+  public static ValidatedEvent fiatPayoutEvent(
+      long amountMicros, String currency, String internalStatus) {
+    var envelope = envelope();
+    var money =
+        new GenericRecordBuilder(MONEY_SCHEMA)
+            .set("amount_micros", amountMicros)
+            .set("currency_code", currency)
+            .build();
+    var record =
+        new GenericRecordBuilder(PAYOUT_FIAT_SCHEMA)
+            .set("envelope", envelope)
+            .set("amount", money)
+            .set("internal_status", internalStatus)
+            .build();
+    return ValidatedEvent.fromRecord(
+        "payment.payout.fiat.v1",
+        0,
+        0L,
+        "key-1",
+        record,
+        SOME_EVENT_ID,
+        SOME_EVENT_TIME_MILLIS,
+        SOME_FLOW_ID,
+        SOME_SCHEMA_VERSION);
+  }
 
-    public static ValidatedEvent cryptoPayinEvent(long amountMicros, String currency) {
-        var envelope = envelope();
-        var money = new GenericRecordBuilder(MONEY_SCHEMA)
-                .set("amount_micros", amountMicros)
-                .set("currency_code", currency)
-                .build();
-        var record = new GenericRecordBuilder(PAYOUT_CRYPTO_SCHEMA)
-                .set("envelope", envelope)
-                .set("amount", money)
-                .set("internal_status", "PENDING")
-                .build();
-        return ValidatedEvent.fromRecord(
-                "payment.payin.crypto.v1", 0, 0L, "key-1", record,
-                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
-    }
+  public static ValidatedEvent cryptoPayinEvent(long amountMicros, String currency) {
+    var envelope = envelope();
+    var money =
+        new GenericRecordBuilder(MONEY_SCHEMA)
+            .set("amount_micros", amountMicros)
+            .set("currency_code", currency)
+            .build();
+    var record =
+        new GenericRecordBuilder(PAYOUT_CRYPTO_SCHEMA)
+            .set("envelope", envelope)
+            .set("amount", money)
+            .set("internal_status", "PENDING")
+            .build();
+    return ValidatedEvent.fromRecord(
+        "payment.payin.crypto.v1",
+        0,
+        0L,
+        "key-1",
+        record,
+        SOME_EVENT_ID,
+        SOME_EVENT_TIME_MILLIS,
+        SOME_FLOW_ID,
+        SOME_SCHEMA_VERSION);
+  }
 
-    public static ValidatedEvent screeningEvent(String outcome, String provider, double riskScore,
-            long eventTime, long ingestTime) {
-        var envelope = envelope(eventTime, ingestTime);
-        var record = new GenericRecordBuilder(SCREENING_SCHEMA)
-                .set("envelope", envelope)
-                .set("outcome", outcome)
-                .set("provider", provider)
-                .set("risk_score", riskScore)
-                .build();
-        return ValidatedEvent.fromRecord(
-                "screening.result.v1", 0, 0L, "key-1", record,
-                SOME_EVENT_ID, eventTime, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
-    }
+  public static ValidatedEvent screeningEvent(
+      String outcome, String provider, double riskScore, long eventTime, long ingestTime) {
+    var envelope = envelope(eventTime, ingestTime);
+    var record =
+        new GenericRecordBuilder(SCREENING_SCHEMA)
+            .set("envelope", envelope)
+            .set("outcome", outcome)
+            .set("provider", provider)
+            .set("risk_score", riskScore)
+            .build();
+    return ValidatedEvent.fromRecord(
+        "screening.result.v1",
+        0,
+        0L,
+        "key-1",
+        record,
+        SOME_EVENT_ID,
+        eventTime,
+        SOME_FLOW_ID,
+        SOME_SCHEMA_VERSION);
+  }
 
-    private static GenericRecord envelope() {
-        return envelope(SOME_EVENT_TIME_MILLIS, SOME_INGEST_TIME_MILLIS);
-    }
+  private static GenericRecord envelope() {
+    return envelope(SOME_EVENT_TIME_MILLIS, SOME_INGEST_TIME_MILLIS);
+  }
 
-    private static GenericRecord envelope(long eventTime, long ingestTime) {
-        var rec = new GenericData.Record(ENVELOPE_SCHEMA);
-        rec.put("event_id", SOME_EVENT_ID);
-        rec.put("event_time", eventTime);
-        rec.put("ingest_time", ingestTime);
-        rec.put("schema_version", SOME_SCHEMA_VERSION);
-        rec.put("flow_id", SOME_FLOW_ID);
-        return rec;
-    }
+  private static GenericRecord envelope(long eventTime, long ingestTime) {
+    var rec = new GenericData.Record(ENVELOPE_SCHEMA);
+    rec.put("event_id", SOME_EVENT_ID);
+    rec.put("event_time", eventTime);
+    rec.put("ingest_time", ingestTime);
+    rec.put("schema_version", SOME_SCHEMA_VERSION);
+    rec.put("flow_id", SOME_FLOW_ID);
+    return rec;
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/FactFixtures.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/FactFixtures.java
@@ -1,120 +1,136 @@
 package io.stablepay.flink.fixtures;
 
+import io.stablepay.flink.model.ValidatedEvent;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 
-import io.stablepay.flink.model.ValidatedEvent;
-
 public final class FactFixtures {
 
-    public static final long SOME_EVENT_TIME_MILLIS = 1_711_000_000_000L;
-    public static final long SOME_INGEST_TIME_MILLIS = 1_711_000_000_500L;
-    public static final String SOME_EVENT_ID = "evt-fact-001";
-    public static final String SOME_FLOW_ID = "flow-fact-001";
-    public static final String SOME_SCHEMA_VERSION = "1.0.0";
-    public static final String SOME_CUSTOMER_ID = "cust-a1b2c3d4-e5f6-7890";
-    public static final String SOME_ACCOUNT_ID = "acc-x1y2z3w4-5678-9012";
-    public static final String SOME_CORRELATION_ID = "corr-001";
-    public static final String SOME_TRACE_ID = "trace-001";
+  public static final long SOME_EVENT_TIME_MILLIS = 1_711_000_000_000L;
+  public static final long SOME_INGEST_TIME_MILLIS = 1_711_000_000_500L;
+  public static final String SOME_EVENT_ID = "evt-fact-001";
+  public static final String SOME_FLOW_ID = "flow-fact-001";
+  public static final String SOME_SCHEMA_VERSION = "1.0.0";
+  public static final String SOME_CUSTOMER_ID = "cust-a1b2c3d4-e5f6-7890";
+  public static final String SOME_ACCOUNT_ID = "acc-x1y2z3w4-5678-9012";
+  public static final String SOME_CORRELATION_ID = "corr-001";
+  public static final String SOME_TRACE_ID = "trace-001";
 
-    private static final Schema MONEY_SCHEMA = SchemaBuilder.money();
-    private static final Schema ENVELOPE_SCHEMA = SchemaBuilder.envelope();
-    private static final Schema PARTY_SCHEMA = SchemaBuilder.party();
-    private static final Schema PAYOUT_FIAT_SCHEMA =
-            SchemaBuilder.payoutFiat(ENVELOPE_SCHEMA, MONEY_SCHEMA, PARTY_SCHEMA);
-    private static final Schema SCREENING_SCHEMA =
-            SchemaBuilder.screeningResult(ENVELOPE_SCHEMA);
+  private static final Schema MONEY_SCHEMA = SchemaBuilder.money();
+  private static final Schema ENVELOPE_SCHEMA = SchemaBuilder.envelope();
+  private static final Schema PARTY_SCHEMA = SchemaBuilder.party();
+  private static final Schema PAYOUT_FIAT_SCHEMA =
+      SchemaBuilder.payoutFiat(ENVELOPE_SCHEMA, MONEY_SCHEMA, PARTY_SCHEMA);
+  private static final Schema SCREENING_SCHEMA = SchemaBuilder.screeningResult(ENVELOPE_SCHEMA);
 
-    private FactFixtures() {}
+  private FactFixtures() {}
 
-    public static ValidatedEvent fiatPayoutEvent(
-            long amountMicros, String currency, String internalStatus) {
-        var envelope = envelope(SOME_CORRELATION_ID, SOME_TRACE_ID);
-        var money = money(amountMicros, currency);
-        var beneficiary = party("Jane Beneficiary");
-        var sender = party("John Sender");
+  public static ValidatedEvent fiatPayoutEvent(
+      long amountMicros, String currency, String internalStatus) {
+    var envelope = envelope(SOME_CORRELATION_ID, SOME_TRACE_ID);
+    var money = money(amountMicros, currency);
+    var beneficiary = party("Jane Beneficiary");
+    var sender = party("John Sender");
 
-        var record = new GenericRecordBuilder(PAYOUT_FIAT_SCHEMA)
-                .set("envelope", envelope)
-                .set("customer_id", SOME_CUSTOMER_ID)
-                .set("account_id", SOME_ACCOUNT_ID)
-                .set("amount", money)
-                .set("fee", null)
-                .set("source_amount", null)
-                .set("target_amount", null)
-                .set("fx_rate", null)
-                .set("internal_status", internalStatus)
-                .set("customer_status", "PROCESSING")
-                .set("screening_outcome", null)
-                .set("payout_reference", "PAY-REF-001")
-                .set("is_user_facing", null)
-                .set("chain", null)
-                .set("asset", null)
-                .set("source_address", null)
-                .set("destination_address", null)
-                .set("tx_hash", null)
-                .set("confirmations", null)
-                .set("gas_fee_micros", null)
-                .set("block_number", null)
-                .set("block_timestamp", null)
-                .set("provider", "provider-x")
-                .set("route", "route-1")
-                .set("beneficiary", beneficiary)
-                .set("sender", sender)
-                .set("description", "Payment to vendor")
-                .set("notes", "Monthly invoice")
-                .build();
+    var record =
+        new GenericRecordBuilder(PAYOUT_FIAT_SCHEMA)
+            .set("envelope", envelope)
+            .set("customer_id", SOME_CUSTOMER_ID)
+            .set("account_id", SOME_ACCOUNT_ID)
+            .set("amount", money)
+            .set("fee", null)
+            .set("source_amount", null)
+            .set("target_amount", null)
+            .set("fx_rate", null)
+            .set("internal_status", internalStatus)
+            .set("customer_status", "PROCESSING")
+            .set("screening_outcome", null)
+            .set("payout_reference", "PAY-REF-001")
+            .set("is_user_facing", null)
+            .set("chain", null)
+            .set("asset", null)
+            .set("source_address", null)
+            .set("destination_address", null)
+            .set("tx_hash", null)
+            .set("confirmations", null)
+            .set("gas_fee_micros", null)
+            .set("block_number", null)
+            .set("block_timestamp", null)
+            .set("provider", "provider-x")
+            .set("route", "route-1")
+            .set("beneficiary", beneficiary)
+            .set("sender", sender)
+            .set("description", "Payment to vendor")
+            .set("notes", "Monthly invoice")
+            .build();
 
-        return ValidatedEvent.fromRecord(
-                "payment.payout.fiat.v1", 0, 0L, "key-1", record,
-                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
-    }
+    return ValidatedEvent.fromRecord(
+        "payment.payout.fiat.v1",
+        0,
+        0L,
+        "key-1",
+        record,
+        SOME_EVENT_ID,
+        SOME_EVENT_TIME_MILLIS,
+        SOME_FLOW_ID,
+        SOME_SCHEMA_VERSION);
+  }
 
-    public static ValidatedEvent screeningEvent(
-            String screeningId, String customerId, String outcome,
-            String provider, double score, long durationMs) {
-        var envelope = envelope(null, null);
-        var record = new GenericRecordBuilder(SCREENING_SCHEMA)
-                .set("envelope", envelope)
-                .set("screening_id", screeningId)
-                .set("customer_id", customerId)
-                .set("transaction_reference", "TX-REF-001")
-                .set("outcome", outcome)
-                .set("provider", provider)
-                .set("rule_triggered", "RULE-01")
-                .set("score", score)
-                .set("duration_ms", durationMs)
-                .build();
+  public static ValidatedEvent screeningEvent(
+      String screeningId,
+      String customerId,
+      String outcome,
+      String provider,
+      double score,
+      long durationMs) {
+    var envelope = envelope(null, null);
+    var record =
+        new GenericRecordBuilder(SCREENING_SCHEMA)
+            .set("envelope", envelope)
+            .set("screening_id", screeningId)
+            .set("customer_id", customerId)
+            .set("transaction_reference", "TX-REF-001")
+            .set("outcome", outcome)
+            .set("provider", provider)
+            .set("rule_triggered", "RULE-01")
+            .set("score", score)
+            .set("duration_ms", durationMs)
+            .build();
 
-        return ValidatedEvent.fromRecord(
-                "screening.result.v1", 0, 0L, "key-1", record,
-                SOME_EVENT_ID, SOME_EVENT_TIME_MILLIS, SOME_FLOW_ID, SOME_SCHEMA_VERSION);
-    }
+    return ValidatedEvent.fromRecord(
+        "screening.result.v1",
+        0,
+        0L,
+        "key-1",
+        record,
+        SOME_EVENT_ID,
+        SOME_EVENT_TIME_MILLIS,
+        SOME_FLOW_ID,
+        SOME_SCHEMA_VERSION);
+  }
 
-    private static GenericRecord envelope(String correlationId, String traceId) {
-        var rec = new GenericData.Record(ENVELOPE_SCHEMA);
-        rec.put("event_id", SOME_EVENT_ID);
-        rec.put("event_time", SOME_EVENT_TIME_MILLIS);
-        rec.put("ingest_time", SOME_INGEST_TIME_MILLIS);
-        rec.put("schema_version", SOME_SCHEMA_VERSION);
-        rec.put("flow_id", SOME_FLOW_ID);
-        rec.put("correlation_id", correlationId);
-        rec.put("trace_id", traceId);
-        return rec;
-    }
+  private static GenericRecord envelope(String correlationId, String traceId) {
+    var rec = new GenericData.Record(ENVELOPE_SCHEMA);
+    rec.put("event_id", SOME_EVENT_ID);
+    rec.put("event_time", SOME_EVENT_TIME_MILLIS);
+    rec.put("ingest_time", SOME_INGEST_TIME_MILLIS);
+    rec.put("schema_version", SOME_SCHEMA_VERSION);
+    rec.put("flow_id", SOME_FLOW_ID);
+    rec.put("correlation_id", correlationId);
+    rec.put("trace_id", traceId);
+    return rec;
+  }
 
-    private static GenericRecord money(long amountMicros, String currency) {
-        return new GenericRecordBuilder(MONEY_SCHEMA)
-                .set("amount_micros", amountMicros)
-                .set("currency_code", currency)
-                .build();
-    }
+  private static GenericRecord money(long amountMicros, String currency) {
+    return new GenericRecordBuilder(MONEY_SCHEMA)
+        .set("amount_micros", amountMicros)
+        .set("currency_code", currency)
+        .build();
+  }
 
-    private static GenericRecord party(String name) {
-        return new GenericRecordBuilder(PARTY_SCHEMA)
-                .set("name", name)
-                .build();
-    }
+  private static GenericRecord party(String name) {
+    return new GenericRecordBuilder(PARTY_SCHEMA).set("name", name).build();
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/SchemaBuilder.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/fixtures/SchemaBuilder.java
@@ -1,15 +1,16 @@
 package io.stablepay.flink.fixtures;
 
 import java.util.List;
-
 import org.apache.avro.Schema;
 
 final class SchemaBuilder {
 
-    private SchemaBuilder() {}
+  private SchemaBuilder() {}
 
-    static Schema money() {
-        return new Schema.Parser().parse("""
+  static Schema money() {
+    return new Schema.Parser()
+        .parse(
+            """
                 {
                   "type": "record",
                   "name": "Money",
@@ -20,10 +21,12 @@ final class SchemaBuilder {
                   ]
                 }
                 """);
-    }
+  }
 
-    static Schema envelope() {
-        return new Schema.Parser().parse("""
+  static Schema envelope() {
+    return new Schema.Parser()
+        .parse(
+            """
                 {
                   "type": "record",
                   "name": "EventEnvelope",
@@ -39,10 +42,12 @@ final class SchemaBuilder {
                   ]
                 }
                 """);
-    }
+  }
 
-    static Schema party() {
-        return new Schema.Parser().parse("""
+  static Schema party() {
+    return new Schema.Parser()
+        .parse(
+            """
                 {
                   "type": "record",
                   "name": "Party",
@@ -52,84 +57,94 @@ final class SchemaBuilder {
                   ]
                 }
                 """);
-    }
+  }
 
-    static Schema payoutFiat(Schema envelope, Schema money) {
-        return record("PayoutFiatV1", "io.stablepay.events.payments",
-                field("envelope", envelope),
-                field("amount", money),
-                field("internal_status", Schema.create(Schema.Type.STRING)));
-    }
+  static Schema payoutFiat(Schema envelope, Schema money) {
+    return record(
+        "PayoutFiatV1",
+        "io.stablepay.events.payments",
+        field("envelope", envelope),
+        field("amount", money),
+        field("internal_status", Schema.create(Schema.Type.STRING)));
+  }
 
-    static Schema payoutFiat(Schema envelope, Schema money, Schema party) {
-        return record("PayoutFiatV1", "io.stablepay.events.payments",
-                field("envelope", envelope),
-                field("customer_id", Schema.create(Schema.Type.STRING)),
-                field("account_id", Schema.create(Schema.Type.STRING)),
-                field("amount", money),
-                field("fee", nullable(money)),
-                field("source_amount", nullable(money)),
-                field("target_amount", nullable(money)),
-                field("fx_rate", nullable(Schema.create(Schema.Type.DOUBLE))),
-                field("internal_status", Schema.create(Schema.Type.STRING)),
-                field("customer_status", nullable(Schema.create(Schema.Type.STRING))),
-                field("screening_outcome", nullable(Schema.create(Schema.Type.STRING))),
-                field("payout_reference", nullable(Schema.create(Schema.Type.STRING))),
-                field("is_user_facing", nullable(Schema.create(Schema.Type.BOOLEAN))),
-                field("chain", nullable(Schema.create(Schema.Type.STRING))),
-                field("asset", nullable(Schema.create(Schema.Type.STRING))),
-                field("source_address", nullable(Schema.create(Schema.Type.STRING))),
-                field("destination_address", nullable(Schema.create(Schema.Type.STRING))),
-                field("tx_hash", nullable(Schema.create(Schema.Type.STRING))),
-                field("confirmations", nullable(Schema.create(Schema.Type.INT))),
-                field("gas_fee_micros", nullable(Schema.create(Schema.Type.LONG))),
-                field("block_number", nullable(Schema.create(Schema.Type.LONG))),
-                field("block_timestamp", nullable(Schema.create(Schema.Type.LONG))),
-                field("provider", nullable(Schema.create(Schema.Type.STRING))),
-                field("route", nullable(Schema.create(Schema.Type.STRING))),
-                field("beneficiary", nullable(party)),
-                field("sender", nullable(party)),
-                field("description", nullable(Schema.create(Schema.Type.STRING))),
-                field("notes", nullable(Schema.create(Schema.Type.STRING))));
-    }
+  static Schema payoutFiat(Schema envelope, Schema money, Schema party) {
+    return record(
+        "PayoutFiatV1",
+        "io.stablepay.events.payments",
+        field("envelope", envelope),
+        field("customer_id", Schema.create(Schema.Type.STRING)),
+        field("account_id", Schema.create(Schema.Type.STRING)),
+        field("amount", money),
+        field("fee", nullable(money)),
+        field("source_amount", nullable(money)),
+        field("target_amount", nullable(money)),
+        field("fx_rate", nullable(Schema.create(Schema.Type.DOUBLE))),
+        field("internal_status", Schema.create(Schema.Type.STRING)),
+        field("customer_status", nullable(Schema.create(Schema.Type.STRING))),
+        field("screening_outcome", nullable(Schema.create(Schema.Type.STRING))),
+        field("payout_reference", nullable(Schema.create(Schema.Type.STRING))),
+        field("is_user_facing", nullable(Schema.create(Schema.Type.BOOLEAN))),
+        field("chain", nullable(Schema.create(Schema.Type.STRING))),
+        field("asset", nullable(Schema.create(Schema.Type.STRING))),
+        field("source_address", nullable(Schema.create(Schema.Type.STRING))),
+        field("destination_address", nullable(Schema.create(Schema.Type.STRING))),
+        field("tx_hash", nullable(Schema.create(Schema.Type.STRING))),
+        field("confirmations", nullable(Schema.create(Schema.Type.INT))),
+        field("gas_fee_micros", nullable(Schema.create(Schema.Type.LONG))),
+        field("block_number", nullable(Schema.create(Schema.Type.LONG))),
+        field("block_timestamp", nullable(Schema.create(Schema.Type.LONG))),
+        field("provider", nullable(Schema.create(Schema.Type.STRING))),
+        field("route", nullable(Schema.create(Schema.Type.STRING))),
+        field("beneficiary", nullable(party)),
+        field("sender", nullable(party)),
+        field("description", nullable(Schema.create(Schema.Type.STRING))),
+        field("notes", nullable(Schema.create(Schema.Type.STRING))));
+  }
 
-    static Schema payoutCrypto(Schema envelope, Schema money) {
-        return record("PayoutCryptoV1", "io.stablepay.events.payments",
-                field("envelope", envelope),
-                field("amount", money),
-                field("internal_status", Schema.create(Schema.Type.STRING)));
-    }
+  static Schema payoutCrypto(Schema envelope, Schema money) {
+    return record(
+        "PayoutCryptoV1",
+        "io.stablepay.events.payments",
+        field("envelope", envelope),
+        field("amount", money),
+        field("internal_status", Schema.create(Schema.Type.STRING)));
+  }
 
-    static Schema screening(Schema envelope) {
-        return record("ScreeningResultV1", "io.stablepay.events.screening",
-                field("envelope", envelope),
-                field("outcome", Schema.create(Schema.Type.STRING)),
-                field("provider", Schema.create(Schema.Type.STRING)),
-                field("risk_score", Schema.create(Schema.Type.DOUBLE)));
-    }
+  static Schema screening(Schema envelope) {
+    return record(
+        "ScreeningResultV1",
+        "io.stablepay.events.screening",
+        field("envelope", envelope),
+        field("outcome", Schema.create(Schema.Type.STRING)),
+        field("provider", Schema.create(Schema.Type.STRING)),
+        field("risk_score", Schema.create(Schema.Type.DOUBLE)));
+  }
 
-    static Schema screeningResult(Schema envelope) {
-        return record("ScreeningResultV1", "io.stablepay.events.screening",
-                field("envelope", envelope),
-                field("screening_id", nullable(Schema.create(Schema.Type.STRING))),
-                field("customer_id", nullable(Schema.create(Schema.Type.STRING))),
-                field("transaction_reference", nullable(Schema.create(Schema.Type.STRING))),
-                field("outcome", nullable(Schema.create(Schema.Type.STRING))),
-                field("provider", nullable(Schema.create(Schema.Type.STRING))),
-                field("rule_triggered", nullable(Schema.create(Schema.Type.STRING))),
-                field("score", nullable(Schema.create(Schema.Type.DOUBLE))),
-                field("duration_ms", nullable(Schema.create(Schema.Type.LONG))));
-    }
+  static Schema screeningResult(Schema envelope) {
+    return record(
+        "ScreeningResultV1",
+        "io.stablepay.events.screening",
+        field("envelope", envelope),
+        field("screening_id", nullable(Schema.create(Schema.Type.STRING))),
+        field("customer_id", nullable(Schema.create(Schema.Type.STRING))),
+        field("transaction_reference", nullable(Schema.create(Schema.Type.STRING))),
+        field("outcome", nullable(Schema.create(Schema.Type.STRING))),
+        field("provider", nullable(Schema.create(Schema.Type.STRING))),
+        field("rule_triggered", nullable(Schema.create(Schema.Type.STRING))),
+        field("score", nullable(Schema.create(Schema.Type.DOUBLE))),
+        field("duration_ms", nullable(Schema.create(Schema.Type.LONG))));
+  }
 
-    private static Schema nullable(Schema schema) {
-        return Schema.createUnion(Schema.create(Schema.Type.NULL), schema);
-    }
+  private static Schema nullable(Schema schema) {
+    return Schema.createUnion(Schema.create(Schema.Type.NULL), schema);
+  }
 
-    private static Schema record(String name, String namespace, Schema.Field... fields) {
-        return Schema.createRecord(name, null, namespace, false, List.of(fields));
-    }
+  private static Schema record(String name, String namespace, Schema.Field... fields) {
+    return Schema.createRecord(name, null, namespace, false, List.of(fields));
+  }
 
-    private static Schema.Field field(String name, Schema schema) {
-        return new Schema.Field(name, schema, null, null);
-    }
+  private static Schema.Field field(String name, Schema schema) {
+    return new Schema.Field(name, schema, null, null);
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/DlqToIcebergRowMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/DlqToIcebergRowMapperTest.java
@@ -3,88 +3,89 @@ package io.stablepay.flink.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.DlqEventIds;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.junit.jupiter.api.Test;
 
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.DlqEventIds;
-
 class DlqToIcebergRowMapperTest {
 
-    @Test
-    void shouldBuildRowDataFromEnvelopeWithDeterministicEventId() {
-        // given
-        var payload = "{\"k\":\"v\"}".getBytes(StandardCharsets.UTF_8);
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic("payment.flow.v1")
-                .sourcePartition(2)
-                .sourceOffset(123L)
-                .errorClass("LATE_EVENT")
-                .errorMessage("event arrived late")
-                .originalPayloadBytes(payload)
-                .failedAt(1_700_000_000_000L)
-                .retryCount(1)
-                .build();
+  @Test
+  void shouldBuildRowDataFromEnvelopeWithDeterministicEventId() {
+    // given
+    var payload = "{\"k\":\"v\"}".getBytes(StandardCharsets.UTF_8);
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic("payment.flow.v1")
+            .sourcePartition(2)
+            .sourceOffset(123L)
+            .errorClass("LATE_EVENT")
+            .errorMessage("event arrived late")
+            .originalPayloadBytes(payload)
+            .failedAt(1_700_000_000_000L)
+            .retryCount(1)
+            .build();
 
-        var expected = new GenericRowData(9);
-        expected.setField(0, StringData.fromString(DlqEventIds.of(envelope)));
-        expected.setField(1, StringData.fromString("payment.flow.v1"));
-        expected.setField(2, 2);
-        expected.setField(3, 123L);
-        expected.setField(4, StringData.fromString("LATE_EVENT"));
-        expected.setField(5, StringData.fromString("event arrived late"));
-        expected.setField(6, TimestampData.fromInstant(Instant.ofEpochMilli(1_700_000_000_000L)));
-        expected.setField(7, 1);
-        expected.setField(8, StringData.fromString("{\"k\":\"v\"}"));
+    var expected = new GenericRowData(9);
+    expected.setField(0, StringData.fromString(DlqEventIds.of(envelope)));
+    expected.setField(1, StringData.fromString("payment.flow.v1"));
+    expected.setField(2, 2);
+    expected.setField(3, 123L);
+    expected.setField(4, StringData.fromString("LATE_EVENT"));
+    expected.setField(5, StringData.fromString("event arrived late"));
+    expected.setField(6, TimestampData.fromInstant(Instant.ofEpochMilli(1_700_000_000_000L)));
+    expected.setField(7, 1);
+    expected.setField(8, StringData.fromString("{\"k\":\"v\"}"));
 
-        // when
-        var actual = DlqToIcebergRowMapper.toRowData(envelope);
+    // when
+    var actual = DlqToIcebergRowMapper.toRowData(envelope);
 
-        // then
-        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
 
-    @Test
-    void shouldEmitNullPayloadFieldWhenBytesAreNull() {
-        // given
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic("topic.v1")
-                .sourcePartition(0)
-                .sourceOffset(0L)
-                .errorClass("SINK_FAILURE")
-                .errorMessage("opensearch 503")
-                .failedAt(1L)
-                .retryCount(0)
-                .build();
+  @Test
+  void shouldEmitNullPayloadFieldWhenBytesAreNull() {
+    // given
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic("topic.v1")
+            .sourcePartition(0)
+            .sourceOffset(0L)
+            .errorClass("SINK_FAILURE")
+            .errorMessage("opensearch 503")
+            .failedAt(1L)
+            .retryCount(0)
+            .build();
 
-        // when
-        var actual = (GenericRowData) DlqToIcebergRowMapper.toRowData(envelope);
+    // when
+    var actual = (GenericRowData) DlqToIcebergRowMapper.toRowData(envelope);
 
-        // then
-        assertThat(actual.getField(8)).isNull();
-    }
+    // then
+    assertThat(actual.getField(8)).isNull();
+  }
 
-    @Test
-    void shouldRejectEnvelopeWithNullSourceTopic() {
-        // given
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic(null)
-                .sourcePartition(0)
-                .sourceOffset(0L)
-                .errorClass("LATE_EVENT")
-                .errorMessage("late")
-                .failedAt(1L)
-                .retryCount(0)
-                .build();
+  @Test
+  void shouldRejectEnvelopeWithNullSourceTopic() {
+    // given
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic(null)
+            .sourcePartition(0)
+            .sourceOffset(0L)
+            .errorClass("LATE_EVENT")
+            .errorMessage("late")
+            .failedAt(1L)
+            .retryCount(0)
+            .build();
 
-        // when / then
-        assertThatThrownBy(() -> DlqToIcebergRowMapper.toRowData(envelope))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("sourceTopic");
-    }
+    // when / then
+    assertThatThrownBy(() -> DlqToIcebergRowMapper.toRowData(envelope))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("sourceTopic");
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/DlqToOpenSearchDocMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/DlqToOpenSearchDocMapperTest.java
@@ -3,86 +3,87 @@ package io.stablepay.flink.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.stablepay.flink.model.DlqEnvelope;
+import io.stablepay.flink.model.DlqEventIds;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
-
-import io.stablepay.flink.model.DlqEnvelope;
-import io.stablepay.flink.model.DlqEventIds;
 
 class DlqToOpenSearchDocMapperTest {
 
-    @Test
-    void shouldBuildDocumentFromEnvelopeWithDeterministicEventId() {
-        // given
-        var payload = "{\"a\":1}".getBytes(StandardCharsets.UTF_8);
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic("payment.flow.v1")
-                .sourcePartition(2)
-                .sourceOffset(123L)
-                .errorClass("LATE_EVENT")
-                .errorMessage("event arrived late")
-                .originalPayloadBytes(payload)
-                .failedAt(1_700_000_000_000L)
-                .retryCount(0)
-                .build();
+  @Test
+  void shouldBuildDocumentFromEnvelopeWithDeterministicEventId() {
+    // given
+    var payload = "{\"a\":1}".getBytes(StandardCharsets.UTF_8);
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic("payment.flow.v1")
+            .sourcePartition(2)
+            .sourceOffset(123L)
+            .errorClass("LATE_EVENT")
+            .errorMessage("event arrived late")
+            .originalPayloadBytes(payload)
+            .failedAt(1_700_000_000_000L)
+            .retryCount(0)
+            .build();
 
-        var expected = new HashMap<String, Object>();
-        expected.put("event_id", DlqEventIds.of(envelope));
-        expected.put("source_topic", "payment.flow.v1");
-        expected.put("source_partition", 2);
-        expected.put("source_offset", 123L);
-        expected.put("error_class", "LATE_EVENT");
-        expected.put("error_message", "event arrived late");
-        expected.put("failed_at", 1_700_000_000_000L);
-        expected.put("retry_count", 0);
-        expected.put("original_payload_json", "{\"a\":1}");
+    var expected = new HashMap<String, Object>();
+    expected.put("event_id", DlqEventIds.of(envelope));
+    expected.put("source_topic", "payment.flow.v1");
+    expected.put("source_partition", 2);
+    expected.put("source_offset", 123L);
+    expected.put("error_class", "LATE_EVENT");
+    expected.put("error_message", "event arrived late");
+    expected.put("failed_at", 1_700_000_000_000L);
+    expected.put("retry_count", 0);
+    expected.put("original_payload_json", "{\"a\":1}");
 
-        // when
-        Map<String, Object> doc = DlqToOpenSearchDocMapper.toDocument(envelope);
+    // when
+    Map<String, Object> doc = DlqToOpenSearchDocMapper.toDocument(envelope);
 
-        // then
-        assertThat(doc).usingRecursiveComparison().isEqualTo(expected);
-    }
+    // then
+    assertThat(doc).usingRecursiveComparison().isEqualTo(expected);
+  }
 
-    @Test
-    void shouldOmitOriginalPayloadJsonWhenBytesAreNull() {
-        // given
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic("topic.v1")
-                .sourcePartition(0)
-                .sourceOffset(0L)
-                .errorClass("SINK_FAILURE")
-                .errorMessage("opensearch 503")
-                .failedAt(1_700_000_000_000L)
-                .retryCount(2)
-                .build();
+  @Test
+  void shouldOmitOriginalPayloadJsonWhenBytesAreNull() {
+    // given
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic("topic.v1")
+            .sourcePartition(0)
+            .sourceOffset(0L)
+            .errorClass("SINK_FAILURE")
+            .errorMessage("opensearch 503")
+            .failedAt(1_700_000_000_000L)
+            .retryCount(2)
+            .build();
 
-        // when
-        var doc = DlqToOpenSearchDocMapper.toDocument(envelope);
+    // when
+    var doc = DlqToOpenSearchDocMapper.toDocument(envelope);
 
-        // then
-        assertThat(doc).doesNotContainKey("original_payload_json");
-    }
+    // then
+    assertThat(doc).doesNotContainKey("original_payload_json");
+  }
 
-    @Test
-    void shouldRejectEnvelopeWithNullErrorMessage() {
-        // given
-        var envelope = DlqEnvelope.builder()
-                .sourceTopic("topic.v1")
-                .sourcePartition(0)
-                .sourceOffset(0L)
-                .errorClass("LATE_EVENT")
-                .errorMessage(null)
-                .failedAt(1L)
-                .retryCount(0)
-                .build();
+  @Test
+  void shouldRejectEnvelopeWithNullErrorMessage() {
+    // given
+    var envelope =
+        DlqEnvelope.builder()
+            .sourceTopic("topic.v1")
+            .sourcePartition(0)
+            .sourceOffset(0L)
+            .errorClass("LATE_EVENT")
+            .errorMessage(null)
+            .failedAt(1L)
+            .retryCount(0)
+            .build();
 
-        // when / then
-        assertThatThrownBy(() -> DlqToOpenSearchDocMapper.toDocument(envelope))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("errorMessage");
-    }
+    // when / then
+    assertThatThrownBy(() -> DlqToOpenSearchDocMapper.toDocument(envelope))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("errorMessage");
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactScreeningMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactScreeningMapperTest.java
@@ -6,7 +6,6 @@ import static io.stablepay.flink.fixtures.FactFixtures.screeningEvent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
@@ -15,88 +14,88 @@ import org.junit.jupiter.api.Test;
 
 class EventToFactScreeningMapperTest {
 
+  @Test
+  void shouldProduceRowDataWith10Fields() {
+    // given
+    var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.1, 250L);
+
+    // when
+    var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+    // then
+    assertThat(result.getArity()).isEqualTo(10);
+  }
+
+  @Test
+  void shouldMapAllFieldsCorrectly() {
+    // given
+    var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.85, 250L);
+
+    // when
+    var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+
+    // then
+    var expected = new GenericRowData(10);
+    expected.setField(0, StringData.fromString(SOME_EVENT_ID));
+    expected.setField(1, StringData.fromString("SCR-001"));
+    expected.setField(2, StringData.fromString("cust-001"));
+    expected.setField(3, StringData.fromString("TX-REF-001"));
+    expected.setField(4, StringData.fromString("PASS"));
+    expected.setField(5, StringData.fromString("chainalysis"));
+    expected.setField(6, StringData.fromString("RULE-01"));
+    expected.setField(7, 0.85);
+    expected.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
+    expected.setField(9, 250L);
+
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Nested
+  class CustomerIdIsNotMasked {
+
     @Test
-    void shouldProduceRowDataWith10Fields() {
-        // given
-        var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.1, 250L);
+    void shouldStoreCustomerIdUnmasked() {
+      // given
+      var customerId = "a1b2c3d4-e5f6-7890-abcd-1234";
+      var event = screeningEvent("SCR-001", customerId, "PASS", "provider", 0.5, 100L);
 
-        // when
-        var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
 
-        // then
-        assertThat(result.getArity()).isEqualTo(10);
+      // then
+      assertThat(result.getString(2).toString()).isEqualTo(customerId);
     }
+  }
+
+  @Nested
+  class ScoreUsesDouble {
 
     @Test
-    void shouldMapAllFieldsCorrectly() {
-        // given
-        var event = screeningEvent("SCR-001", "cust-001", "PASS", "chainalysis", 0.85, 250L);
+    void shouldStoreScoreAsDouble() {
+      // given
+      var event = screeningEvent("SCR-001", "cust-001", "FLAG", "provider", 0.95, 100L);
 
-        // when
-        var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
 
-        // then
-        var expected = new GenericRowData(10);
-        expected.setField(0, StringData.fromString(SOME_EVENT_ID));
-        expected.setField(1, StringData.fromString("SCR-001"));
-        expected.setField(2, StringData.fromString("cust-001"));
-        expected.setField(3, StringData.fromString("TX-REF-001"));
-        expected.setField(4, StringData.fromString("PASS"));
-        expected.setField(5, StringData.fromString("chainalysis"));
-        expected.setField(6, StringData.fromString("RULE-01"));
-        expected.setField(7, 0.85);
-        expected.setField(8, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
-        expected.setField(9, 250L);
-
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+      // then
+      assertThat(result.getDouble(7)).isEqualTo(0.95);
     }
+  }
 
-    @Nested
-    class CustomerIdIsNotMasked {
+  @Nested
+  class DurationUsesLong {
 
-        @Test
-        void shouldStoreCustomerIdUnmasked() {
-            // given
-            var customerId = "a1b2c3d4-e5f6-7890-abcd-1234";
-            var event = screeningEvent("SCR-001", customerId, "PASS", "provider", 0.5, 100L);
+    @Test
+    void shouldStoreDurationMsAsLong() {
+      // given
+      var event = screeningEvent("SCR-001", "cust-001", "PASS", "provider", 0.1, 3500L);
 
-            // when
-            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
 
-            // then
-            assertThat(result.getString(2).toString()).isEqualTo(customerId);
-        }
+      // then
+      assertThat(result.getLong(9)).isEqualTo(3500L);
     }
-
-    @Nested
-    class ScoreUsesDouble {
-
-        @Test
-        void shouldStoreScoreAsDouble() {
-            // given
-            var event = screeningEvent("SCR-001", "cust-001", "FLAG", "provider", 0.95, 100L);
-
-            // when
-            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
-
-            // then
-            assertThat(result.getDouble(7)).isEqualTo(0.95);
-        }
-    }
-
-    @Nested
-    class DurationUsesLong {
-
-        @Test
-        void shouldStoreDurationMsAsLong() {
-            // given
-            var event = screeningEvent("SCR-001", "cust-001", "PASS", "provider", 0.1, 3500L);
-
-            // when
-            var result = (GenericRowData) EventToFactScreeningMapper.toRowData(event);
-
-            // then
-            assertThat(result.getLong(9)).isEqualTo(3500L);
-        }
-    }
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactTransactionMapperTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/EventToFactTransactionMapperTest.java
@@ -12,7 +12,6 @@ import static io.stablepay.flink.fixtures.FactFixtures.fiatPayoutEvent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
-
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
@@ -21,207 +20,207 @@ import org.junit.jupiter.api.Test;
 
 class EventToFactTransactionMapperTest {
 
+  @Test
+  void shouldProduceRowDataWith41Fields() {
+    // given
+    var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+
+    // when
+    var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+    // then
+    assertThat(result.getArity()).isEqualTo(41);
+  }
+
+  @Test
+  void shouldMapAllFieldsForFiatPayout() {
+    // given
+    var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+
+    // when
+    var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+    // then
+    var expected = new GenericRowData(41);
+    expected.setField(0, StringData.fromString(SOME_EVENT_ID));
+    expected.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
+    expected.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_INGEST_TIME_MILLIS)));
+    expected.setField(3, StringData.fromString(SOME_FLOW_ID));
+    expected.setField(4, StringData.fromString(SOME_CORRELATION_ID));
+    expected.setField(5, StringData.fromString(SOME_TRACE_ID));
+    expected.setField(6, StringData.fromString("PAYOUT_FIAT"));
+    expected.setField(7, StringData.fromString("FIAT"));
+    expected.setField(8, StringData.fromString("OUTBOUND"));
+    expected.setField(9, false);
+    expected.setField(10, null);
+    expected.setField(11, StringData.fromString("PAY-REF-001"));
+    expected.setField(12, StringData.fromString(SOME_CUSTOMER_ID));
+    expected.setField(13, StringData.fromString(SOME_ACCOUNT_ID));
+    expected.setField(14, 5_000_000L);
+    expected.setField(15, StringData.fromString("USD"));
+    expected.setField(16, null);
+    expected.setField(17, null);
+    expected.setField(18, null);
+    expected.setField(19, null);
+    expected.setField(20, null);
+    expected.setField(21, null);
+    expected.setField(22, null);
+    expected.setField(23, StringData.fromString("COMPLETED"));
+    expected.setField(24, StringData.fromString("PROCESSING"));
+    expected.setField(25, null);
+    expected.setField(26, null);
+    expected.setField(27, null);
+    expected.setField(28, null);
+    expected.setField(29, null);
+    expected.setField(30, null);
+    expected.setField(31, null);
+    expected.setField(32, null);
+    expected.setField(33, null);
+    expected.setField(34, null);
+    expected.setField(35, StringData.fromString("provider-x"));
+    expected.setField(36, StringData.fromString("route-1"));
+    expected.setField(37, StringData.fromString(PiiMasker.mask("Jane Beneficiary")));
+    expected.setField(38, StringData.fromString(PiiMasker.mask("John Sender")));
+    expected.setField(39, StringData.fromString(PiiMasker.mask("Payment to vendor")));
+    expected.setField(40, StringData.fromString(PiiMasker.mask("Monthly invoice")));
+
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Nested
+  class CustomerIdIsNotMasked {
+
     @Test
-    void shouldProduceRowDataWith41Fields() {
-        // given
-        var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+    void shouldStoreCustomerIdUnmasked() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
 
-        // when
-        var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-        // then
-        assertThat(result.getArity()).isEqualTo(41);
+      // then
+      assertThat(result.getString(12).toString()).isEqualTo(SOME_CUSTOMER_ID);
     }
 
     @Test
-    void shouldMapAllFieldsForFiatPayout() {
-        // given
-        var event = fiatPayoutEvent(5_000_000L, "USD", "COMPLETED");
+    void shouldStoreAccountIdUnmasked() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
 
-        // when
-        var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-        // then
-        var expected = new GenericRowData(41);
-        expected.setField(0, StringData.fromString(SOME_EVENT_ID));
-        expected.setField(1, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_EVENT_TIME_MILLIS)));
-        expected.setField(2, TimestampData.fromInstant(Instant.ofEpochMilli(SOME_INGEST_TIME_MILLIS)));
-        expected.setField(3, StringData.fromString(SOME_FLOW_ID));
-        expected.setField(4, StringData.fromString(SOME_CORRELATION_ID));
-        expected.setField(5, StringData.fromString(SOME_TRACE_ID));
-        expected.setField(6, StringData.fromString("PAYOUT_FIAT"));
-        expected.setField(7, StringData.fromString("FIAT"));
-        expected.setField(8, StringData.fromString("OUTBOUND"));
-        expected.setField(9, false);
-        expected.setField(10, null);
-        expected.setField(11, StringData.fromString("PAY-REF-001"));
-        expected.setField(12, StringData.fromString(SOME_CUSTOMER_ID));
-        expected.setField(13, StringData.fromString(SOME_ACCOUNT_ID));
-        expected.setField(14, 5_000_000L);
-        expected.setField(15, StringData.fromString("USD"));
-        expected.setField(16, null);
-        expected.setField(17, null);
-        expected.setField(18, null);
-        expected.setField(19, null);
-        expected.setField(20, null);
-        expected.setField(21, null);
-        expected.setField(22, null);
-        expected.setField(23, StringData.fromString("COMPLETED"));
-        expected.setField(24, StringData.fromString("PROCESSING"));
-        expected.setField(25, null);
-        expected.setField(26, null);
-        expected.setField(27, null);
-        expected.setField(28, null);
-        expected.setField(29, null);
-        expected.setField(30, null);
-        expected.setField(31, null);
-        expected.setField(32, null);
-        expected.setField(33, null);
-        expected.setField(34, null);
-        expected.setField(35, StringData.fromString("provider-x"));
-        expected.setField(36, StringData.fromString("route-1"));
-        expected.setField(37, StringData.fromString(PiiMasker.mask("Jane Beneficiary")));
-        expected.setField(38, StringData.fromString(PiiMasker.mask("John Sender")));
-        expected.setField(39, StringData.fromString(PiiMasker.mask("Payment to vendor")));
-        expected.setField(40, StringData.fromString(PiiMasker.mask("Monthly invoice")));
+      // then
+      assertThat(result.getString(13).toString()).isEqualTo(SOME_ACCOUNT_ID);
+    }
+  }
 
-        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  @Nested
+  class PiiFieldsAreMasked {
+
+    @Test
+    void shouldMaskBeneficiaryName() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+      // then
+      assertThat(result.getString(37).toString()).isEqualTo("Jane************");
     }
 
-    @Nested
-    class CustomerIdIsNotMasked {
+    @Test
+    void shouldMaskDescription() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
 
-        @Test
-        void shouldStoreCustomerIdUnmasked() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // then
+      assertThat(result.getString(39).toString()).startsWith("Paym");
+      assertThat(result.getString(39).toString()).contains("*");
+    }
+  }
 
-            // then
-            assertThat(result.getString(12).toString()).isEqualTo(SOME_CUSTOMER_ID);
-        }
+  @Nested
+  class MoneyFieldsUseLong {
 
-        @Test
-        void shouldStoreAccountIdUnmasked() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+    @Test
+    void shouldStoreAmountMicrosAsLong() {
+      // given
+      var event = fiatPayoutEvent(12_345_678L, "GBP", "COMPLETED");
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // then
-            assertThat(result.getString(13).toString()).isEqualTo(SOME_ACCOUNT_ID);
-        }
+      // then
+      assertThat(result.getLong(14)).isEqualTo(12_345_678L);
     }
 
-    @Nested
-    class PiiFieldsAreMasked {
+    @Test
+    void shouldStoreCurrencyCodeAsString() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "GBP", "COMPLETED");
 
-        @Test
-        void shouldMaskBeneficiaryName() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // then
+      assertThat(result.getString(15).toString()).isEqualTo("GBP");
+    }
+  }
 
-            // then
-            assertThat(result.getString(37).toString()).isEqualTo("Jane************");
-        }
+  @Nested
+  class DerivedFields {
 
-        @Test
-        void shouldMaskDescription() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "EUR", "PENDING");
+    @Test
+    void shouldDeriveEventTypeFromTopic() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // then
-            assertThat(result.getString(39).toString()).startsWith("Paym");
-            assertThat(result.getString(39).toString()).contains("*");
-        }
+      // then
+      assertThat(result.getString(6).toString()).isEqualTo("PAYOUT_FIAT");
     }
 
-    @Nested
-    class MoneyFieldsUseLong {
+    @Test
+    void shouldDeriveFlowTypeFiatFromFiatTopic() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
 
-        @Test
-        void shouldStoreAmountMicrosAsLong() {
-            // given
-            var event = fiatPayoutEvent(12_345_678L, "GBP", "COMPLETED");
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getLong(14)).isEqualTo(12_345_678L);
-        }
-
-        @Test
-        void shouldStoreCurrencyCodeAsString() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "GBP", "COMPLETED");
-
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getString(15).toString()).isEqualTo("GBP");
-        }
+      // then
+      assertThat(result.getString(7).toString()).isEqualTo("FIAT");
     }
 
-    @Nested
-    class DerivedFields {
+    @Test
+    void shouldDeriveDirectionOutboundFromPayoutTopic() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
 
-        @Test
-        void shouldDeriveEventTypeFromTopic() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
 
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getString(6).toString()).isEqualTo("PAYOUT_FIAT");
-        }
-
-        @Test
-        void shouldDeriveFlowTypeFiatFromFiatTopic() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
-
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getString(7).toString()).isEqualTo("FIAT");
-        }
-
-        @Test
-        void shouldDeriveDirectionOutboundFromPayoutTopic() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
-
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getString(8).toString()).isEqualTo("OUTBOUND");
-        }
-
-        @Test
-        void shouldSetIsCryptoFalseForFiatTopic() {
-            // given
-            var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
-
-            // when
-            var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
-
-            // then
-            assertThat(result.getBoolean(9)).isFalse();
-        }
+      // then
+      assertThat(result.getString(8).toString()).isEqualTo("OUTBOUND");
     }
+
+    @Test
+    void shouldSetIsCryptoFalseForFiatTopic() {
+      // given
+      var event = fiatPayoutEvent(1_000_000L, "USD", "PENDING");
+
+      // when
+      var result = (GenericRowData) EventToFactTransactionMapper.toRowData(event);
+
+      // then
+      assertThat(result.getBoolean(9)).isFalse();
+    }
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/PiiMaskerTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/mapper/PiiMaskerTest.java
@@ -2,76 +2,76 @@ package io.stablepay.flink.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 class PiiMaskerTest {
 
-    @Nested
-    class WhenInputIsNullOrEmpty {
+  @Nested
+  class WhenInputIsNullOrEmpty {
 
-        @Test
-        void shouldReturnNullForNullInput() {
-            // when
-            var result = PiiMasker.mask(null);
+    @Test
+    void shouldReturnNullForNullInput() {
+      // when
+      var result = PiiMasker.mask(null);
 
-            // then
-            assertThat(result).isNull();
-        }
-
-        @Test
-        void shouldReturnEmptyForEmptyInput() {
-            // when
-            var result = PiiMasker.mask("");
-
-            // then
-            assertThat(result).isEmpty();
-        }
+      // then
+      assertThat(result).isNull();
     }
 
-    @Nested
-    class WhenInputIsShorterThanPrefix {
+    @Test
+    void shouldReturnEmptyForEmptyInput() {
+      // when
+      var result = PiiMasker.mask("");
 
-        @Test
-        void shouldFullyMaskSingleCharacter() {
-            // when
-            var result = PiiMasker.mask("A");
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
 
-            // then
-            assertThat(result).isEqualTo("*");
-        }
+  @Nested
+  class WhenInputIsShorterThanPrefix {
 
-        @Test
-        void shouldFullyMaskStringAtPrefixLength() {
-            // when
-            var result = PiiMasker.mask("abcd");
+    @Test
+    void shouldFullyMaskSingleCharacter() {
+      // when
+      var result = PiiMasker.mask("A");
 
-            // then
-            assertThat(result).isEqualTo("****");
-        }
+      // then
+      assertThat(result).isEqualTo("*");
     }
 
-    @Nested
-    class WhenInputIsLongerThanPrefix {
+    @Test
+    void shouldFullyMaskStringAtPrefixLength() {
+      // when
+      var result = PiiMasker.mask("abcd");
 
-        @Test
-        void shouldPreservePrefixAndMaskRemainder() {
-            // when
-            var result = PiiMasker.mask("John Doe");
-
-            // then
-            assertThat(result).isEqualTo("John****");
-        }
-
-        @Test
-        void shouldMaskUuidPreservingFirstFourChars() {
-            // when
-            var result = PiiMasker.mask("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-
-            // then
-            assertThat(result).startsWith("a1b2");
-            assertThat(result).hasSize(36);
-            assertThat(result.substring(4)).matches("\\*+");
-        }
+      // then
+      assertThat(result).isEqualTo("****");
     }
+  }
+
+  @Nested
+  class WhenInputIsLongerThanPrefix {
+
+    @Test
+    void shouldPreservePrefixAndMaskRemainder() {
+      // when
+      var result = PiiMasker.mask("John Doe");
+
+      // then
+      assertThat(result).isEqualTo("John****");
+    }
+
+    @Test
+    void shouldMaskUuidPreservingFirstFourChars() {
+      // when
+      var result = PiiMasker.mask("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+      // then
+      assertThat(result).startsWith("a1b2");
+      assertThat(result).hasSize(36);
+      assertThat(result.substring(4)).matches("\\*+");
+    }
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/model/DlqEventIdsTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/model/DlqEventIdsTest.java
@@ -6,63 +6,70 @@ import org.junit.jupiter.api.Test;
 
 class DlqEventIdsTest {
 
-    private static DlqEnvelope envelope(String topic, int partition, long offset, long failedAt, String errorClass) {
-        return DlqEnvelope.builder()
-                .sourceTopic(topic)
-                .sourcePartition(partition)
-                .sourceOffset(offset)
-                .errorClass(errorClass)
-                .errorMessage("ignored")
-                .failedAt(failedAt)
-                .retryCount(0)
-                .build();
-    }
+  private static DlqEnvelope envelope(
+      String topic, int partition, long offset, long failedAt, String errorClass) {
+    return DlqEnvelope.builder()
+        .sourceTopic(topic)
+        .sourcePartition(partition)
+        .sourceOffset(offset)
+        .errorClass(errorClass)
+        .errorMessage("ignored")
+        .failedAt(failedAt)
+        .retryCount(0)
+        .build();
+  }
 
-    @Test
-    void shouldReturnSameIdForIdenticalSourceCoordinates() {
-        // given
-        var first = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
-        var second = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
+  @Test
+  void shouldReturnSameIdForIdenticalSourceCoordinates() {
+    // given
+    var first = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
+    var second = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
 
-        // when
-        var firstId = DlqEventIds.of(first);
-        var secondId = DlqEventIds.of(second);
+    // when
+    var firstId = DlqEventIds.of(first);
+    var secondId = DlqEventIds.of(second);
 
-        // then
-        assertThat(firstId).isEqualTo(secondId);
-    }
+    // then
+    assertThat(firstId).isEqualTo(secondId);
+  }
 
-    @Test
-    void shouldReturnDifferentIdsWhenAnyCoordinateChanges() {
-        // given
-        var base = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
+  @Test
+  void shouldReturnDifferentIdsWhenAnyCoordinateChanges() {
+    // given
+    var base = envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "LATE_EVENT");
 
-        // when
-        var baseId = DlqEventIds.of(base);
-        var differentTopic = DlqEventIds.of(envelope("payment.flow.v2", 3, 42L, 1_700_000_000_000L, "LATE_EVENT"));
-        var differentPartition = DlqEventIds.of(envelope("payment.flow.v1", 4, 42L, 1_700_000_000_000L, "LATE_EVENT"));
-        var differentOffset = DlqEventIds.of(envelope("payment.flow.v1", 3, 43L, 1_700_000_000_000L, "LATE_EVENT"));
-        var differentFailedAt = DlqEventIds.of(envelope("payment.flow.v1", 3, 42L, 1_700_000_000_001L, "LATE_EVENT"));
-        var differentClass = DlqEventIds.of(envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "ILLEGAL_TRANSITION"));
+    // when
+    var baseId = DlqEventIds.of(base);
+    var differentTopic =
+        DlqEventIds.of(envelope("payment.flow.v2", 3, 42L, 1_700_000_000_000L, "LATE_EVENT"));
+    var differentPartition =
+        DlqEventIds.of(envelope("payment.flow.v1", 4, 42L, 1_700_000_000_000L, "LATE_EVENT"));
+    var differentOffset =
+        DlqEventIds.of(envelope("payment.flow.v1", 3, 43L, 1_700_000_000_000L, "LATE_EVENT"));
+    var differentFailedAt =
+        DlqEventIds.of(envelope("payment.flow.v1", 3, 42L, 1_700_000_000_001L, "LATE_EVENT"));
+    var differentClass =
+        DlqEventIds.of(
+            envelope("payment.flow.v1", 3, 42L, 1_700_000_000_000L, "ILLEGAL_TRANSITION"));
 
-        // then
-        assertThat(baseId)
-                .isNotEqualTo(differentTopic)
-                .isNotEqualTo(differentPartition)
-                .isNotEqualTo(differentOffset)
-                .isNotEqualTo(differentFailedAt)
-                .isNotEqualTo(differentClass);
-    }
+    // then
+    assertThat(baseId)
+        .isNotEqualTo(differentTopic)
+        .isNotEqualTo(differentPartition)
+        .isNotEqualTo(differentOffset)
+        .isNotEqualTo(differentFailedAt)
+        .isNotEqualTo(differentClass);
+  }
 
-    @Test
-    void shouldReturnRfc4122UuidString() {
-        // given
-        var env = envelope("payment.flow.v1", 0, 0L, 1L, "SCHEMA_INVALID");
+  @Test
+  void shouldReturnRfc4122UuidString() {
+    // given
+    var env = envelope("payment.flow.v1", 0, 0L, 1L, "SCHEMA_INVALID");
 
-        // when
-        var id = DlqEventIds.of(env);
+    // when
+    var id = DlqEventIds.of(env);
 
-        // then
-        assertThat(id).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
-    }
+    // then
+    assertThat(id).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+  }
 }

--- a/apps/flink-jobs/src/test/java/io/stablepay/flink/topic/TopicDerivationTest.java
+++ b/apps/flink-jobs/src/test/java/io/stablepay/flink/topic/TopicDerivationTest.java
@@ -6,30 +6,30 @@ import org.junit.jupiter.api.Test;
 
 class TopicDerivationTest {
 
-    @Test
-    void shouldDeriveCryptoFlowTypeForChainTopics() {
-        assertThat(TopicDerivation.deriveFlowType("payment.payout.crypto.v1")).isEqualTo("CRYPTO");
-        assertThat(TopicDerivation.deriveFlowType("chain.tx.confirmed.v1")).isEqualTo("CRYPTO");
-    }
+  @Test
+  void shouldDeriveCryptoFlowTypeForChainTopics() {
+    assertThat(TopicDerivation.deriveFlowType("payment.payout.crypto.v1")).isEqualTo("CRYPTO");
+    assertThat(TopicDerivation.deriveFlowType("chain.tx.confirmed.v1")).isEqualTo("CRYPTO");
+  }
 
-    @Test
-    void shouldDeriveFiatFlowType() {
-        assertThat(TopicDerivation.deriveFlowType("payment.payin.fiat.v1")).isEqualTo("FIAT");
-    }
+  @Test
+  void shouldDeriveFiatFlowType() {
+    assertThat(TopicDerivation.deriveFlowType("payment.payin.fiat.v1")).isEqualTo("FIAT");
+  }
 
-    @Test
-    void shouldDefaultToMixedForUnclassifiedTopics() {
-        assertThat(TopicDerivation.deriveFlowType("internal.transfer.v1")).isEqualTo("MIXED");
-    }
+  @Test
+  void shouldDefaultToMixedForUnclassifiedTopics() {
+    assertThat(TopicDerivation.deriveFlowType("internal.transfer.v1")).isEqualTo("MIXED");
+  }
 
-    @Test
-    void shouldDeriveDirectionFromPayinAndPayout() {
-        assertThat(TopicDerivation.deriveDirection("payment.payin.fiat.v1")).isEqualTo("INBOUND");
-        assertThat(TopicDerivation.deriveDirection("payment.payout.crypto.v1")).isEqualTo("OUTBOUND");
-    }
+  @Test
+  void shouldDeriveDirectionFromPayinAndPayout() {
+    assertThat(TopicDerivation.deriveDirection("payment.payin.fiat.v1")).isEqualTo("INBOUND");
+    assertThat(TopicDerivation.deriveDirection("payment.payout.crypto.v1")).isEqualTo("OUTBOUND");
+  }
 
-    @Test
-    void shouldDefaultToInternalForUnclassifiedDirection() {
-        assertThat(TopicDerivation.deriveDirection("screening.result.v1")).isEqualTo("INTERNAL");
-    }
+  @Test
+  void shouldDefaultToInternalForUnclassifiedDirection() {
+    assertThat(TopicDerivation.deriveDirection("screening.result.v1")).isEqualTo("INTERNAL");
+  }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     // Pin commons-compress 1.27.1: Spring Boot 4.0.6's BootZipCopyAction calls
     // putArchiveEntry(ZipArchiveEntry), removed in commons-compress 1.28+ shipped with Gradle 9.5.
     implementation("org.apache.commons:commons-compress:1.27.1")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:7.0.4")
 }

--- a/buildSrc/src/main/kotlin/stablepay.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/stablepay.java-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    id("com.diffplug.spotless")
 }
 
 java {
@@ -16,4 +17,18 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}
+
+spotless {
+    java {
+        target("src/*/java/**/*.java")
+        googleJavaFormat("1.35.0")
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.named("check") {
+    dependsOn("spotlessCheck")
 }


### PR DESCRIPTION
## Summary
- Add Spotless 7.0.4 (`com.diffplug.spotless`) to the `java-conventions` precompiled script plugin so every Java module inherits the same formatter + unused-import removal + trailing-whitespace + final-newline rules
- Pin **google-java-format 1.35.0** explicitly — Spotless 7.0.4's bundled GJF 1.27.0 fails on JDK 25 (`NoSuchMethodError: Log\$DeferredDiagnosticHandler.getDiagnostics()`); 1.34.0+ added JDK 25 support
- Hook `spotlessCheck` into the `check` task so CI fails on unformatted code
- Run `./gradlew spotlessApply` once across the repo — 75 Java files reformatted (apps/flink-jobs + apps/auth/main)

## Why two commits
1. `chore(tooling): add spotless googleJavaFormat to java conventions` — 2-file config change; this is the actual review surface
2. `style(tooling): apply spotless googleJavaFormat across all modules` — 75-file mechanical reformat; review by skimming, no logic changes

## Verification
- `./gradlew spotlessCheck` — green
- `./gradlew :apps:flink-jobs:test` — green (existing test suite still passes after reformat)
- `./gradlew :apps:auth:main:compileJava` — green
- `./gradlew check` — green

## Notes
- Future modules (`apps/api/api`, `apps/api/client`, `apps/api/main`) auto-inherit Spotless via the conventions plugin — no per-module config needed
- The `removeUnusedImports()` step is included; if any future code intentionally needs an unused import (e.g., for `// @noinspection`), it can be excluded per-target
- Locks `googleJavaFormat("1.35.0")` to a specific version rather than tracking latest, since GJF rules can change between versions and we want deterministic CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)