### PR TITLE
fix(auth): add spring-boot-starter-flyway so migrations run on startup

### DIFF
--- a/apps/auth/main/build.gradle.kts
+++ b/apps/auth/main/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.validation)
 
+    implementation(libs.spring.boot.starter.flyway)
     implementation(libs.flyway.core)
     runtimeOnly(libs.flyway.database.postgresql)
     runtimeOnly(libs.postgresql.driver)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ spring-boot-starter-validation = { module = "org.springframework.boot:spring-boo
 spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-boot-starter-webmvc-test = { module = "org.springframework.boot:spring-boot-starter-webmvc-test" }
+spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 
 namastack-outbox-starter-jdbc = { module = "io.namastack:namastack-outbox-starter-jdbc", version.ref = "namastack-outbox" }
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }


### PR DESCRIPTION
## Summary

Spring Boot 4.0 modularized **FlywayAutoConfiguration** out of `spring-boot-autoconfigure` into a dedicated `spring-boot-flyway` module. The auth module declared `org.flywaydb:flyway-core` directly but never pulled in the autoconfig, so Flyway didn't run at startup. Spring Data JDBC then queried `jwt_signing_keys` against an empty schema and the actuator healthcheck stayed unhealthy with:

> `ERROR: relation "jwt_signing_keys" does not exist`

This blocked the runtime AC of #134 (SPP-84) even after the Jackson 3 fix in #135 went in.

## Why a starter, not just `flyway-core`

Spring Boot 3 bundled `FlywayAutoConfiguration` inside `spring-boot-autoconfigure`, so a bare `org.flywaydb:flyway-core` was enough — Boot wired it up, read `spring.flyway.*`, and ran migrations on the primary `DataSource` automatically. In Spring Boot 4 the autoconfig moved to `org.springframework.boot:spring-boot-flyway`. `spring-boot-starter-flyway` is the canonical way to bring it in (and it transitively pins `flyway-core` to the BOM-managed version, alongside our existing explicit pin in `libs.versions.toml`).

## Changes

- `gradle/libs.versions.toml` — add `spring-boot-starter-flyway` alias (BOM-managed version).
- `apps/auth/main/build.gradle.kts` — add `implementation(libs.spring.boot.starter.flyway)`. Keep the explicit `flyway-core` and `flyway-database-postgresql` pins so we still control the Flyway version (`12.5.0`).

## Verification

- [x] `./gradlew :apps:auth:main:check` — BUILD SUCCESSFUL (unit + integration + business + spotless)
- [x] Fat jar now includes `BOOT-INF/lib/spring-boot-flyway-4.0.6.jar` containing `FlywayAutoConfiguration` and `FlywayProperties`
- [x] `docker compose up apps-auth` — Flyway applies V1/V2/V3, four tables created (`flyway_schema_history`, `users`, `refresh_tokens`, `jwt_signing_keys`), `curl /actuator/health` returns `{"status":"UP"}`, `Container stablepay-auth Healthy`

## Relation to other PRs

Closes the runtime gap left after #134 (SPP-84) and #135 (Jackson 3). With this merged, `just auth-build && just auth-up` brings the service up healthy end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)