### PR TITLE
SPP-89: add Spring Security JWT bearer auth with AuthenticatedUser

### DIFF
--- a/apps/api/main/build.gradle.kts
+++ b/apps/api/main/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
 
     testFixturesApi(libs.spring.boot.starter.test)
     testFixturesApi(libs.spring.security.test)
+    testFixturesApi(libs.spring.boot.starter.oauth2.resource.server)
     testFixturesApi(libs.testcontainers.postgres)
     testFixturesApi(libs.nv.i18n)
     testFixturesCompileOnly(libs.lombok)

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/AuthenticatedUser.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/AuthenticatedUser.java
@@ -1,0 +1,38 @@
+package io.stablepay.api.infrastructure.security;
+
+import io.stablepay.api.domain.model.CustomerId;
+import io.stablepay.api.domain.model.UserId;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AuthenticatedUser(
+    UserId userId, Optional<CustomerId> customerId, Set<Role> roles, String email) {
+
+  public AuthenticatedUser {
+    Objects.requireNonNull(userId, "userId");
+    Objects.requireNonNull(customerId, "customerId");
+    Objects.requireNonNull(roles, "roles");
+    Objects.requireNonNull(email, "email");
+    roles = Set.copyOf(roles);
+  }
+
+  public boolean isAdmin() {
+    return roles.contains(Role.ADMIN);
+  }
+
+  public boolean isCustomer() {
+    return roles.contains(Role.CUSTOMER);
+  }
+
+  public boolean isAgent() {
+    return roles.contains(Role.AGENT);
+  }
+
+  public CustomerId requireCustomerId() {
+    return customerId.orElseThrow(
+        () -> new IllegalStateException("Endpoint requires CUSTOMER role"));
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/AuthenticatedUserToken.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/AuthenticatedUserToken.java
@@ -1,0 +1,40 @@
+package io.stablepay.api.infrastructure.security;
+
+import java.util.Collection;
+import java.util.Objects;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AuthenticatedUserToken extends AbstractAuthenticationToken {
+
+  private final Jwt jwt;
+  private final AuthenticatedUser principal;
+
+  public AuthenticatedUserToken(
+      Jwt jwt, AuthenticatedUser principal, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    this.jwt = Objects.requireNonNull(jwt, "jwt");
+    this.principal = Objects.requireNonNull(principal, "principal");
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return jwt;
+  }
+
+  @Override
+  public AuthenticatedUser getPrincipal() {
+    return principal;
+  }
+
+  public Jwt getToken() {
+    return jwt;
+  }
+
+  @Override
+  public String getName() {
+    return principal.email();
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverter.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverter.java
@@ -1,0 +1,42 @@
+package io.stablepay.api.infrastructure.security;
+
+import io.stablepay.api.domain.model.CustomerId;
+import io.stablepay.api.domain.model.UserId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtToAuthenticatedUserConverter
+    implements Converter<Jwt, AbstractAuthenticationToken> {
+
+  private static final String CLAIM_ROLES = "roles";
+  private static final String CLAIM_CUSTOMER_ID = "customer_id";
+  private static final String CLAIM_EMAIL = "email";
+  private static final String ROLE_PREFIX = "ROLE_";
+
+  @Override
+  public AbstractAuthenticationToken convert(Jwt jwt) {
+    var roleClaims = Optional.ofNullable(jwt.getClaimAsStringList(CLAIM_ROLES)).orElse(List.of());
+    var authorities =
+        roleClaims.stream().map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role)).toList();
+    var customerId =
+        Optional.ofNullable(jwt.getClaimAsString(CLAIM_CUSTOMER_ID))
+            .map(value -> CustomerId.of(UUID.fromString(value)));
+    var roles = roleClaims.stream().map(Role::valueOf).collect(Collectors.toUnmodifiableSet());
+    var user =
+        AuthenticatedUser.builder()
+            .userId(UserId.of(UUID.fromString(jwt.getSubject())))
+            .customerId(customerId)
+            .roles(roles)
+            .email(jwt.getClaimAsString(CLAIM_EMAIL))
+            .build();
+    return new AuthenticatedUserToken(jwt, user, authorities);
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/Role.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/Role.java
@@ -1,0 +1,7 @@
+package io.stablepay.api.infrastructure.security;
+
+public enum Role {
+  CUSTOMER,
+  ADMIN,
+  AGENT
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,39 @@
+package io.stablepay.api.infrastructure.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private static final String[] PUBLIC_ENDPOINTS = {
+    "/actuator/health", "/actuator/health/**", "/v3/api-docs/**", "/swagger-ui/**"
+  };
+
+  private final JwtToAuthenticatedUserConverter jwtConverter;
+
+  @Value("${stablepay.auth.jwks-uri}")
+  private String jwksUri;
+
+  @Bean
+  public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+    return http.csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            a -> a.requestMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated())
+        .oauth2ResourceServer(
+            o -> o.jwt(j -> j.jwkSetUri(jwksUri).jwtAuthenticationConverter(jwtConverter)))
+        .build();
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package io.stablepay.api.infrastructure.security;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,20 +13,18 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true)
-@RequiredArgsConstructor
 public class SecurityConfig {
 
   private static final String[] PUBLIC_ENDPOINTS = {
     "/actuator/health", "/actuator/health/**", "/v3/api-docs/**", "/swagger-ui/**"
   };
 
-  private final JwtToAuthenticatedUserConverter jwtConverter;
-
-  @Value("${stablepay.auth.jwks-uri}")
-  private String jwksUri;
-
   @Bean
-  public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain apiSecurityFilterChain(
+      HttpSecurity http,
+      JwtToAuthenticatedUserConverter jwtConverter,
+      @Value("${stablepay.auth.jwks-uri}") String jwksUri)
+      throws Exception {
     return http.csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(

--- a/apps/api/main/src/main/resources/application.yml
+++ b/apps/api/main/src/main/resources/application.yml
@@ -26,6 +26,8 @@ namastack:
         enabled: true
 
 stablepay:
+  auth:
+    jwks-uri: ${STABLEPAY_AUTH_JWKS_URI:http://apps-auth:9000/.well-known/jwks.json}
   opensearch:
     uri: ${OPENSEARCH_URI:http://opensearch:9200}
     transactions-index: ${OPENSEARCH_TRANSACTIONS_INDEX:transactions}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/AuthenticatedUserTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/AuthenticatedUserTest.java
@@ -1,0 +1,130 @@
+package io.stablepay.api.infrastructure.security;
+
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_ID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_USER_ID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAgentUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AuthenticatedUserTest {
+
+  @Test
+  void shouldBuildCustomerUser() {
+    var result =
+        AuthenticatedUser.builder()
+            .userId(SOME_USER_ID)
+            .customerId(Optional.of(SOME_CUSTOMER_ID))
+            .roles(Set.of(Role.CUSTOMER))
+            .email(SOME_CUSTOMER_EMAIL)
+            .build();
+
+    var expected = someCustomerUser();
+
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldBuildAdminUserWithoutCustomerId() {
+    var result =
+        AuthenticatedUser.builder()
+            .userId(SOME_USER_ID)
+            .customerId(Optional.empty())
+            .roles(Set.of(Role.ADMIN))
+            .email(SOME_ADMIN_EMAIL)
+            .build();
+
+    var expected = someAdminUser();
+
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldReportCustomerRole() {
+    var result = someCustomerUser();
+
+    assertThat(result.isCustomer()).isTrue();
+    assertThat(result.isAdmin()).isFalse();
+    assertThat(result.isAgent()).isFalse();
+  }
+
+  @Test
+  void shouldReportAdminRole() {
+    var result = someAdminUser();
+
+    assertThat(result.isAdmin()).isTrue();
+    assertThat(result.isCustomer()).isFalse();
+    assertThat(result.isAgent()).isFalse();
+  }
+
+  @Test
+  void shouldReportAgentRole() {
+    var result = someAgentUser();
+
+    assertThat(result.isAgent()).isTrue();
+    assertThat(result.isCustomer()).isFalse();
+    assertThat(result.isAdmin()).isFalse();
+  }
+
+  @Test
+  void shouldReturnCustomerIdWhenPresent() {
+    var user = someCustomerUser();
+
+    var result = user.requireCustomerId();
+
+    assertThat(result).usingRecursiveComparison().isEqualTo(SOME_CUSTOMER_ID);
+  }
+
+  @Test
+  void shouldThrowWhenAdminAttemptsToRequireCustomerId() {
+    var user = someAdminUser();
+
+    assertThatThrownBy(user::requireCustomerId)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Endpoint requires CUSTOMER role");
+  }
+
+  @Test
+  void shouldThrowWhenAgentAttemptsToRequireCustomerId() {
+    var user = someAgentUser();
+
+    assertThatThrownBy(user::requireCustomerId)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Endpoint requires CUSTOMER role");
+  }
+
+  @Test
+  void shouldRejectNullUserId() {
+    assertThatThrownBy(
+            () ->
+                AuthenticatedUser.builder()
+                    .userId(null)
+                    .customerId(Optional.empty())
+                    .roles(Set.of(Role.ADMIN))
+                    .email(SOME_ADMIN_EMAIL)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("userId");
+  }
+
+  @Test
+  void shouldRejectNullCustomerIdOptional() {
+    assertThatThrownBy(
+            () ->
+                AuthenticatedUser.builder()
+                    .userId(SOME_USER_ID)
+                    .customerId(null)
+                    .roles(Set.of(Role.ADMIN))
+                    .email(SOME_ADMIN_EMAIL)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("customerId");
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/AuthenticatedUserTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/AuthenticatedUserTest.java
@@ -1,9 +1,10 @@
 package io.stablepay.api.infrastructure.security;
 
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_USER_ID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_EMAIL;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_ID;
-import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_USER_ID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_USER_ID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAgentUser;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
@@ -18,38 +19,42 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldBuildCustomerUser() {
+    // when
     var result =
         AuthenticatedUser.builder()
-            .userId(SOME_USER_ID)
+            .userId(SOME_CUSTOMER_USER_ID)
             .customerId(Optional.of(SOME_CUSTOMER_ID))
             .roles(Set.of(Role.CUSTOMER))
             .email(SOME_CUSTOMER_EMAIL)
             .build();
 
+    // then
     var expected = someCustomerUser();
-
     assertThat(result).usingRecursiveComparison().isEqualTo(expected);
   }
 
   @Test
   void shouldBuildAdminUserWithoutCustomerId() {
+    // when
     var result =
         AuthenticatedUser.builder()
-            .userId(SOME_USER_ID)
+            .userId(SOME_ADMIN_USER_ID)
             .customerId(Optional.empty())
             .roles(Set.of(Role.ADMIN))
             .email(SOME_ADMIN_EMAIL)
             .build();
 
+    // then
     var expected = someAdminUser();
-
     assertThat(result).usingRecursiveComparison().isEqualTo(expected);
   }
 
   @Test
   void shouldReportCustomerRole() {
+    // given
     var result = someCustomerUser();
 
+    // then
     assertThat(result.isCustomer()).isTrue();
     assertThat(result.isAdmin()).isFalse();
     assertThat(result.isAgent()).isFalse();
@@ -57,8 +62,10 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldReportAdminRole() {
+    // given
     var result = someAdminUser();
 
+    // then
     assertThat(result.isAdmin()).isTrue();
     assertThat(result.isCustomer()).isFalse();
     assertThat(result.isAgent()).isFalse();
@@ -66,8 +73,10 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldReportAgentRole() {
+    // given
     var result = someAgentUser();
 
+    // then
     assertThat(result.isAgent()).isTrue();
     assertThat(result.isCustomer()).isFalse();
     assertThat(result.isAdmin()).isFalse();
@@ -75,17 +84,22 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldReturnCustomerIdWhenPresent() {
+    // given
     var user = someCustomerUser();
 
+    // when
     var result = user.requireCustomerId();
 
+    // then
     assertThat(result).usingRecursiveComparison().isEqualTo(SOME_CUSTOMER_ID);
   }
 
   @Test
   void shouldThrowWhenAdminAttemptsToRequireCustomerId() {
+    // given
     var user = someAdminUser();
 
+    // when/then
     assertThatThrownBy(user::requireCustomerId)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Endpoint requires CUSTOMER role");
@@ -93,8 +107,10 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldThrowWhenAgentAttemptsToRequireCustomerId() {
+    // given
     var user = someAgentUser();
 
+    // when/then
     assertThatThrownBy(user::requireCustomerId)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Endpoint requires CUSTOMER role");
@@ -102,6 +118,7 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldRejectNullUserId() {
+    // when/then
     assertThatThrownBy(
             () ->
                 AuthenticatedUser.builder()
@@ -116,10 +133,11 @@ class AuthenticatedUserTest {
 
   @Test
   void shouldRejectNullCustomerIdOptional() {
+    // when/then
     assertThatThrownBy(
             () ->
                 AuthenticatedUser.builder()
-                    .userId(SOME_USER_ID)
+                    .userId(SOME_ADMIN_USER_ID)
                     .customerId(null)
                     .roles(Set.of(Role.ADMIN))
                     .email(SOME_ADMIN_EMAIL)

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverterTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverterTest.java
@@ -1,40 +1,42 @@
 package io.stablepay.api.infrastructure.security;
 
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_USER_UUID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_USER_UUID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_USER_UUID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_UUID;
-import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_USER_UUID;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAgentUser;
 import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static io.stablepay.api.infrastructure.security.fixtures.JwtFixtures.jwtBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
 
 class JwtToAuthenticatedUserConverterTest {
-
-  private static final Instant ISSUED_AT = Instant.parse("2026-05-01T10:00:00Z");
-  private static final Instant EXPIRES_AT = Instant.parse("2026-05-01T10:15:00Z");
 
   private final JwtToAuthenticatedUserConverter converter = new JwtToAuthenticatedUserConverter();
 
   @Test
   void shouldConvertCustomerJwtWithCustomerIdClaim() {
+    // given
     var jwt =
         jwtBuilder()
-            .subject(SOME_USER_UUID.toString())
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
             .claim("email", SOME_CUSTOMER_EMAIL)
             .claim("roles", List.of("CUSTOMER"))
             .claim("customer_id", SOME_CUSTOMER_UUID.toString())
             .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     var expected = someCustomerUser();
     assertThat(result).isInstanceOf(AuthenticatedUserToken.class);
     assertThat(((AuthenticatedUserToken) result).getPrincipal())
@@ -45,15 +47,18 @@ class JwtToAuthenticatedUserConverterTest {
 
   @Test
   void shouldConvertAdminJwtWithoutCustomerIdClaimWithoutNpe() {
+    // given
     var jwt =
         jwtBuilder()
-            .subject(SOME_USER_UUID.toString())
+            .subject(SOME_ADMIN_USER_UUID.toString())
             .claim("email", SOME_ADMIN_EMAIL)
             .claim("roles", List.of("ADMIN"))
             .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     var expected = someAdminUser();
     assertThat(((AuthenticatedUserToken) result).getPrincipal())
         .usingRecursiveComparison()
@@ -63,15 +68,18 @@ class JwtToAuthenticatedUserConverterTest {
 
   @Test
   void shouldConvertAgentJwtWithoutCustomerIdClaimWithoutNpe() {
+    // given
     var jwt =
         jwtBuilder()
-            .subject(SOME_USER_UUID.toString())
+            .subject(SOME_AGENT_USER_UUID.toString())
             .claim("email", SOME_AGENT_EMAIL)
             .claim("roles", List.of("AGENT"))
             .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     var expected = someAgentUser();
     assertThat(((AuthenticatedUserToken) result).getPrincipal())
         .usingRecursiveComparison()
@@ -81,52 +89,119 @@ class JwtToAuthenticatedUserConverterTest {
 
   @Test
   void shouldHandleMissingRolesClaim() {
+    // given
     var jwt =
-        jwtBuilder().subject(SOME_USER_UUID.toString()).claim("email", SOME_ADMIN_EMAIL).build();
+        jwtBuilder()
+            .subject(SOME_ADMIN_USER_UUID.toString())
+            .claim("email", SOME_ADMIN_EMAIL)
+            .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     assertThat(result.getAuthorities()).isEmpty();
     assertThat(((AuthenticatedUserToken) result).getPrincipal().roles()).isEmpty();
   }
 
   @Test
   void shouldExposeJwtAsCredentials() {
+    // given
     var jwt =
         jwtBuilder()
-            .subject(SOME_USER_UUID.toString())
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
             .claim("email", SOME_CUSTOMER_EMAIL)
             .claim("roles", List.of("CUSTOMER"))
             .claim("customer_id", SOME_CUSTOMER_UUID.toString())
             .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     assertThat(result.getCredentials()).isSameAs(jwt);
   }
 
   @Test
   void shouldUseEmailAsAuthenticationName() {
+    // given
     var jwt =
         jwtBuilder()
-            .subject(SOME_USER_UUID.toString())
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
             .claim("email", SOME_CUSTOMER_EMAIL)
             .claim("roles", List.of("CUSTOMER"))
             .claim("customer_id", SOME_CUSTOMER_UUID.toString())
             .build();
 
+    // when
     var result = converter.convert(jwt);
 
+    // then
     assertThat(result.getName()).isEqualTo(SOME_CUSTOMER_EMAIL);
   }
 
-  private static Jwt.Builder jwtBuilder() {
-    return Jwt.withTokenValue("token-value")
-        .header("alg", "RS256")
-        .header("kid", "test-key-1")
-        .issuedAt(ISSUED_AT)
-        .expiresAt(EXPIRES_AT)
-        .issuer("https://auth.stablepay.local")
-        .audience(List.of("stablepay-api"));
+  @Test
+  void shouldRejectJwtWithInvalidSubjectUuid() {
+    // given
+    var jwt =
+        jwtBuilder()
+            .subject("not-a-uuid")
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("CUSTOMER"))
+            .claim("customer_id", SOME_CUSTOMER_UUID.toString())
+            .build();
+
+    // when/then
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("UUID");
+  }
+
+  @Test
+  void shouldRejectJwtWithInvalidCustomerIdUuid() {
+    // given
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("CUSTOMER"))
+            .claim("customer_id", "not-a-uuid")
+            .build();
+
+    // when/then
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("UUID");
+  }
+
+  @Test
+  void shouldRejectJwtWithUnknownRole() {
+    // given
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("WIZARD"))
+            .build();
+
+    // when/then
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("WIZARD");
+  }
+
+  @Test
+  void shouldRejectJwtWithMissingEmailClaim() {
+    // given
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_ADMIN_USER_UUID.toString())
+            .claim("roles", List.of("ADMIN"))
+            .build();
+
+    // when/then
+    assertThatThrownBy(() -> converter.convert(jwt))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("email");
   }
 }

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverterTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/security/JwtToAuthenticatedUserConverterTest.java
@@ -1,0 +1,132 @@
+package io.stablepay.api.infrastructure.security;
+
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_EMAIL;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_USER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAgentUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class JwtToAuthenticatedUserConverterTest {
+
+  private static final Instant ISSUED_AT = Instant.parse("2026-05-01T10:00:00Z");
+  private static final Instant EXPIRES_AT = Instant.parse("2026-05-01T10:15:00Z");
+
+  private final JwtToAuthenticatedUserConverter converter = new JwtToAuthenticatedUserConverter();
+
+  @Test
+  void shouldConvertCustomerJwtWithCustomerIdClaim() {
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_USER_UUID.toString())
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("CUSTOMER"))
+            .claim("customer_id", SOME_CUSTOMER_UUID.toString())
+            .build();
+
+    var result = converter.convert(jwt);
+
+    var expected = someCustomerUser();
+    assertThat(result).isInstanceOf(AuthenticatedUserToken.class);
+    assertThat(((AuthenticatedUserToken) result).getPrincipal())
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+    assertThat(result.getAuthorities()).containsOnly(new SimpleGrantedAuthority("ROLE_CUSTOMER"));
+  }
+
+  @Test
+  void shouldConvertAdminJwtWithoutCustomerIdClaimWithoutNpe() {
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_USER_UUID.toString())
+            .claim("email", SOME_ADMIN_EMAIL)
+            .claim("roles", List.of("ADMIN"))
+            .build();
+
+    var result = converter.convert(jwt);
+
+    var expected = someAdminUser();
+    assertThat(((AuthenticatedUserToken) result).getPrincipal())
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+    assertThat(result.getAuthorities()).containsOnly(new SimpleGrantedAuthority("ROLE_ADMIN"));
+  }
+
+  @Test
+  void shouldConvertAgentJwtWithoutCustomerIdClaimWithoutNpe() {
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_USER_UUID.toString())
+            .claim("email", SOME_AGENT_EMAIL)
+            .claim("roles", List.of("AGENT"))
+            .build();
+
+    var result = converter.convert(jwt);
+
+    var expected = someAgentUser();
+    assertThat(((AuthenticatedUserToken) result).getPrincipal())
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+    assertThat(result.getAuthorities()).containsOnly(new SimpleGrantedAuthority("ROLE_AGENT"));
+  }
+
+  @Test
+  void shouldHandleMissingRolesClaim() {
+    var jwt =
+        jwtBuilder().subject(SOME_USER_UUID.toString()).claim("email", SOME_ADMIN_EMAIL).build();
+
+    var result = converter.convert(jwt);
+
+    assertThat(result.getAuthorities()).isEmpty();
+    assertThat(((AuthenticatedUserToken) result).getPrincipal().roles()).isEmpty();
+  }
+
+  @Test
+  void shouldExposeJwtAsCredentials() {
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_USER_UUID.toString())
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("CUSTOMER"))
+            .claim("customer_id", SOME_CUSTOMER_UUID.toString())
+            .build();
+
+    var result = converter.convert(jwt);
+
+    assertThat(result.getCredentials()).isSameAs(jwt);
+  }
+
+  @Test
+  void shouldUseEmailAsAuthenticationName() {
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_USER_UUID.toString())
+            .claim("email", SOME_CUSTOMER_EMAIL)
+            .claim("roles", List.of("CUSTOMER"))
+            .claim("customer_id", SOME_CUSTOMER_UUID.toString())
+            .build();
+
+    var result = converter.convert(jwt);
+
+    assertThat(result.getName()).isEqualTo(SOME_CUSTOMER_EMAIL);
+  }
+
+  private static Jwt.Builder jwtBuilder() {
+    return Jwt.withTokenValue("token-value")
+        .header("alg", "RS256")
+        .header("kid", "test-key-1")
+        .issuedAt(ISSUED_AT)
+        .expiresAt(EXPIRES_AT)
+        .issuer("https://auth.stablepay.local")
+        .audience(List.of("stablepay-api"));
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/AuthenticatedUserFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/AuthenticatedUserFixtures.java
@@ -1,0 +1,50 @@
+package io.stablepay.api.infrastructure.security.fixtures;
+
+import io.stablepay.api.domain.model.CustomerId;
+import io.stablepay.api.domain.model.UserId;
+import io.stablepay.api.infrastructure.security.AuthenticatedUser;
+import io.stablepay.api.infrastructure.security.Role;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public final class AuthenticatedUserFixtures {
+
+  public static final UUID SOME_USER_UUID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  public static final UUID SOME_CUSTOMER_UUID =
+      UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+  public static final UserId SOME_USER_ID = UserId.of(SOME_USER_UUID);
+  public static final CustomerId SOME_CUSTOMER_ID = CustomerId.of(SOME_CUSTOMER_UUID);
+  public static final String SOME_CUSTOMER_EMAIL = "alice@stablepay.io";
+  public static final String SOME_ADMIN_EMAIL = "admin@stablepay.io";
+  public static final String SOME_AGENT_EMAIL = "agent@stablepay.io";
+
+  private AuthenticatedUserFixtures() {}
+
+  public static AuthenticatedUser someCustomerUser() {
+    return AuthenticatedUser.builder()
+        .userId(SOME_USER_ID)
+        .customerId(Optional.of(SOME_CUSTOMER_ID))
+        .roles(Set.of(Role.CUSTOMER))
+        .email(SOME_CUSTOMER_EMAIL)
+        .build();
+  }
+
+  public static AuthenticatedUser someAdminUser() {
+    return AuthenticatedUser.builder()
+        .userId(SOME_USER_ID)
+        .customerId(Optional.empty())
+        .roles(Set.of(Role.ADMIN))
+        .email(SOME_ADMIN_EMAIL)
+        .build();
+  }
+
+  public static AuthenticatedUser someAgentUser() {
+    return AuthenticatedUser.builder()
+        .userId(SOME_USER_ID)
+        .customerId(Optional.empty())
+        .roles(Set.of(Role.AGENT))
+        .email(SOME_AGENT_EMAIL)
+        .build();
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/AuthenticatedUserFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/AuthenticatedUserFixtures.java
@@ -10,11 +10,20 @@ import java.util.UUID;
 
 public final class AuthenticatedUserFixtures {
 
-  public static final UUID SOME_USER_UUID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  public static final UUID SOME_CUSTOMER_USER_UUID =
+      UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  public static final UUID SOME_ADMIN_USER_UUID =
+      UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+  public static final UUID SOME_AGENT_USER_UUID =
+      UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
   public static final UUID SOME_CUSTOMER_UUID =
       UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
-  public static final UserId SOME_USER_ID = UserId.of(SOME_USER_UUID);
+
+  public static final UserId SOME_CUSTOMER_USER_ID = UserId.of(SOME_CUSTOMER_USER_UUID);
+  public static final UserId SOME_ADMIN_USER_ID = UserId.of(SOME_ADMIN_USER_UUID);
+  public static final UserId SOME_AGENT_USER_ID = UserId.of(SOME_AGENT_USER_UUID);
   public static final CustomerId SOME_CUSTOMER_ID = CustomerId.of(SOME_CUSTOMER_UUID);
+
   public static final String SOME_CUSTOMER_EMAIL = "alice@stablepay.io";
   public static final String SOME_ADMIN_EMAIL = "admin@stablepay.io";
   public static final String SOME_AGENT_EMAIL = "agent@stablepay.io";
@@ -23,7 +32,7 @@ public final class AuthenticatedUserFixtures {
 
   public static AuthenticatedUser someCustomerUser() {
     return AuthenticatedUser.builder()
-        .userId(SOME_USER_ID)
+        .userId(SOME_CUSTOMER_USER_ID)
         .customerId(Optional.of(SOME_CUSTOMER_ID))
         .roles(Set.of(Role.CUSTOMER))
         .email(SOME_CUSTOMER_EMAIL)
@@ -32,7 +41,7 @@ public final class AuthenticatedUserFixtures {
 
   public static AuthenticatedUser someAdminUser() {
     return AuthenticatedUser.builder()
-        .userId(SOME_USER_ID)
+        .userId(SOME_ADMIN_USER_ID)
         .customerId(Optional.empty())
         .roles(Set.of(Role.ADMIN))
         .email(SOME_ADMIN_EMAIL)
@@ -41,7 +50,7 @@ public final class AuthenticatedUserFixtures {
 
   public static AuthenticatedUser someAgentUser() {
     return AuthenticatedUser.builder()
-        .userId(SOME_USER_ID)
+        .userId(SOME_AGENT_USER_ID)
         .customerId(Optional.empty())
         .roles(Set.of(Role.AGENT))
         .email(SOME_AGENT_EMAIL)

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/JwtFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/security/fixtures/JwtFixtures.java
@@ -1,0 +1,28 @@
+package io.stablepay.api.infrastructure.security.fixtures;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public final class JwtFixtures {
+
+  public static final String SOME_JWT_TOKEN_VALUE = "token-value";
+  public static final String SOME_JWT_KID = "test-key-1";
+  public static final String SOME_JWT_ALG = "RS256";
+  public static final Instant SOME_JWT_ISSUED_AT = Instant.parse("2026-05-01T10:00:00Z");
+  public static final Instant SOME_JWT_EXPIRES_AT = Instant.parse("2026-05-01T10:15:00Z");
+  public static final String SOME_JWT_ISSUER = "https://auth.stablepay.local";
+  public static final List<String> SOME_JWT_AUDIENCE = List.of("stablepay-api");
+
+  private JwtFixtures() {}
+
+  public static Jwt.Builder jwtBuilder() {
+    return Jwt.withTokenValue(SOME_JWT_TOKEN_VALUE)
+        .header("alg", SOME_JWT_ALG)
+        .header("kid", SOME_JWT_KID)
+        .issuedAt(SOME_JWT_ISSUED_AT)
+        .expiresAt(SOME_JWT_EXPIRES_AT)
+        .issuer(SOME_JWT_ISSUER)
+        .audience(SOME_JWT_AUDIENCE);
+  }
+}


### PR DESCRIPTION
## SPP Issue
Closes #94

## Changes
- Add `Role` enum (`CUSTOMER`, `ADMIN`, `AGENT`) under `infrastructure/security/`.
- Add `AuthenticatedUser` record with `Optional<CustomerId>`, `@Builder(toBuilder = true)`, role helpers (`isAdmin/isCustomer/isAgent`), and `requireCustomerId()` for customer-scoped endpoints.
- Add `AuthenticatedUserToken` (custom `AbstractAuthenticationToken`) so `@AuthenticationPrincipal AuthenticatedUser` resolves directly in controller signatures.
- Add `JwtToAuthenticatedUserConverter` (`@Component`) — uses `Optional.ofNullable(jwt.getClaimAsString("customer_id"))` so admin/agent JWTs (no `customer_id` claim) decode without NPE. Pass-2 review fix.
- Add `SecurityConfig` — `@EnableWebSecurity` + `@EnableMethodSecurity(securedEnabled = true)`, stateless session, CSRF disabled, public endpoints (`/actuator/health`, `/v3/api-docs/**`, `/swagger-ui/**`), OAuth2 Resource Server with `jwkSetUri` + the custom converter.
- Add `stablepay.auth.jwks-uri` to `application.yml` (env override `STABLEPAY_AUTH_JWKS_URI`, default `http://apps-auth:9000/.well-known/jwks.json`).
- Add `AuthenticatedUserFixtures` in `testFixtures/` with `someCustomerUser/someAdminUser/someAgentUser` builders + `SOME_*` constants.
- Add `AuthenticatedUserTest` (10 tests) and `JwtToAuthenticatedUserConverterTest` (6 tests) — including regression tests proving admin and agent JWTs without `customer_id` decode without NPE.

## Notes / Deviations
- The issue's example used `JwtAuthenticationToken` whose principal is the `Jwt`. That contradicts the acceptance criterion `@AuthenticationPrincipal AuthenticatedUser user injection works in controller signatures`. I introduced `AuthenticatedUserToken` to satisfy that criterion cleanly.
- `RateLimitFilter` wiring (referenced in the issue snippet) is deferred to Task 4.2.6 / a separate SPP issue — that bean does not yet exist and adding the wiring here would prevent the context from starting.
- Integration tests for the full 401/403 + JWT signature flow are deferred to Task 4.2.10 (they need WireMock JWKs + signed test tokens, plus controllers to assert against).

## Checklist
- [x] `./gradlew :apps:api:main:test :apps:api:main:spotlessCheck :apps:api:main:bootJar` passes
- [x] Unit tests added (16 new tests, all passing)
- [ ] Integration tests added (deferred to Task 4.2.10)
- [x] ArchUnit rules pass (no new domain dependencies; security lives in `infrastructure/`)
- [x] Spotless formatting applied
- [x] Golden recursive-comparison rule followed in object assertions
- [x] BDD Mockito convention not exercised (no mocks needed in these tests)