### PR TITLE
SPP-84: Compose service + Dockerfile + healthcheck for apps-auth

### DIFF
--- a/apps/auth/.dockerignore
+++ b/apps/auth/.dockerignore
@@ -1,0 +1,13 @@
+**/.gradle
+**/.idea
+**/src
+**/auth/build
+**/client/build
+**/main/build/classes
+**/main/build/distributions
+**/main/build/generated
+**/main/build/reports
+**/main/build/resources
+**/main/build/test-results
+**/main/build/tmp
+*.md

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,18 @@
+FROM eclipse-temurin:25-jre-alpine
+
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+COPY main/build/libs/stablepay-auth-*.jar app.jar
+
+RUN addgroup -S stablepay && adduser -S -G stablepay stablepay \
+    && chown stablepay:stablepay /app/app.jar
+USER stablepay
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=30s \
+    CMD curl -fs http://localhost:9000/actuator/health | grep -q '"status":"UP"' || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -251,6 +251,34 @@ services:
     networks:
       - stablepay_default
 
+  # ─── Auth Service (Spring Boot JWT issuer) ────────
+  apps-auth:
+    build:
+      context: ../apps/auth
+      dockerfile: Dockerfile
+    container_name: stablepay-auth
+    init: true
+    ports:
+      - "9100:9000"
+    environment:
+      AUTH_DB_URL: jdbc:postgresql://postgres:5432/stablepay_auth
+      AUTH_DB_USERNAME: ${POSTGRES_USER:-stablepay}
+      AUTH_DB_PASSWORD: ${POSTGRES_PASSWORD:-stablepay_dev}
+      AUTH_PORT: "9000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9000/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - stablepay_default
+
   # ─── Lakehouse Maintenance Jobs ───────────────────
   # Gated behind the `lakehouse` profile until Trino is added in Plan 3.4.
   # Run with: docker compose --profile lakehouse up -d lakehouse-jobs

--- a/justfile
+++ b/justfile
@@ -110,6 +110,21 @@ superset-init:
 trino-time-travel version:
     docker exec stablepay-trino trino --server http://localhost:8080 --execute "SELECT count(*) FROM iceberg.facts.fact_transactions FOR VERSION AS OF {{version}}"
 
+# ─── Auth Service ─────────────────────────────────
+
+# Build the auth service jar and Docker image
+auth-build:
+    ./gradlew :apps:auth:main:bootJar
+    docker compose -f infra/docker-compose.yml build apps-auth
+
+# Bring up the auth service (waits for healthy)
+auth-up:
+    docker compose -f infra/docker-compose.yml up -d --wait apps-auth
+
+# Follow auth service logs
+auth-logs:
+    docker compose -f infra/docker-compose.yml logs -f apps-auth
+
 # ─── DLQ Tools ────────────────────────────────────
 
 # List DLQ entries


### PR DESCRIPTION
## Summary

Containerize `apps/auth/` (Spring Boot JWT issuer) for `just up` orchestration. Closes #90.

- **`apps/auth/Dockerfile`** — `eclipse-temurin:25-jre-alpine` with `curl` installed (alpine JRE doesn't ship curl/wget by default — without this the healthcheck would emit "command not found" and the container would loop unhealthy, blocking `depends_on: service_healthy` indefinitely). Non-root user, exec-form `ENTRYPOINT` for SIGTERM forwarding, container `HEALTHCHECK` mirroring the compose-level test.
- **`apps/auth/.dockerignore`** — keeps build context focused on `main/build/libs/` (rest of source tree, IDE artifacts, generated reports excluded).
- **`infra/docker-compose.yml`** — adds `apps-auth` service. Build context `../apps/auth` (consistent with `lakehouse-jobs`), `mem_limit: 512m`, `depends_on: postgres: condition: service_healthy`, `init: true` for proper signal forwarding, restart `unless-stopped`, joined to `stablepay_default`.
- **`justfile`** — `auth-build`, `auth-up`, `auth-logs` recipes following the existing `flink-*` style.

## Deviations from the spec (with rationale)

1. **Host port `9100:9000`** instead of `9000:9000` — MinIO already binds host port 9000 (`infra/docker-compose.yml:94`). Container-internal port stays 9000.
2. **Healthcheck uses `CMD-SHELL`** instead of `CMD` (issue's literal example used `CMD ... | grep`) — Compose v2 `CMD` form runs without a shell, so the `|` and `||` would be passed as literal arguments to `curl` and the healthcheck would silently fail. `CMD-SHELL` is the only correct form for a piped test.
3. **Build context `../apps/auth`** instead of repo root — matches the `lakehouse-jobs` pattern, keeps the build context small, and avoids accidentally sending `.git` / `.env` / other module builds to the Docker daemon.
4. **Env vars `AUTH_DB_URL`/`AUTH_DB_USERNAME`/`AUTH_DB_PASSWORD`/`AUTH_PORT`** instead of generic `POSTGRES_HOST`/`POSTGRES_PORT`/`POSTGRES_USER`/`POSTGRES_PASSWORD` — these are the keys the Spring app actually reads (`apps/auth/main/src/main/resources/application.yml`). The compose entry interpolates them from the existing `POSTGRES_USER`/`POSTGRES_PASSWORD` in `.env`, so no `.env.example` change is required.

## Verification

- [x] `docker compose -f infra/docker-compose.yml config --quiet` validates clean
- [x] `docker compose -f infra/docker-compose.yml build apps-auth` succeeds
- [x] Container builds, JVM starts, healthcheck command syntax is correct (verified rendered config: `["CMD-SHELL", "curl -fs http://localhost:9000/actuator/health | grep -q '\"status\":\"UP\"' || exit 1"]`)
- [⚠️] **Runtime healthcheck blocked by upstream issue from SPP-83**: the auth jar fails at startup with `Parameter 0 of constructor in LoginRateLimitFilter required a bean of type 'com.fasterxml.jackson.databind.ObjectMapper' that could not be found`. Root cause: Spring Boot 4.0.6 ships Jackson 3 (`tools.jackson.databind.ObjectMapper`) by default while `LoginRateLimitFilter.java` imports Jackson 2 (`com.fasterxml.jackson.databind.ObjectMapper`). The fat jar contains both `jackson-databind-2.21.2.jar` and `jackson-databind-3.1.2.jar`, but only the v3 bean is auto-configured. **This is a pre-existing bug in SPP-83's runtime, not introduced by SPP-84.** Recommend opening a separate ticket to switch the import to `tools.jackson.databind.ObjectMapper` (or expose a Jackson 2 `ObjectMapper` bean).

## Test plan

- [x] Compose config validates
- [x] Image builds
- [ ] (post-Jackson-fix) `just auth-build && just auth-up` brings the service up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)