### PR TITLE
SPP-83: web layer — AuthController, JwksController, security + login rate limiter

### DIFF
--- a/apps/auth/client/build.gradle.kts
+++ b/apps/auth/client/build.gradle.kts
@@ -12,6 +12,7 @@ dependencyManagement {
 dependencies {
     implementation(project(":apps:auth:auth"))
     implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.validation)
 
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)

--- a/apps/auth/client/src/main/java/io/stablepay/auth/client/ApiError.java
+++ b/apps/auth/client/src/main/java/io/stablepay/auth/client/ApiError.java
@@ -1,0 +1,7 @@
+package io.stablepay.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+public record ApiError(
+    @JsonProperty("error_code") String errorCode, String message, Instant timestamp) {}

--- a/apps/auth/client/src/main/java/io/stablepay/auth/client/LoginRequest.java
+++ b/apps/auth/client/src/main/java/io/stablepay/auth/client/LoginRequest.java
@@ -1,0 +1,6 @@
+package io.stablepay.auth.client;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(@NotBlank @Email String email, @NotBlank String password) {}

--- a/apps/auth/client/src/main/java/io/stablepay/auth/client/RefreshRequest.java
+++ b/apps/auth/client/src/main/java/io/stablepay/auth/client/RefreshRequest.java
@@ -1,0 +1,6 @@
+package io.stablepay.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(@JsonProperty("refresh_token") @NotBlank String refreshToken) {}

--- a/apps/auth/client/src/main/java/io/stablepay/auth/client/TokenResponse.java
+++ b/apps/auth/client/src/main/java/io/stablepay/auth/client/TokenResponse.java
@@ -1,0 +1,8 @@
+package io.stablepay.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenResponse(
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("expires_in") long expiresIn) {}

--- a/apps/auth/main/build.gradle.kts
+++ b/apps/auth/main/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.nimbus.jose.jwt)
     implementation(libs.springdoc.openapi.starter.webmvc.ui)
     implementation(libs.bucket4j.core)
+    implementation(libs.caffeine)
 
     implementation(libs.mapstruct)
     annotationProcessor(libs.mapstruct.processor)
@@ -77,6 +78,8 @@ dependencies {
     testAnnotationProcessor(libs.lombok)
 
     integrationTestImplementation(libs.spring.boot.starter.test)
+    integrationTestImplementation(libs.spring.boot.starter.webmvc.test)
+    integrationTestImplementation(libs.spring.security.test)
     integrationTestImplementation(libs.testcontainers.postgres)
     integrationTestImplementation(libs.testcontainers.junit)
     integrationTestImplementation(testFixtures(project(":apps:auth:auth")))

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/FixedClockConfig.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/FixedClockConfig.java
@@ -1,0 +1,24 @@
+package io.stablepay.auth.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+class FixedClockConfig {
+
+  static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+
+  @Bean
+  Clock clock() {
+    return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+  }
+
+  @Bean
+  ObjectMapper objectMapper() {
+    return new ObjectMapper().findAndRegisterModules();
+  }
+}

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
@@ -1,6 +1,6 @@
 package io.stablepay.auth.infrastructure.security;
 
-import static io.stablepay.auth.infrastructure.security.FixedClockConfig.FIXED_NOW;
+import static io.stablepay.auth.infrastructure.security.TestConfig.FIXED_NOW;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -31,7 +31,7 @@ import org.springframework.test.web.servlet.MockMvc;
   SecurityConfig.class,
   LoginRateLimitFilter.class,
   GlobalExceptionHandler.class,
-  FixedClockConfig.class
+  TestConfig.class
 })
 class SecurityFilterChainIT {
 

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
@@ -1,5 +1,6 @@
 package io.stablepay.auth.infrastructure.security;
 
+import static io.stablepay.auth.infrastructure.security.FixedClockConfig.FIXED_NOW;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -15,16 +16,11 @@ import io.stablepay.auth.infrastructure.ratelimit.LoginRateLimitFilter;
 import io.stablepay.auth.infrastructure.web.AuthController;
 import io.stablepay.auth.infrastructure.web.GlobalExceptionHandler;
 import io.stablepay.auth.infrastructure.web.JwksController;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -35,11 +31,10 @@ import org.springframework.test.web.servlet.MockMvc;
   SecurityConfig.class,
   LoginRateLimitFilter.class,
   GlobalExceptionHandler.class,
-  SecurityFilterChainIT.FixedClockConfig.class
+  FixedClockConfig.class
 })
 class SecurityFilterChainIT {
 
-  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
   private static final String SOME_IP = "198.51.100.42";
   private static final String SOME_EMAIL = "alice@example.com";
   private static final String SOME_PASSWORD = "wrong-password";
@@ -93,7 +88,11 @@ class SecurityFilterChainIT {
       mockMvc
           .perform(
               post("/api/v1/auth/login")
-                  .with(remoteAddr(SOME_IP))
+                  .with(
+                      req -> {
+                        req.setRemoteAddr(SOME_IP);
+                        return req;
+                      })
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(body))
           .andExpect(status().isUnauthorized());
@@ -103,31 +102,14 @@ class SecurityFilterChainIT {
     mockMvc
         .perform(
             post("/api/v1/auth/login")
-                .with(remoteAddr(SOME_IP))
+                .with(
+                    req -> {
+                      req.setRemoteAddr(SOME_IP);
+                      return req;
+                    })
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body))
         .andExpect(status().isTooManyRequests())
         .andExpect(header().string("Retry-After", "60"));
-  }
-
-  private static org.springframework.test.web.servlet.request.RequestPostProcessor remoteAddr(
-      String ip) {
-    return req -> {
-      req.setRemoteAddr(ip);
-      return req;
-    };
-  }
-
-  @TestConfiguration
-  static class FixedClockConfig {
-    @Bean
-    Clock clock() {
-      return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
-    }
-
-    @Bean
-    ObjectMapper objectMapper() {
-      return new ObjectMapper().findAndRegisterModules();
-    }
   }
 }

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
@@ -1,0 +1,133 @@
+package io.stablepay.auth.infrastructure.security;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.auth.application.AuthService;
+import io.stablepay.auth.application.AuthService.LoginOutcome;
+import io.stablepay.auth.application.SigningKeyManager;
+import io.stablepay.auth.client.LoginRequest;
+import io.stablepay.auth.infrastructure.ratelimit.LoginRateLimitFilter;
+import io.stablepay.auth.infrastructure.web.AuthController;
+import io.stablepay.auth.infrastructure.web.GlobalExceptionHandler;
+import io.stablepay.auth.infrastructure.web.JwksController;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {AuthController.class, JwksController.class})
+@Import({
+  SecurityConfig.class,
+  LoginRateLimitFilter.class,
+  GlobalExceptionHandler.class,
+  SecurityFilterChainIT.FixedClockConfig.class
+})
+class SecurityFilterChainIT {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+  private static final String SOME_IP = "198.51.100.42";
+  private static final String SOME_EMAIL = "alice@example.com";
+  private static final String SOME_PASSWORD = "wrong-password";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @MockitoBean private AuthService authService;
+  @MockitoBean private SigningKeyManager signingKeyManager;
+
+  @Test
+  void shouldAllowAnonymousAccessToLoginEndpoint() throws Exception {
+    // given
+    given(authService.login(SOME_EMAIL, SOME_PASSWORD, FIXED_NOW))
+        .willReturn(new LoginOutcome.InvalidCredentials());
+    var body = objectMapper.writeValueAsString(new LoginRequest(SOME_EMAIL, SOME_PASSWORD));
+
+    // when/then — security must permit, controller returns 401 from credentials check
+    mockMvc
+        .perform(post("/api/v1/auth/login").contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void shouldAllowAnonymousAccessToJwksEndpoint() throws Exception {
+    // given
+    given(signingKeyManager.getJwkSet()).willReturn(Map.of("keys", List.of()));
+
+    // when/then
+    mockMvc
+        .perform(get("/.well-known/jwks.json"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Cache-Control", "max-age=3600, public"));
+  }
+
+  @Test
+  void shouldDenyAnonymousAccessToProtectedRoutes() throws Exception {
+    // when/then — any non-permitAll path is denied (Spring Security default
+    // returns 403 since no AuthenticationEntryPoint sends a 401 challenge yet)
+    mockMvc.perform(get("/api/v1/admin/anything")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldRateLimitLoginAfterFiveAttemptsFromSameIp() throws Exception {
+    // given
+    given(authService.login(SOME_EMAIL, SOME_PASSWORD, FIXED_NOW))
+        .willReturn(new LoginOutcome.InvalidCredentials());
+    var body = objectMapper.writeValueAsString(new LoginRequest(SOME_EMAIL, SOME_PASSWORD));
+
+    // when — drain the bucket from a single IP
+    for (var i = 0; i < 5; i++) {
+      mockMvc
+          .perform(
+              post("/api/v1/auth/login")
+                  .with(remoteAddr(SOME_IP))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(body))
+          .andExpect(status().isUnauthorized());
+    }
+
+    // then — sixth call from same IP is rate-limited
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .with(remoteAddr(SOME_IP))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(header().string("Retry-After", "60"));
+  }
+
+  private static org.springframework.test.web.servlet.request.RequestPostProcessor remoteAddr(
+      String ip) {
+    return req -> {
+      req.setRemoteAddr(ip);
+      return req;
+    };
+  }
+
+  @TestConfiguration
+  static class FixedClockConfig {
+    @Bean
+    Clock clock() {
+      return Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+    }
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper().findAndRegisterModules();
+    }
+  }
+}

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/TestConfig.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/TestConfig.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 @TestConfiguration
-class FixedClockConfig {
+class TestConfig {
 
   static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
 

--- a/apps/auth/main/src/main/java/io/stablepay/auth/application/SigningKeyManager.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/application/SigningKeyManager.java
@@ -2,6 +2,7 @@ package io.stablepay.auth.application;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import io.stablepay.auth.domain.exception.SigningKeyGenerationException;
 import io.stablepay.auth.domain.exception.SigningKeyParseException;
@@ -66,6 +67,7 @@ public class SigningKeyManager {
         new RSAKey.Builder(activePublicKey)
             .keyID(activeKey.kid())
             .algorithm(JWSAlgorithm.RS256)
+            .keyUse(KeyUse.SIGNATURE)
             .build()
             .toJSONObject();
     return Map.of("keys", List.of(jwk));

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
@@ -1,0 +1,86 @@
+package io.stablepay.auth.infrastructure.ratelimit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.stablepay.auth.client.ApiError;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginRateLimitFilter extends OncePerRequestFilter {
+
+  private static final String LOGIN_PATH = "/api/v1/auth/login";
+  private static final String RATE_LIMIT_ERROR_CODE = "STBLPAY-1004";
+  private static final String RATE_LIMIT_MESSAGE =
+      "Too many login attempts. Try again in 60 seconds.";
+  private static final long RETRY_AFTER_SECONDS = 60L;
+  private static final int BUCKET_CAPACITY = 5;
+  private static final Duration REFILL_PERIOD = Duration.ofMinutes(1);
+
+  private final ObjectMapper objectMapper;
+  private final Clock clock;
+  private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    if (!isLoginRequest(request)) {
+      chain.doFilter(request, response);
+      return;
+    }
+    var bucket = buckets.computeIfAbsent(clientIp(request), key -> newBucket());
+    if (bucket.tryConsume(1)) {
+      chain.doFilter(request, response);
+      return;
+    }
+    writeRateLimited(response);
+  }
+
+  private boolean isLoginRequest(HttpServletRequest request) {
+    return "POST".equalsIgnoreCase(request.getMethod())
+        && LOGIN_PATH.equals(request.getRequestURI());
+  }
+
+  private String clientIp(HttpServletRequest request) {
+    var forwarded = request.getHeader("X-Forwarded-For");
+    if (forwarded != null && !forwarded.isBlank()) {
+      return forwarded.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+
+  private Bucket newBucket() {
+    var bandwidth =
+        Bandwidth.builder()
+            .capacity(BUCKET_CAPACITY)
+            .refillIntervally(BUCKET_CAPACITY, REFILL_PERIOD)
+            .build();
+    return Bucket.builder().addLimit(bandwidth).build();
+  }
+
+  private void writeRateLimited(HttpServletResponse response) throws IOException {
+    var body = new ApiError(RATE_LIMIT_ERROR_CODE, RATE_LIMIT_MESSAGE, clock.instant());
+    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(RETRY_AFTER_SECONDS));
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.getWriter().write(objectMapper.writeValueAsString(body));
+  }
+}

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
@@ -46,7 +46,7 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
       chain.doFilter(request, response);
       return;
     }
-    var bucket = buckets.computeIfAbsent(clientIp(request), key -> newBucket());
+    var bucket = buckets.computeIfAbsent(request.getRemoteAddr(), key -> newBucket());
     if (bucket.tryConsume(1)) {
       chain.doFilter(request, response);
       return;
@@ -57,14 +57,6 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
   private boolean isLoginRequest(HttpServletRequest request) {
     return "POST".equalsIgnoreCase(request.getMethod())
         && LOGIN_PATH.equals(request.getRequestURI());
-  }
-
-  private String clientIp(HttpServletRequest request) {
-    var forwarded = request.getHeader("X-Forwarded-For");
-    if (forwarded != null && !forwarded.isBlank()) {
-      return forwarded.split(",")[0].trim();
-    }
-    return request.getRemoteAddr();
   }
 
   private Bucket newBucket() {

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
@@ -1,7 +1,8 @@
 package io.stablepay.auth.infrastructure.ratelimit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.bucket4j.Bandwidth;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bucket;
 import io.stablepay.auth.client.ApiError;
 import jakarta.servlet.FilterChain;
@@ -11,8 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -28,15 +27,21 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
 
   private static final String LOGIN_PATH = "/api/v1/auth/login";
   private static final String RATE_LIMIT_ERROR_CODE = "STBLPAY-1004";
-  private static final String RATE_LIMIT_MESSAGE =
-      "Too many login attempts. Try again in 60 seconds.";
-  private static final long RETRY_AFTER_SECONDS = 60L;
   private static final int BUCKET_CAPACITY = 5;
   private static final Duration REFILL_PERIOD = Duration.ofMinutes(1);
+  private static final long RETRY_AFTER_SECONDS = REFILL_PERIOD.toSeconds();
+  private static final String RATE_LIMIT_MESSAGE =
+      "Too many login attempts. Try again in " + RETRY_AFTER_SECONDS + " seconds.";
+  private static final Duration BUCKET_IDLE_TTL = Duration.ofMinutes(2);
+  private static final long BUCKET_MAX_ENTRIES = 100_000L;
 
   private final ObjectMapper objectMapper;
   private final Clock clock;
-  private final ConcurrentMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+  private final Cache<String, Bucket> buckets =
+      Caffeine.newBuilder()
+          .expireAfterAccess(BUCKET_IDLE_TTL)
+          .maximumSize(BUCKET_MAX_ENTRIES)
+          .build();
 
   @Override
   protected void doFilterInternal(
@@ -46,7 +51,7 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
       chain.doFilter(request, response);
       return;
     }
-    var bucket = buckets.computeIfAbsent(request.getRemoteAddr(), key -> newBucket());
+    var bucket = buckets.get(request.getRemoteAddr(), key -> newBucket());
     if (bucket.tryConsume(1)) {
       chain.doFilter(request, response);
       return;
@@ -55,17 +60,27 @@ public class LoginRateLimitFilter extends OncePerRequestFilter {
   }
 
   private boolean isLoginRequest(HttpServletRequest request) {
-    return "POST".equalsIgnoreCase(request.getMethod())
-        && LOGIN_PATH.equals(request.getRequestURI());
+    return "POST".equalsIgnoreCase(request.getMethod()) && LOGIN_PATH.equals(normalize(request));
   }
 
-  private Bucket newBucket() {
-    var bandwidth =
-        Bandwidth.builder()
-            .capacity(BUCKET_CAPACITY)
-            .refillIntervally(BUCKET_CAPACITY, REFILL_PERIOD)
-            .build();
-    return Bucket.builder().addLimit(bandwidth).build();
+  private static String normalize(HttpServletRequest request) {
+    var uri = request.getRequestURI();
+    var semi = uri.indexOf(';');
+    if (semi >= 0) {
+      uri = uri.substring(0, semi);
+    }
+    if (uri.length() > 1 && uri.endsWith("/")) {
+      uri = uri.substring(0, uri.length() - 1);
+    }
+    return uri;
+  }
+
+  private static Bucket newBucket() {
+    return Bucket.builder()
+        .addLimit(
+            limit ->
+                limit.capacity(BUCKET_CAPACITY).refillIntervally(BUCKET_CAPACITY, REFILL_PERIOD))
+        .build();
   }
 
   private void writeRateLimited(HttpServletResponse response) throws IOException {

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
@@ -28,7 +28,12 @@ public class SecurityConfig {
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers(
-                        "/api/v1/auth/**", "/.well-known/jwks.json", "/actuator/health/**")
+                        "/api/v1/auth/login",
+                        "/api/v1/auth/refresh",
+                        "/api/v1/auth/logout",
+                        "/.well-known/jwks.json",
+                        "/actuator/health",
+                        "/actuator/health/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())
@@ -36,9 +41,6 @@ public class SecurityConfig {
     return http.build();
   }
 
-  // Suppress Spring Boot's auto-registration of LoginRateLimitFilter as a top-level
-  // servlet filter. The filter is wired into the Spring Security chain above; without
-  // this disable, it would also run for every request at the servlet container level.
   @Bean
   public FilterRegistrationBean<LoginRateLimitFilter> loginRateLimitFilterRegistration(
       LoginRateLimitFilter filter) {

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package io.stablepay.auth.infrastructure.security;
 
 import io.stablepay.auth.infrastructure.ratelimit.LoginRateLimitFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -33,5 +34,16 @@ public class SecurityConfig {
                     .authenticated())
         .addFilterBefore(loginRateLimitFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
+  }
+
+  // Suppress Spring Boot's auto-registration of LoginRateLimitFilter as a top-level
+  // servlet filter. The filter is wired into the Spring Security chain above; without
+  // this disable, it would also run for every request at the servlet container level.
+  @Bean
+  public FilterRegistrationBean<LoginRateLimitFilter> loginRateLimitFilterRegistration(
+      LoginRateLimitFilter filter) {
+    var registration = new FilterRegistrationBean<>(filter);
+    registration.setEnabled(false);
+    return registration;
   }
 }

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,37 @@
+package io.stablepay.auth.infrastructure.security;
+
+import io.stablepay.auth.infrastructure.ratelimit.LoginRateLimitFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final LoginRateLimitFilter loginRateLimitFilter;
+
+  @Bean
+  public SecurityFilterChain authSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(
+                        "/api/v1/auth/**", "/.well-known/jwks.json", "/actuator/health/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
+        .addFilterBefore(loginRateLimitFilter, UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+}

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/AuthController.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/AuthController.java
@@ -1,0 +1,66 @@
+package io.stablepay.auth.infrastructure.web;
+
+import io.stablepay.auth.application.AuthService;
+import io.stablepay.auth.application.AuthService.LoginOutcome;
+import io.stablepay.auth.client.ApiError;
+import io.stablepay.auth.client.LoginRequest;
+import io.stablepay.auth.client.RefreshRequest;
+import io.stablepay.auth.client.TokenResponse;
+import jakarta.validation.Valid;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private static final String INVALID_LOGIN_CODE = "STBLPAY-1001";
+  private static final String INVALID_REFRESH_CODE = "STBLPAY-1002";
+  private static final String INVALID_CREDENTIALS_MSG = "Invalid credentials";
+
+  private final AuthService authService;
+  private final Clock clock;
+
+  @PostMapping("/login")
+  public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
+    var outcome = authService.login(request.email(), request.password(), clock.instant());
+    return switch (outcome) {
+      case LoginOutcome.Success success -> ResponseEntity.ok(toTokenResponse(success));
+      case LoginOutcome.InvalidCredentials ignored ->
+          ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+              .body(new ApiError(INVALID_LOGIN_CODE, INVALID_CREDENTIALS_MSG, clock.instant()));
+    };
+  }
+
+  @PostMapping("/refresh")
+  public ResponseEntity<?> refresh(@Valid @RequestBody RefreshRequest request) {
+    var outcome = authService.refresh(request.refreshToken(), clock.instant());
+    return switch (outcome) {
+      case LoginOutcome.Success success -> ResponseEntity.ok(toTokenResponse(success));
+      case LoginOutcome.InvalidCredentials ignored ->
+          ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+              .body(new ApiError(INVALID_REFRESH_CODE, INVALID_CREDENTIALS_MSG, clock.instant()));
+    };
+  }
+
+  @PostMapping("/logout")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void logout(@Valid @RequestBody RefreshRequest request) {
+    authService.logout(request.refreshToken(), clock.instant());
+  }
+
+  private static TokenResponse toTokenResponse(LoginOutcome.Success success) {
+    return new TokenResponse(
+        success.accessToken(), success.refreshToken(), success.expiresIn().toSeconds());
+  }
+}

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -5,40 +5,72 @@ import java.time.Clock;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponseException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   private static final String VALIDATION_ERROR_CODE = "STBLPAY-1003";
+  private static final String CLIENT_ERROR_CODE = "STBLPAY-1003";
   private static final String INTERNAL_ERROR_CODE = "STBLPAY-1999";
   private static final String INTERNAL_ERROR_MSG = "Internal server error";
 
   private final Clock clock;
 
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<ApiError> handleUnexpected(RuntimeException ex) {
+    log.error("Unhandled exception", ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new ApiError(INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG, clock.instant()));
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleMethodArgumentNotValid(
+      MethodArgumentNotValidException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
     var message =
         ex.getBindingResult().getFieldErrors().stream()
             .map(this::formatFieldError)
             .collect(Collectors.joining("; "));
     log.warn("Validation failure: {}", message);
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ApiError(VALIDATION_ERROR_CODE, message, clock.instant()));
+    var body = new ApiError(VALIDATION_ERROR_CODE, message, clock.instant());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).headers(headers).body(body);
   }
 
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ApiError> handleUnexpected(Exception ex) {
-    log.error("Unhandled exception", ex);
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(new ApiError(INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG, clock.instant()));
+  @Override
+  protected ResponseEntity<Object> handleExceptionInternal(
+      Exception ex,
+      Object body,
+      HttpHeaders headers,
+      HttpStatusCode statusCode,
+      WebRequest request) {
+    if (statusCode.is5xxServerError()) {
+      log.error("Framework 5xx exception", ex);
+    } else {
+      log.warn("Framework client exception: {}", ex.getMessage());
+    }
+    var detail =
+        ex instanceof ErrorResponseException ere ? ere.getBody().getDetail() : ex.getMessage();
+    var apiError =
+        new ApiError(
+            statusCode.is5xxServerError() ? INTERNAL_ERROR_CODE : CLIENT_ERROR_CODE,
+            statusCode.is5xxServerError() ? INTERNAL_ERROR_MSG : detail,
+            clock.instant());
+    return ResponseEntity.status(statusCode).headers(headers).body(apiError);
   }
 
   private String formatFieldError(FieldError fe) {

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandler.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package io.stablepay.auth.infrastructure.web;
+
+import io.stablepay.auth.client.ApiError;
+import java.time.Clock;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+  private static final String VALIDATION_ERROR_CODE = "STBLPAY-1003";
+  private static final String INTERNAL_ERROR_CODE = "STBLPAY-1999";
+  private static final String INTERNAL_ERROR_MSG = "Internal server error";
+
+  private final Clock clock;
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+    var message =
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(this::formatFieldError)
+            .collect(Collectors.joining("; "));
+    log.warn("Validation failure: {}", message);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ApiError(VALIDATION_ERROR_CODE, message, clock.instant()));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiError> handleUnexpected(Exception ex) {
+    log.error("Unhandled exception", ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new ApiError(INTERNAL_ERROR_CODE, INTERNAL_ERROR_MSG, clock.instant()));
+  }
+
+  private String formatFieldError(FieldError fe) {
+    return fe.getField() + ": " + fe.getDefaultMessage();
+  }
+}

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/JwksController.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/JwksController.java
@@ -1,0 +1,20 @@
+package io.stablepay.auth.infrastructure.web;
+
+import io.stablepay.auth.application.SigningKeyManager;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class JwksController {
+
+  private final SigningKeyManager signingKeyManager;
+
+  @GetMapping(path = "/.well-known/jwks.json", produces = MediaType.APPLICATION_JSON_VALUE)
+  public Map<String, Object> jwks() {
+    return signingKeyManager.getJwkSet();
+  }
+}

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/JwksController.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/web/JwksController.java
@@ -1,9 +1,12 @@
 package io.stablepay.auth.infrastructure.web;
 
 import io.stablepay.auth.application.SigningKeyManager;
+import java.time.Duration;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,10 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class JwksController {
 
+  private static final Duration JWKS_CACHE_TTL = Duration.ofHours(1);
+
   private final SigningKeyManager signingKeyManager;
 
   @GetMapping(path = "/.well-known/jwks.json", produces = MediaType.APPLICATION_JSON_VALUE)
-  public Map<String, Object> jwks() {
-    return signingKeyManager.getJwkSet();
+  public ResponseEntity<Map<String, Object>> jwks() {
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.maxAge(JWKS_CACHE_TTL).cachePublic())
+        .body(signingKeyManager.getJwkSet());
   }
 }

--- a/apps/auth/main/src/test/java/io/stablepay/auth/application/SigningKeyManagerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/application/SigningKeyManagerTest.java
@@ -90,6 +90,7 @@ class SigningKeyManagerTest {
         new com.nimbusds.jose.jwk.RSAKey.Builder(publicKey)
             .keyID(existing.kid())
             .algorithm(JWSAlgorithm.RS256)
+            .keyUse(com.nimbusds.jose.jwk.KeyUse.SIGNATURE)
             .build()
             .toJSONObject();
 

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
@@ -1,0 +1,130 @@
+package io.stablepay.auth.infrastructure.ratelimit;
+
+import static org.mockito.BDDMockito.willAnswer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.auth.client.ApiError;
+import jakarta.servlet.FilterChain;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class LoginRateLimitFilterTest {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+  private static final String LOGIN_PATH = "/api/v1/auth/login";
+  private static final String SOME_IP = "203.0.113.7";
+
+  @Mock private FilterChain chain;
+
+  private LoginRateLimitFilter filter;
+  private ObjectMapper objectMapper;
+  private AtomicInteger chainInvocations;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    objectMapper = new ObjectMapper().findAndRegisterModules();
+    filter = new LoginRateLimitFilter(objectMapper, Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    chainInvocations = new AtomicInteger(0);
+    willAnswer(
+            invocation -> {
+              chainInvocations.incrementAndGet();
+              return null;
+            })
+        .given(chain)
+        .doFilter(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void shouldAllowFirstFiveLoginRequestsFromSameIp() throws Exception {
+    // given
+    // when
+    for (var i = 0; i < 5; i++) {
+      filter.doFilter(loginRequest(), new MockHttpServletResponse(), chain);
+    }
+
+    // then
+    Assertions.assertThat(chainInvocations.get()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldReturn429WithRetryAfterAndApiErrorOnSixthRequest() throws Exception {
+    // given — exhaust the bucket
+    for (var i = 0; i < 5; i++) {
+      filter.doFilter(loginRequest(), new MockHttpServletResponse(), chain);
+    }
+    var response = new MockHttpServletResponse();
+    var expectedBody =
+        new ApiError(
+            "STBLPAY-1004", "Too many login attempts. Try again in 60 seconds.", FIXED_NOW);
+
+    // when
+    filter.doFilter(loginRequest(), response, chain);
+
+    // then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    Assertions.assertThat(response.getHeader(HttpHeaders.RETRY_AFTER)).isEqualTo("60");
+    Assertions.assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+    var actualBody = objectMapper.readValue(response.getContentAsString(), ApiError.class);
+    Assertions.assertThat(actualBody).usingRecursiveComparison().isEqualTo(expectedBody);
+    Assertions.assertThat(chainInvocations.get()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldNotRateLimitNonLoginPaths() throws Exception {
+    // given
+    var request = new MockHttpServletRequest();
+    request.setMethod("POST");
+    request.setRequestURI("/api/v1/auth/refresh");
+    request.setRemoteAddr(SOME_IP);
+
+    // when — fire 10 times, well above the 5/min limit
+    for (var i = 0; i < 10; i++) {
+      filter.doFilter(request, new MockHttpServletResponse(), chain);
+    }
+
+    // then
+    Assertions.assertThat(chainInvocations.get()).isEqualTo(10);
+  }
+
+  @Test
+  void shouldRateLimitPerIpIndependently() throws Exception {
+    // given — exhaust bucket for ip1
+    for (var i = 0; i < 5; i++) {
+      filter.doFilter(loginRequestFrom("198.51.100.1"), new MockHttpServletResponse(), chain);
+    }
+
+    // when — first request from a fresh ip2 must succeed
+    var response = new MockHttpServletResponse();
+    filter.doFilter(loginRequestFrom("198.51.100.2"), response, chain);
+
+    // then
+    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    Assertions.assertThat(chainInvocations.get()).isEqualTo(6);
+  }
+
+  private MockHttpServletRequest loginRequest() {
+    return loginRequestFrom(SOME_IP);
+  }
+
+  private MockHttpServletRequest loginRequestFrom(String ip) {
+    var request = new MockHttpServletRequest();
+    request.setMethod("POST");
+    request.setRequestURI(LOGIN_PATH);
+    request.setRemoteAddr(ip);
+    return request;
+  }
+}

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
@@ -1,7 +1,5 @@
 package io.stablepay.auth.infrastructure.ratelimit;
 
-import static org.mockito.BDDMockito.willAnswer;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stablepay.auth.client.ApiError;
 import jakarta.servlet.FilterChain;
@@ -12,40 +10,29 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-@ExtendWith(MockitoExtension.class)
 class LoginRateLimitFilterTest {
 
   private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
   private static final String LOGIN_PATH = "/api/v1/auth/login";
   private static final String SOME_IP = "203.0.113.7";
 
-  @Mock private FilterChain chain;
-
   private LoginRateLimitFilter filter;
   private ObjectMapper objectMapper;
   private AtomicInteger chainInvocations;
+  private FilterChain chain;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     objectMapper = new ObjectMapper().findAndRegisterModules();
     filter = new LoginRateLimitFilter(objectMapper, Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
     chainInvocations = new AtomicInteger(0);
-    willAnswer(
-            invocation -> {
-              chainInvocations.incrementAndGet();
-              return null;
-            })
-        .given(chain)
-        .doFilter(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    chain = (req, res) -> chainInvocations.incrementAndGet();
   }
 
   @Test
@@ -108,12 +95,31 @@ class LoginRateLimitFilterTest {
     }
 
     // when — first request from a fresh ip2 must succeed
-    var response = new MockHttpServletResponse();
-    filter.doFilter(loginRequestFrom("198.51.100.2"), response, chain);
+    filter.doFilter(loginRequestFrom("198.51.100.2"), new MockHttpServletResponse(), chain);
 
     // then
-    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
     Assertions.assertThat(chainInvocations.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldNormalizeTrailingSlashAndMatrixParamsForLoginPath() throws Exception {
+    // given — three rate-limited variants of the same path, plus two normal hits
+    var trailing = loginRequestFromWithUri(SOME_IP, LOGIN_PATH + "/");
+    var matrix = loginRequestFromWithUri(SOME_IP, LOGIN_PATH + ";jsessionid=abc");
+    var plain = loginRequestFromWithUri(SOME_IP, LOGIN_PATH);
+
+    // when — five attempts across normalized variants exhaust the bucket; the sixth is rejected
+    filter.doFilter(plain, new MockHttpServletResponse(), chain);
+    filter.doFilter(trailing, new MockHttpServletResponse(), chain);
+    filter.doFilter(matrix, new MockHttpServletResponse(), chain);
+    filter.doFilter(plain, new MockHttpServletResponse(), chain);
+    filter.doFilter(trailing, new MockHttpServletResponse(), chain);
+    var sixth = new MockHttpServletResponse();
+    filter.doFilter(matrix, sixth, chain);
+
+    // then
+    Assertions.assertThat(chainInvocations.get()).isEqualTo(5);
+    Assertions.assertThat(sixth.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
   }
 
   private MockHttpServletRequest loginRequest() {
@@ -121,9 +127,13 @@ class LoginRateLimitFilterTest {
   }
 
   private MockHttpServletRequest loginRequestFrom(String ip) {
+    return loginRequestFromWithUri(ip, LOGIN_PATH);
+  }
+
+  private MockHttpServletRequest loginRequestFromWithUri(String ip, String uri) {
     var request = new MockHttpServletRequest();
     request.setMethod("POST");
-    request.setRequestURI(LOGIN_PATH);
+    request.setRequestURI(uri);
     request.setRemoteAddr(ip);
     return request;
   }

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/AuthControllerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/AuthControllerTest.java
@@ -1,0 +1,173 @@
+package io.stablepay.auth.infrastructure.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.auth.application.AuthService;
+import io.stablepay.auth.application.AuthService.LoginOutcome;
+import io.stablepay.auth.client.ApiError;
+import io.stablepay.auth.client.LoginRequest;
+import io.stablepay.auth.client.RefreshRequest;
+import io.stablepay.auth.client.TokenResponse;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+  private static final String SOME_EMAIL = "alice@example.com";
+  private static final String SOME_PASSWORD = "Sup3rSecret!";
+  private static final String SOME_ACCESS_TOKEN = "access-token-xyz";
+  private static final String SOME_REFRESH_TOKEN = "refresh-token-abc";
+  private static final Duration ACCESS_TTL = Duration.ofMinutes(15);
+
+  @Mock private AuthService authService;
+
+  private MockMvc mockMvc;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    var clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+    var controller = new AuthController(authService, clock);
+    var advice = new GlobalExceptionHandler(clock);
+    mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(advice).build();
+    objectMapper = new ObjectMapper().findAndRegisterModules();
+  }
+
+  @Test
+  void shouldReturn200AndTokenResponseOnLoginSuccess() throws Exception {
+    // given
+    var expected = new TokenResponse(SOME_ACCESS_TOKEN, SOME_REFRESH_TOKEN, ACCESS_TTL.toSeconds());
+    given(authService.login(SOME_EMAIL, SOME_PASSWORD, FIXED_NOW))
+        .willReturn(new LoginOutcome.Success(SOME_ACCESS_TOKEN, SOME_REFRESH_TOKEN, ACCESS_TTL));
+    var requestBody = objectMapper.writeValueAsString(new LoginRequest(SOME_EMAIL, SOME_PASSWORD));
+
+    // when
+    var responseBody =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    var actual = objectMapper.readValue(responseBody, TokenResponse.class);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn401AndApiErrorOnInvalidLoginCredentials() throws Exception {
+    // given
+    var expected = new ApiError("STBLPAY-1001", "Invalid credentials", FIXED_NOW);
+    given(authService.login(SOME_EMAIL, SOME_PASSWORD, FIXED_NOW))
+        .willReturn(new LoginOutcome.InvalidCredentials());
+    var requestBody = objectMapper.writeValueAsString(new LoginRequest(SOME_EMAIL, SOME_PASSWORD));
+
+    // when
+    var responseBody =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    var actual = objectMapper.readValue(responseBody, ApiError.class);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn200AndTokenResponseOnRefreshSuccess() throws Exception {
+    // given
+    var newAccess = "new-access-token";
+    var newRefresh = "new-refresh-token";
+    var expected = new TokenResponse(newAccess, newRefresh, ACCESS_TTL.toSeconds());
+    given(authService.refresh(SOME_REFRESH_TOKEN, FIXED_NOW))
+        .willReturn(new LoginOutcome.Success(newAccess, newRefresh, ACCESS_TTL));
+    var requestBody = objectMapper.writeValueAsString(new RefreshRequest(SOME_REFRESH_TOKEN));
+
+    // when
+    var responseBody =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    var actual = objectMapper.readValue(responseBody, TokenResponse.class);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn401AndApiErrorOnInvalidRefreshToken() throws Exception {
+    // given
+    var expected = new ApiError("STBLPAY-1002", "Invalid credentials", FIXED_NOW);
+    given(authService.refresh(SOME_REFRESH_TOKEN, FIXED_NOW))
+        .willReturn(new LoginOutcome.InvalidCredentials());
+    var requestBody = objectMapper.writeValueAsString(new RefreshRequest(SOME_REFRESH_TOKEN));
+
+    // when
+    var responseBody =
+        mockMvc
+            .perform(
+                post("/api/v1/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    var actual = objectMapper.readValue(responseBody, ApiError.class);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn204AndDelegateToAuthServiceOnLogout() throws Exception {
+    // given
+    var requestBody = objectMapper.writeValueAsString(new RefreshRequest(SOME_REFRESH_TOKEN));
+
+    // when
+    mockMvc
+        .perform(
+            post("/api/v1/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isNoContent())
+        .andExpect(header().doesNotExist("Content-Type"));
+
+    // then
+    then(authService).should().logout(SOME_REFRESH_TOKEN, FIXED_NOW);
+  }
+}

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandlerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,64 @@
+package io.stablepay.auth.infrastructure.web;
+
+import io.stablepay.auth.client.ApiError;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+class GlobalExceptionHandlerTest {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+
+  private final GlobalExceptionHandler handler =
+      new GlobalExceptionHandler(Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+
+  @Test
+  void shouldReturn400AndJoinedFieldMessagesOnValidationFailure() throws Exception {
+    // given
+    var bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+    bindingResult.addError(new FieldError("request", "email", "must not be blank"));
+    bindingResult.addError(new FieldError("request", "password", "must not be blank"));
+    var ex = new MethodArgumentNotValidException(stubMethodParameter(), bindingResult);
+    var expected =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(
+                new ApiError(
+                    "STBLPAY-1003",
+                    "email: must not be blank; password: must not be blank",
+                    FIXED_NOW));
+
+    // when
+    var actual = handler.handleValidation(ex);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn500AndGenericMessageOnUnhandledException() {
+    // given
+    var ex = new RuntimeException("boom");
+    var expected =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new ApiError("STBLPAY-1999", "Internal server error", FIXED_NOW));
+
+    // when
+    var actual = handler.handleUnexpected(ex);
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  private static MethodParameter stubMethodParameter() throws NoSuchMethodException {
+    var method = GlobalExceptionHandlerTest.class.getDeclaredMethod("stubMethodParameter");
+    return new MethodParameter(method, -1);
+  }
+}

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandlerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/GlobalExceptionHandlerTest.java
@@ -8,10 +8,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
 
 class GlobalExceptionHandlerTest {
 
@@ -27,19 +34,16 @@ class GlobalExceptionHandlerTest {
     bindingResult.addError(new FieldError("request", "email", "must not be blank"));
     bindingResult.addError(new FieldError("request", "password", "must not be blank"));
     var ex = new MethodArgumentNotValidException(stubMethodParameter(), bindingResult);
-    var expected =
-        ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(
-                new ApiError(
-                    "STBLPAY-1003",
-                    "email: must not be blank; password: must not be blank",
-                    FIXED_NOW));
+    var expectedBody =
+        new ApiError(
+            "STBLPAY-1003", "email: must not be blank; password: must not be blank", FIXED_NOW);
 
     // when
-    var actual = handler.handleValidation(ex);
+    var actual = handler.handleException(ex, webRequest());
 
     // then
-    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    Assertions.assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    Assertions.assertThat(actual.getBody()).usingRecursiveComparison().isEqualTo(expectedBody);
   }
 
   @Test
@@ -55,6 +59,55 @@ class GlobalExceptionHandlerTest {
 
     // then
     Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReturn400OnMalformedJsonBody() throws Exception {
+    // given
+    var ex =
+        new HttpMessageNotReadableException("malformed", new MockHttpInputMessage(new byte[0]));
+    var expectedBody = new ApiError("STBLPAY-1003", "malformed", FIXED_NOW);
+
+    // when
+    var actual = handler.handleException(ex, webRequest());
+
+    // then
+    Assertions.assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    Assertions.assertThat(actual.getBody()).usingRecursiveComparison().isEqualTo(expectedBody);
+  }
+
+  @Test
+  void shouldReturn405WhenMethodNotSupported() throws Exception {
+    // given
+    var ex = new HttpRequestMethodNotSupportedException("GET");
+
+    // when
+    var actual = handler.handleException(ex, webRequest());
+
+    // then
+    Assertions.assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    Assertions.assertThat(((ApiError) actual.getBody()).errorCode()).isEqualTo("STBLPAY-1003");
+  }
+
+  @Test
+  void shouldReturn415WhenMediaTypeNotSupported() throws Exception {
+    // given
+    var ex =
+        new HttpMediaTypeNotSupportedException(
+            MediaType.TEXT_PLAIN, java.util.List.of(MediaType.APPLICATION_JSON));
+
+    // when
+    var actual = handler.handleException(ex, webRequest());
+
+    // then
+    Assertions.assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    Assertions.assertThat(((ApiError) actual.getBody()).errorCode()).isEqualTo("STBLPAY-1003");
+  }
+
+  private static ServletWebRequest webRequest() {
+    var req = new MockHttpServletRequest();
+    req.setRequestURI("/api/v1/auth/login");
+    return new ServletWebRequest(req);
   }
 
   private static MethodParameter stubMethodParameter() throws NoSuchMethodException {

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
@@ -2,6 +2,7 @@ package io.stablepay.auth.infrastructure.web;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -53,6 +54,7 @@ class JwksControllerTest {
         mockMvc
             .perform(get("/.well-known/jwks.json"))
             .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "max-age=3600, public"))
             .andReturn()
             .getResponse()
             .getContentAsString();

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
@@ -1,0 +1,64 @@
+package io.stablepay.auth.infrastructure.web;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.stablepay.auth.application.SigningKeyManager;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class JwksControllerTest {
+
+  @Mock private SigningKeyManager signingKeyManager;
+
+  private MockMvc mockMvc;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.standaloneSetup(new JwksController(signingKeyManager)).build();
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  void shouldReturnJwkSetFromSigningKeyManager() throws Exception {
+    // given
+    var expected =
+        Map.<String, Object>of(
+            "keys",
+            List.of(
+                Map.of(
+                    "kty", "RSA",
+                    "e", "AQAB",
+                    "n", "abcdef",
+                    "kid", "kid-1",
+                    "alg", "RS256",
+                    "use", "sig")));
+    given(signingKeyManager.getJwkSet()).willReturn(expected);
+
+    // when
+    var responseBody =
+        mockMvc
+            .perform(get("/.well-known/jwks.json"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    var actual = objectMapper.readValue(responseBody, new TypeReference<Map<String, Object>>() {});
+
+    // then
+    Assertions.assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ nimbus-jose-jwt = "10.9"
 flyway = "12.5.0"
 springdoc-openapi = "3.0.0"
 trino-jdbc = "475"
+caffeine = "3.2.2"
 
 [libraries]
 avro-core = { module = "org.apache.avro:avro", version.ref = "avro" }
@@ -73,6 +74,7 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-starter-webmvc-test = { module = "org.springframework.boot:spring-boot-starter-webmvc-test" }
 
 namastack-outbox-starter-jdbc = { module = "io.namastack:namastack-outbox-starter-jdbc", version.ref = "namastack-outbox" }
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
@@ -83,6 +85,7 @@ flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
 trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 trino-parser = { module = "io.trino:trino-parser", version.ref = "trino-jdbc" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 
 [plugins]
 avro = { id = "com.github.davidmc24.gradle.plugin.avro", version.ref = "avro-plugin" }


### PR DESCRIPTION
## Summary

Adds the HTTP surface for `apps/auth/`:

- `POST /api/v1/auth/login` → 200 `TokenResponse` | 401 `STBLPAY-1001`
- `POST /api/v1/auth/refresh` → 200 `TokenResponse` | 401 `STBLPAY-1002`
- `POST /api/v1/auth/logout` → 204 (idempotent)
- `GET /.well-known/jwks.json` → public RSA JWK with `use:sig`

Spring Security stateless config (CSRF off, `permitAll` on auth/jwks/health).
`LoginRateLimitFilter` (Bucket4j 8.18) gates `/login` at 5 req/min per client IP — exhaustion returns 429 + `Retry-After: 60` + `STBLPAY-1004`. Per-IP, **not** per-user, to avoid lockout-as-DoS.
`GlobalExceptionHandler` maps `MethodArgumentNotValidException` → 400 `STBLPAY-1003`, fallback `Exception` → 500 `STBLPAY-1999` (hides internals).

Side fix: `SigningKeyManager#getJwkSet` now sets `keyUse=SIGNATURE` so the published JWK actually includes `"use":"sig"` (required by AC #4).

Closes #89.

## Acceptance criteria

- [x] `POST /auth/login` → 200 + `TokenResponse` | 401 + `ApiError`
- [x] `POST /auth/refresh` → 200 + new tokens | 401 on invalid/expired
- [x] `POST /auth/logout` → 204
- [x] `GET /.well-known/jwks.json` → JWK with `kid`, `kty:"RSA"`, `alg:"RS256"`, `use:"sig"`
- [x] Stateless Spring Security, CSRF disabled, only auth/jwks/health public
- [x] Rate limiter: 429 + `Retry-After: 60` after 5 attempts/min from same IP
- [x] Bucket key per-IP (not per-user)
- [x] All errors use `STBLPAY-XXXX` codes
- [x] `Clock` injected as a bean (already exists in `AuthApplicationConfig`)

## Test plan

- [x] `./gradlew :apps:auth:main:build` — green (test + integrationTest + businessTest + spotlessCheck)
- [x] 12 new unit tests cover all 4 endpoints, 5/min limiter exhaustion + per-IP isolation, validation 400, fallback 500
- [x] `AuthArchitectureTest` still passes — new code lives in `infrastructure.{web,security,ratelimit}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user authentication endpoints with login, token refresh, and logout functionality.
  * Implemented rate limiting on login endpoint (5 attempts per minute per IP).
  * Added JWKS endpoint (/.well-known/jwks.json) for token signing key retrieval.
  * Standardized error responses with structured codes and messages.

* **Tests**
  * Added integration and unit tests for authentication endpoints and rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->