### PR TITLE
fix(auth): use Jackson 3 ObjectMapper to match Spring Boot 4 autoconfig

### DIFF
--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stablepay.auth.application.AuthService;
 import io.stablepay.auth.application.AuthService.LoginOutcome;
 import io.stablepay.auth.application.SigningKeyManager;
@@ -25,6 +24,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {AuthController.class, JwksController.class})
 @Import({

--- a/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/TestConfig.java
+++ b/apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/TestConfig.java
@@ -1,11 +1,12 @@
 package io.stablepay.auth.infrastructure.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @TestConfiguration
 class TestConfig {
@@ -19,6 +20,6 @@ class TestConfig {
 
   @Bean
   ObjectMapper objectMapper() {
-    return new ObjectMapper().findAndRegisterModules();
+    return JsonMapper.builder().findAndAddModules().build();
   }
 }

--- a/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
+++ b/apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java
@@ -1,6 +1,5 @@
 package io.stablepay.auth.infrastructure.ratelimit;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bucket;
@@ -19,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java
@@ -1,6 +1,5 @@
 package io.stablepay.auth.infrastructure.ratelimit;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stablepay.auth.client.ApiError;
 import jakarta.servlet.FilterChain;
 import java.time.Clock;
@@ -15,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class LoginRateLimitFilterTest {
 
@@ -29,7 +30,7 @@ class LoginRateLimitFilterTest {
 
   @BeforeEach
   void setUp() {
-    objectMapper = new ObjectMapper().findAndRegisterModules();
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
     filter = new LoginRateLimitFilter(objectMapper, Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
     chainInvocations = new AtomicInteger(0);
     chain = (req, res) -> chainInvocations.incrementAndGet();

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/AuthControllerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/AuthControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stablepay.auth.application.AuthService;
 import io.stablepay.auth.application.AuthService.LoginOutcome;
 import io.stablepay.auth.client.ApiError;
@@ -26,6 +25,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -48,7 +49,7 @@ class AuthControllerTest {
     var controller = new AuthController(authService, clock);
     var advice = new GlobalExceptionHandler(clock);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).setControllerAdvice(advice).build();
-    objectMapper = new ObjectMapper().findAndRegisterModules();
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
   }
 
   @Test

--- a/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
+++ b/apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java
@@ -5,8 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.stablepay.auth.application.SigningKeyManager;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +16,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class JwksControllerTest {
@@ -30,7 +31,7 @@ class JwksControllerTest {
   @BeforeEach
   void setUp() {
     mockMvc = MockMvcBuilders.standaloneSetup(new JwksController(signingKeyManager)).build();
-    objectMapper = new ObjectMapper();
+    objectMapper = JsonMapper.builder().build();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Spring Boot 4.0.6 auto-configures the **Jackson 3** `ObjectMapper` (`tools.jackson.databind.ObjectMapper`). `LoginRateLimitFilter` and the auth test stack imported the **Jackson 2** type (`com.fasterxml.jackson.databind.ObjectMapper`), so the production context failed at startup with:

> Parameter 0 of constructor in `LoginRateLimitFilter` required a bean of type `'com.fasterxml.jackson.databind.ObjectMapper'` that could not be found.

This blocked the auth service from starting in the Docker container shipped in #134 (SPP-84).

## Why Jackson 3, not a Jackson 2 bean?

Spring Boot 4's transitive deps (`spring-boot-starter-jackson` → `tools.jackson.core:jackson-databind:3.1.2`) make Jackson 3 the framework default. Jackson 2 jars are still pulled in transitively (via `springdoc-openapi-starter-webmvc-ui`), but those are unused by our code. Defining a Jackson 2 `ObjectMapper @Bean` to satisfy the old import would just paper over the version drift. Migrating the auth code to Jackson 3 aligns with the framework default and matches what `JacksonAutoConfiguration` actually publishes.

DTO annotations (`@JsonProperty` from `com.fasterxml.jackson.annotation`) are unchanged — Jackson 3 reads them natively because `tools.jackson.databind:3.1.2` transitively depends on `jackson-annotations:2.21`.

## Changes

- `LoginRateLimitFilter` — switch `ObjectMapper` import from Jackson 2 to `tools.jackson.databind.ObjectMapper`
- Tests + integration test fixtures — same import switch; replace the deprecated `new ObjectMapper().findAndRegisterModules()` idiom with the Jackson 3 builder form `JsonMapper.builder().findAndAddModules().build()`
- `JwksControllerTest` — `TypeReference` import switched to `tools.jackson.core.type.TypeReference`

Files touched (6):
- `apps/auth/main/src/main/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilter.java`
- `apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/ratelimit/LoginRateLimitFilterTest.java`
- `apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/AuthControllerTest.java`
- `apps/auth/main/src/test/java/io/stablepay/auth/infrastructure/web/JwksControllerTest.java`
- `apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/TestConfig.java`
- `apps/auth/main/src/integration-test/java/io/stablepay/auth/infrastructure/security/SecurityFilterChainIT.java`

## Verification

- [x] \`./gradlew :apps:auth:main:check\` passes (unit + integration + business + spotless) — BUILD SUCCESSFUL in 29s
- [x] Running the boot jar locally confirms the Spring context fully wires past \`LoginRateLimitFilter\` and starts Tomcat. The previous startup failure (\"ObjectMapper bean not found\") is gone; the only remaining failure is the unrelated Hikari Postgres auth on the local dev machine.

## Relation to other PRs

- Unblocks the runtime healthcheck in #134 (SPP-84). With both PRs merged, \`just auth-up\` brings the service up healthy end-to-end.

## Test plan

- [x] \`./gradlew :apps:auth:main:check\`
- [ ] After merging #134 too: \`just auth-build && just auth-up\` reaches \`/actuator/health\` returning \`{\"status\":\"UP\"}\` inside the configured \`start_period\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)