### PR TITLE
feat(api): wire apps/api Gradle modules with Phase 4 dependencies (SPP-86)

### DIFF
--- a/apps/api/api/build.gradle.kts
+++ b/apps/api/api/build.gradle.kts
@@ -1,7 +1,22 @@
 plugins {
     id("stablepay.java-conventions")
+    `java-library`
+    `java-test-fixtures`
 }
 
 dependencies {
     implementation(project(":schemas"))
+
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+
+    testFixturesCompileOnly(libs.lombok)
+    testFixturesAnnotationProcessor(libs.lombok)
+    testFixturesImplementation(libs.assertj.core)
+    testFixturesImplementation(libs.mockito.core)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.assertj.core)
 }

--- a/apps/api/client/build.gradle.kts
+++ b/apps/api/client/build.gradle.kts
@@ -1,7 +1,26 @@
 plugins {
     id("stablepay.java-conventions")
+    alias(libs.plugins.spring.dependency.management)
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:${libs.versions.spring.boot.get()}")
+    }
 }
 
 dependencies {
+    implementation(project(":apps:api:api"))
     implementation(project(":schemas"))
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.validation)
+
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.spring.boot.starter.test)
 }

--- a/apps/api/main/build.gradle.kts
+++ b/apps/api/main/build.gradle.kts
@@ -1,9 +1,147 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
     id("stablepay.java-conventions")
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    `java-test-fixtures`
+    jacoco
 }
+
+val integrationTest: SourceSet by sourceSets.creating {
+    java.srcDir("src/integration-test/java")
+    resources.srcDir("src/integration-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets["testFixtures"].output
+    runtimeClasspath += output + compileClasspath
+}
+
+val businessTest: SourceSet by sourceSets.creating {
+    java.srcDir("src/business-test/java")
+    resources.srcDir("src/business-test/resources")
+    compileClasspath += sourceSets.main.get().output + sourceSets["testFixtures"].output
+    runtimeClasspath += output + compileClasspath
+}
+
+val integrationTestImplementation: Configuration by configurations.getting {
+    extendsFrom(
+        configurations.testImplementation.get(),
+        configurations["testFixturesApi"],
+    )
+}
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations.testRuntimeOnly.get())
+
+val businessTestImplementation: Configuration by configurations.getting {
+    extendsFrom(
+        configurations.testImplementation.get(),
+        configurations.implementation.get(),
+        configurations["testFixturesApi"],
+    )
+}
+configurations["businessTestRuntimeOnly"].extendsFrom(
+    configurations.testRuntimeOnly.get(),
+    configurations.runtimeOnly.get(),
+)
 
 dependencies {
     implementation(project(":apps:api:api"))
     implementation(project(":apps:api:client"))
     implementation(project(":schemas"))
+
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.data.jdbc)
+    implementation(libs.spring.boot.starter.data.redis)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.oauth2.resource.server)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.aspectj)
+
+    implementation(libs.spring.boot.starter.flyway)
+    implementation(libs.flyway.core)
+    runtimeOnly(libs.flyway.database.postgresql)
+    runtimeOnly(libs.postgresql.driver)
+
+    implementation(libs.namastack.outbox.starter.jdbc)
+    implementation(libs.opensearch.java)
+    implementation(libs.httpclient5)
+    implementation(libs.trino.jdbc)
+    implementation(libs.nv.i18n)
+
+    implementation(libs.bucket4j.core)
+    implementation(libs.bucket4j.redis)
+    implementation(libs.caffeine)
+
+    implementation(libs.nimbus.jose.jwt)
+    implementation(libs.springdoc.openapi.starter.webmvc.ui)
+
+    implementation(libs.mapstruct)
+    annotationProcessor(libs.mapstruct.processor)
+
+    compileOnly(libs.lombok)
+    annotationProcessor(libs.lombok)
+
+    testFixturesApi(libs.spring.boot.starter.test)
+    testFixturesApi(libs.spring.security.test)
+    testFixturesApi(libs.testcontainers.postgres)
+    testFixturesCompileOnly(libs.lombok)
+    testFixturesAnnotationProcessor(libs.lombok)
+
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.archunit.junit5)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.junit)
+    testCompileOnly(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
+
+    integrationTestImplementation(libs.spring.boot.starter.test)
+    integrationTestImplementation(libs.spring.boot.starter.webmvc.test)
+    integrationTestImplementation(libs.spring.security.test)
+    integrationTestImplementation(libs.testcontainers.postgres)
+    integrationTestImplementation(libs.testcontainers.junit)
+    "integrationTestCompileOnly"(libs.lombok)
+    "integrationTestAnnotationProcessor"(libs.lombok)
+
+    businessTestImplementation(libs.spring.boot.starter.test)
+    businessTestImplementation(libs.spring.boot.resttestclient)
+    businessTestImplementation(libs.spring.boot.http.client)
+    businessTestImplementation(libs.spring.boot.restclient)
+    businessTestImplementation(libs.spring.boot.testcontainers)
+    businessTestImplementation(libs.testcontainers.postgres)
+    businessTestImplementation(libs.testcontainers.junit)
+    businessTestImplementation(libs.nimbus.jose.jwt)
+    "businessTestCompileOnly"(libs.lombok)
+    "businessTestAnnotationProcessor"(libs.lombok)
+}
+
+val integrationTestTask = tasks.register<Test>("integrationTest") {
+    description = "Runs integration tests."
+    group = "verification"
+    testClassesDirs = integrationTest.output.classesDirs
+    classpath = integrationTest.runtimeClasspath
+    shouldRunAfter("test")
+}
+
+val businessTestTask = tasks.register<Test>("businessTest") {
+    description = "Runs business (E2E) tests."
+    group = "verification"
+    testClassesDirs = businessTest.output.classesDirs
+    classpath = businessTest.runtimeClasspath
+    shouldRunAfter("integrationTest")
+}
+
+tasks.withType<JacocoReport>().configureEach {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.named("check") {
+    dependsOn(integrationTestTask, businessTestTask, "jacocoTestReport")
+}
+
+tasks.named<BootJar>("bootJar") {
+    archiveBaseName.set("stablepay-api")
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/StablepayApiApplication.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/StablepayApiApplication.java
@@ -1,0 +1,16 @@
+package io.stablepay.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+@EnableAspectJAutoProxy
+public class StablepayApiApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(StablepayApiApplication.class, args);
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,7 +72,7 @@ spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boot:spring-boot-starter-oauth2-resource-server" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
-spring-boot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
+spring-boot-starter-aspectj = { module = "org.springframework.boot:spring-boot-starter-aspectj" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-boot-starter-webmvc-test = { module = "org.springframework.boot:spring-boot-starter-webmvc-test" }
 spring-boot-resttestclient = { module = "org.springframework.boot:spring-boot-resttestclient" }

--- a/infra/postgres/init/05-stablepay-api.sql
+++ b/infra/postgres/init/05-stablepay-api.sql
@@ -1,0 +1,3 @@
+-- API service database (Phase 4)
+CREATE DATABASE stablepay_api;
+GRANT ALL PRIVILEGES ON DATABASE stablepay_api TO stablepay;


### PR DESCRIPTION
Closes #92

## Summary
- Wires `apps/api/{api,client,main}` Gradle skeletons with the full Phase 4 dependency set, mirroring the established `apps/auth/main` pattern.
- Adds `StablepayApiApplication` entry point at `io.stablepay.api` with `@EnableScheduling` and `@EnableAspectJAutoProxy`.
- Creates `infra/postgres/init/05-stablepay-api.sql` to provision the `stablepay_api` database.
- Renames `spring-boot-starter-aop` → `spring-boot-starter-aspectj` in `gradle/libs.versions.toml` (Spring Boot 4.0.x removed the legacy alias and the ship-replacement is `starter-aspectj`).

## Why these versions
All deps reuse aliases that already exist in `gradle/libs.versions.toml`:
- Spring Boot 4.0.6, Flyway 12.5.0, Namastack outbox 1.4.1, OpenSearch Java 3.0.0, Trino JDBC 475, Bucket4j jdk17 8.18.0, Nimbus JOSE 10.9, nv-i18n 1.29, SpringDoc 3.0.0, MapStruct 1.6.3, Lombok 1.18.38, ArchUnit 1.4.2, Testcontainers 1.20.6.

## Module structure
- **`apps/api/api`** — pure DTO/contract module. `java-library` + `java-test-fixtures` + Lombok. No Spring.
- **`apps/api/client`** — HTTP client for downstream services. Imports the Spring Boot BOM, depends on `:apps:api:api` + `:schemas`, includes `spring-boot-starter-web` and `-validation`.
- **`apps/api/main`** — Spring Boot 4 application. Full Phase 4 dep set, four source sets (`test`, `testFixtures`, `integration-test`, `business-test`), bootJar archive name `stablepay-api`.

## Deviations from #92 spec
- **Postgres init filename is `05-stablepay-api.sql`, not `04-stablepay-api.sql`** — `04-superset.sql` already exists and ships from prior phases. Bumped to `05-` to keep the lexicographic ordering valid.
- **`apps/api/main` does not yet include a Jacoco coverage rule** — there's no application code yet to set a meaningful threshold against. Coverage rules will be added in plan 4.2.2+ when domain services land.

## Test plan
- [x] `./gradlew spotlessApply` — clean
- [x] `./gradlew :apps:api:main:bootJar` — succeeds (acceptance criterion #1)
- [x] `./gradlew :apps:api:api:build :apps:api:client:build :apps:api:main:build` — all green
- [x] `./gradlew :apps:api:main:compile{Test,TestFixtures,IntegrationTest,BusinessTest}Java` — all four source sets resolve and compile (no sources yet, but compile config is wired)
- [x] `./gradlew :apps:api:main:dependencies --configuration runtimeClasspath` — confirmed bucket4j_jdk17 8.18.0, namastack-outbox 1.4.1, opensearch-java 3.0.0, trino-jdbc 475, nimbus-jose-jwt 10.9, flyway 12.5.0 all resolve cleanly.

## Acceptance criteria (from #92)
- [x] `./gradlew :apps:api:main:bootJar` succeeds
- [x] All four source sets configured per `docs/TESTING_STANDARDS.md`
- [x] Phase 4 deps present: bucket4j, namastack outbox, opensearch-java, trino-jdbc, nimbus JOSE
- [x] New Postgres init script creates `stablepay_api` database
- [x] `apps:api` Gradle module wires everything cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)