### PR TITLE
SPP-90: add Bucket4j + Redis rate limiting per role

### DIFF
--- a/apps/api/client/src/main/java/io/stablepay/api/client/ApiError.java
+++ b/apps/api/client/src/main/java/io/stablepay/api/client/ApiError.java
@@ -1,0 +1,7 @@
+package io.stablepay.api.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+
+public record ApiError(
+    @JsonProperty("error_code") String errorCode, String message, Instant timestamp) {}

--- a/apps/api/main/build.gradle.kts
+++ b/apps/api/main/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     implementation(libs.bucket4j.core)
     implementation(libs.bucket4j.redis)
+    implementation(libs.bucket4j.lettuce)
     implementation(libs.caffeine)
 
     implementation(libs.nimbus.jose.jwt)
@@ -85,6 +86,7 @@ dependencies {
     testFixturesApi(libs.spring.boot.starter.oauth2.resource.server)
     testFixturesApi(libs.testcontainers.postgres)
     testFixturesApi(libs.nv.i18n)
+    testFixturesApi(libs.bucket4j.core)
     testFixturesCompileOnly(libs.lombok)
     testFixturesAnnotationProcessor(libs.lombok)
 

--- a/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterIT.java
+++ b/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterIT.java
@@ -1,0 +1,163 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import static io.stablepay.api.infrastructure.ratelimit.fixtures.RateLimitFixtures.productionConfigurationsForAllRoles;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_USER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static io.stablepay.api.infrastructure.security.fixtures.JwtFixtures.jwtBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.stablepay.api.client.ApiError;
+import io.stablepay.api.infrastructure.security.AuthenticatedUserToken;
+import io.stablepay.api.infrastructure.security.Role;
+import jakarta.servlet.FilterChain;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+@Testcontainers
+@Tag("integration")
+class RateLimitFilterIT {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+  private static final String SOME_ROUTE = "/api/v1/transactions";
+  private static final int REDIS_PORT = 6379;
+
+  @Container
+  static final GenericContainer<?> REDIS =
+      new GenericContainer<>(DockerImageName.parse("redis:8.0-alpine"))
+          .withExposedPorts(REDIS_PORT);
+
+  private static RedisClient redisClient;
+  private static StatefulRedisConnection<String, byte[]> connection;
+  private static ProxyManager<String> proxyManager;
+  private static Map<Role, BucketConfiguration> roleConfigurations;
+  private static ObjectMapper objectMapper;
+
+  @BeforeAll
+  static void setUp() {
+    var redisUri = "redis://" + REDIS.getHost() + ":" + REDIS.getMappedPort(REDIS_PORT);
+    redisClient = RedisClient.create(redisUri);
+    connection = redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
+    proxyManager = Bucket4jLettuce.casBasedBuilder(connection).build();
+    roleConfigurations = productionConfigurationsForAllRoles();
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (connection != null) {
+      connection.close();
+    }
+    if (redisClient != null) {
+      redisClient.shutdown();
+    }
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldAllow100CustomerRequestsThenReturn429() throws Exception {
+    // given
+    var filter = newFilter();
+    authenticateAsCustomer();
+    var chainInvocations = new AtomicInteger(0);
+    FilterChain chain = (req, res) -> chainInvocations.incrementAndGet();
+
+    // when — fire 100 successful requests, then a 101st that must be rejected
+    for (var i = 0; i < RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+    var rejected = new MockHttpServletResponse();
+    filter.doFilter(getRequest(SOME_ROUTE), rejected, chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE);
+    assertThat(rejected.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    assertThat(Long.parseLong(rejected.getHeader(HttpHeaders.RETRY_AFTER))).isBetween(1L, 60L);
+    var expectedBody = new ApiError("STBLPAY-4001", "Rate limit exceeded", FIXED_NOW);
+    var actualBody = objectMapper.readValue(rejected.getContentAsString(), ApiError.class);
+    assertThat(actualBody).usingRecursiveComparison().isEqualTo(expectedBody);
+  }
+
+  @Test
+  void shouldShareBucketAcrossFilterInstances() throws Exception {
+    // given — two filter instances backed by the same Redis-backed ProxyManager
+    var firstInstance = newFilter();
+    var secondInstance = newFilter();
+    authenticateAsCustomer();
+    var chainInvocations = new AtomicInteger(0);
+    FilterChain chain = (req, res) -> chainInvocations.incrementAndGet();
+    var crossInstanceRoute = "/api/v1/cross-instance-route";
+
+    // when — drain the bucket via the first instance, then attempt via the second
+    for (var i = 0; i < RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE; i++) {
+      firstInstance.doFilter(getRequest(crossInstanceRoute), new MockHttpServletResponse(), chain);
+    }
+    var rejected = new MockHttpServletResponse();
+    secondInstance.doFilter(getRequest(crossInstanceRoute), rejected, chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE);
+    assertThat(rejected.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+  }
+
+  private static RateLimitFilter newFilter() {
+    RateLimitBucketResolver resolver =
+        (key, role) -> {
+          var configuration = roleConfigurations.get(role);
+          return proxyManager.builder().build(key, () -> configuration);
+        };
+    return new RateLimitFilter(resolver, objectMapper, Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+  }
+
+  private static MockHttpServletRequest getRequest(String uri) {
+    var request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setRequestURI(uri);
+    return request;
+  }
+
+  private static void authenticateAsCustomer() {
+    var user = someCustomerUser();
+    var jwt =
+        jwtBuilder()
+            .subject(SOME_CUSTOMER_USER_UUID.toString())
+            .claim("email", user.email())
+            .claim("roles", List.of("CUSTOMER"))
+            .build();
+    var token =
+        new AuthenticatedUserToken(jwt, user, List.of(new SimpleGrantedAuthority("ROLE_CUSTOMER")));
+    SecurityContextHolder.getContext().setAuthentication(token);
+  }
+}

--- a/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterIT.java
+++ b/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterIT.java
@@ -133,8 +133,8 @@ class RateLimitFilterIT {
   }
 
   private static RateLimitFilter newFilter() {
-    RateLimitBucketResolver resolver =
-        (key, role) -> {
+    var resolver =
+        (RateLimitBucketResolver) (key, role) -> {
           var configuration = roleConfigurations.get(role);
           return proxyManager.builder().build(key, () -> configuration);
         };

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitBucketResolver.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitBucketResolver.java
@@ -1,0 +1,10 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import io.github.bucket4j.Bucket;
+import io.stablepay.api.infrastructure.security.Role;
+
+@FunctionalInterface
+public interface RateLimitBucketResolver {
+
+  Bucket resolve(String key, Role role);
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitConfig.java
@@ -1,0 +1,89 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.stablepay.api.infrastructure.security.Role;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RateLimitProperties.class)
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitConfig {
+
+  public static final long CUSTOMER_LIMIT_PER_MINUTE = 100L;
+  public static final long ADMIN_LIMIT_PER_MINUTE = 500L;
+  public static final long AGENT_LIMIT_PER_MINUTE = 1_000L;
+  public static final Duration LIMIT_WINDOW = Duration.ofMinutes(1);
+  public static final Duration BUCKET_EXPIRATION = Duration.ofMinutes(5);
+
+  private final RateLimitProperties properties;
+
+  @Bean(destroyMethod = "shutdown")
+  public RedisClient rateLimitRedisClient() {
+    log.info("Configured Bucket4j Redis client for {}", properties.redisUri());
+    return RedisClient.create(properties.redisUri());
+  }
+
+  @Bean(destroyMethod = "close")
+  public StatefulRedisConnection<String, byte[]> rateLimitRedisConnection(
+      RedisClient rateLimitRedisClient) {
+    return rateLimitRedisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE));
+  }
+
+  @Bean
+  public ProxyManager<String> rateLimitProxyManager(
+      StatefulRedisConnection<String, byte[]> rateLimitRedisConnection) {
+    return Bucket4jLettuce.casBasedBuilder(rateLimitRedisConnection)
+        .expirationAfterWrite(
+            ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(BUCKET_EXPIRATION))
+        .build();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+
+  @Bean
+  public Map<Role, BucketConfiguration> roleBucketConfigurations() {
+    var configurations = new EnumMap<Role, BucketConfiguration>(Role.class);
+    configurations.put(Role.CUSTOMER, configurationFor(CUSTOMER_LIMIT_PER_MINUTE));
+    configurations.put(Role.ADMIN, configurationFor(ADMIN_LIMIT_PER_MINUTE));
+    configurations.put(Role.AGENT, configurationFor(AGENT_LIMIT_PER_MINUTE));
+    return Map.copyOf(configurations);
+  }
+
+  @Bean
+  public RateLimitBucketResolver rateLimitBucketResolver(
+      ProxyManager<String> rateLimitProxyManager,
+      Map<Role, BucketConfiguration> roleBucketConfigurations) {
+    return (key, role) -> {
+      var configuration = roleBucketConfigurations.get(role);
+      return rateLimitProxyManager.builder().build(key, () -> configuration);
+    };
+  }
+
+  static BucketConfiguration configurationFor(long capacity) {
+    return BucketConfiguration.builder()
+        .addLimit(limit -> limit.capacity(capacity).refillGreedy(capacity, LIMIT_WINDOW))
+        .build();
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilter.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilter.java
@@ -1,0 +1,116 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import io.github.bucket4j.ConsumptionProbe;
+import io.stablepay.api.client.ApiError;
+import io.stablepay.api.infrastructure.security.AuthenticatedUser;
+import io.stablepay.api.infrastructure.security.AuthenticatedUserToken;
+import io.stablepay.api.infrastructure.security.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+
+  public static final String RATE_LIMIT_ERROR_CODE = "STBLPAY-4001";
+  public static final String RATE_LIMIT_MESSAGE = "Rate limit exceeded";
+  public static final String BUCKET_KEY_PREFIX = "rate:";
+  static final long MIN_RETRY_AFTER_SECONDS = 1L;
+
+  private final RateLimitBucketResolver bucketResolver;
+  private final ObjectMapper objectMapper;
+  private final Clock clock;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    var token = currentToken();
+    if (token == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+    var user = token.getPrincipal();
+    var role = primaryRole(user);
+    if (role == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+    var key = bucketKey(user, request);
+    var bucket = bucketResolver.resolve(key, role);
+    var probe = bucket.tryConsumeAndReturnRemaining(1);
+    if (probe.isConsumed()) {
+      chain.doFilter(request, response);
+      return;
+    }
+    writeRateLimited(response, retryAfterSeconds(probe));
+  }
+
+  private static AuthenticatedUserToken currentToken() {
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+    return authentication instanceof AuthenticatedUserToken token ? token : null;
+  }
+
+  static Role primaryRole(AuthenticatedUser user) {
+    if (user.isAgent()) {
+      return Role.AGENT;
+    }
+    if (user.isAdmin()) {
+      return Role.ADMIN;
+    }
+    if (user.isCustomer()) {
+      return Role.CUSTOMER;
+    }
+    return null;
+  }
+
+  static String bucketKey(AuthenticatedUser user, HttpServletRequest request) {
+    return BUCKET_KEY_PREFIX
+        + user.userId().value()
+        + ":"
+        + request.getMethod()
+        + " "
+        + normalizedRoute(request);
+  }
+
+  private static String normalizedRoute(HttpServletRequest request) {
+    var uri = request.getRequestURI();
+    var semi = uri.indexOf(';');
+    if (semi >= 0) {
+      uri = uri.substring(0, semi);
+    }
+    if (uri.length() > 1 && uri.endsWith("/")) {
+      uri = uri.substring(0, uri.length() - 1);
+    }
+    return uri;
+  }
+
+  static long retryAfterSeconds(ConsumptionProbe probe) {
+    var nanos = probe.getNanosToWaitForRefill();
+    var seconds = (nanos + 999_999_999L) / 1_000_000_000L;
+    return Math.max(MIN_RETRY_AFTER_SECONDS, seconds);
+  }
+
+  private void writeRateLimited(HttpServletResponse response, long retryAfterSeconds)
+      throws IOException {
+    var body = new ApiError(RATE_LIMIT_ERROR_CODE, RATE_LIMIT_MESSAGE, clock.instant());
+    response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfterSeconds));
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.getWriter().write(objectMapper.writeValueAsString(body));
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitProperties.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/ratelimit/RateLimitProperties.java
@@ -1,0 +1,15 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import lombok.Builder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Builder(toBuilder = true)
+@ConfigurationProperties("stablepay.ratelimit")
+public record RateLimitProperties(String redisUri) {
+
+  public RateLimitProperties {
+    if (redisUri == null || redisUri.isBlank()) {
+      redisUri = "redis://redis:6379";
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -34,7 +34,7 @@ public class SecurityConfig {
             a -> a.requestMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated())
         .oauth2ResourceServer(
             o -> o.jwt(j -> j.jwkSetUri(jwksUri).jwtAuthenticationConverter(jwtConverter)))
-        .addFilterAfter(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterAfter(rateLimitFilter, BearerTokenAuthenticationFilter.class)
         .build();
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.stablepay.api.infrastructure.security;
 
+import io.stablepay.api.infrastructure.ratelimit.RateLimitFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -23,6 +25,7 @@ public class SecurityConfig {
   public SecurityFilterChain apiSecurityFilterChain(
       HttpSecurity http,
       JwtToAuthenticatedUserConverter jwtConverter,
+      RateLimitFilter rateLimitFilter,
       @Value("${stablepay.auth.jwks-uri}") String jwksUri)
       throws Exception {
     return http.csrf(AbstractHttpConfigurer::disable)
@@ -31,6 +34,7 @@ public class SecurityConfig {
             a -> a.requestMatchers(PUBLIC_ENDPOINTS).permitAll().anyRequest().authenticated())
         .oauth2ResourceServer(
             o -> o.jwt(j -> j.jwkSetUri(jwksUri).jwtAuthenticationConverter(jwtConverter)))
+        .addFilterAfter(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
 }

--- a/apps/api/main/src/main/resources/application.yml
+++ b/apps/api/main/src/main/resources/application.yml
@@ -28,6 +28,8 @@ namastack:
 stablepay:
   auth:
     jwks-uri: ${STABLEPAY_AUTH_JWKS_URI:http://apps-auth:9000/.well-known/jwks.json}
+  ratelimit:
+    redis-uri: ${STABLEPAY_RATELIMIT_REDIS_URI:redis://${REDIS_HOST:redis}:${REDIS_PORT:6379}}
   opensearch:
     uri: ${OPENSEARCH_URI:http://opensearch:9200}
     transactions-index: ${OPENSEARCH_TRANSACTIONS_INDEX:transactions}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitConfigTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitConfigTest.java
@@ -1,0 +1,72 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.stablepay.api.infrastructure.security.Role;
+import org.junit.jupiter.api.Test;
+
+class RateLimitConfigTest {
+
+  private final RateLimitConfig config =
+      new RateLimitConfig(RateLimitProperties.builder().redisUri("redis://localhost:6379").build());
+
+  @Test
+  void shouldGiveCustomerOneHundredTokensPerMinute() {
+    // given
+    var configuration = config.roleBucketConfigurations().get(Role.CUSTOMER);
+
+    // when
+    var consumed = drainBucket(configuration);
+
+    // then
+    assertThat(consumed).isEqualTo(RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE);
+  }
+
+  @Test
+  void shouldGiveAdminFiveHundredTokensPerMinute() {
+    // given
+    var configuration = config.roleBucketConfigurations().get(Role.ADMIN);
+
+    // when
+    var consumed = drainBucket(configuration);
+
+    // then
+    assertThat(consumed).isEqualTo(RateLimitConfig.ADMIN_LIMIT_PER_MINUTE);
+  }
+
+  @Test
+  void shouldGiveAgentOneThousandTokensPerMinute() {
+    // given
+    var configuration = config.roleBucketConfigurations().get(Role.AGENT);
+
+    // when
+    var consumed = drainBucket(configuration);
+
+    // then
+    assertThat(consumed).isEqualTo(RateLimitConfig.AGENT_LIMIT_PER_MINUTE);
+  }
+
+  @Test
+  void shouldExposeAllThreeRolesInConfigurationsMap() {
+    // when
+    var configurations = config.roleBucketConfigurations();
+
+    // then
+    assertThat(configurations).containsOnlyKeys(Role.CUSTOMER, Role.ADMIN, Role.AGENT);
+  }
+
+  private static long drainBucket(BucketConfiguration configuration) {
+    var builder = Bucket.builder();
+    for (var bandwidth : configuration.getBandwidths()) {
+      builder.addLimit(bandwidth);
+    }
+    var bucket = builder.build();
+    var consumed = 0L;
+    while (bucket.tryConsume(1)) {
+      consumed++;
+    }
+    return consumed;
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,218 @@
+package io.stablepay.api.infrastructure.ratelimit;
+
+import static io.stablepay.api.infrastructure.ratelimit.fixtures.RateLimitFixtures.SOME_TINY_CAPACITY;
+import static io.stablepay.api.infrastructure.ratelimit.fixtures.RateLimitFixtures.inMemoryResolverWith;
+import static io.stablepay.api.infrastructure.ratelimit.fixtures.RateLimitFixtures.tinyConfigurationsForAllRoles;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_USER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_USER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_USER_UUID;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someAgentUser;
+import static io.stablepay.api.infrastructure.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static io.stablepay.api.infrastructure.security.fixtures.JwtFixtures.jwtBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stablepay.api.client.ApiError;
+import io.stablepay.api.infrastructure.security.AuthenticatedUser;
+import io.stablepay.api.infrastructure.security.AuthenticatedUserToken;
+import jakarta.servlet.FilterChain;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class RateLimitFilterTest {
+
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-02T10:15:30Z");
+  private static final String SOME_ROUTE = "/api/v1/transactions";
+
+  private RateLimitFilter filter;
+  private ObjectMapper objectMapper;
+  private AtomicInteger chainInvocations;
+  private FilterChain chain;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
+    filter =
+        new RateLimitFilter(
+            inMemoryResolverWith(tinyConfigurationsForAllRoles()),
+            objectMapper,
+            Clock.fixed(FIXED_NOW, ZoneOffset.UTC));
+    chainInvocations = new AtomicInteger(0);
+    chain = (req, res) -> chainInvocations.incrementAndGet();
+  }
+
+  @AfterEach
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldPassThroughWhenNoAuthentication() throws Exception {
+    // given
+    var request = getRequest(SOME_ROUTE);
+
+    // when
+    filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAllowRequestsUpToBucketCapacity() throws Exception {
+    // given
+    authenticateAs(someCustomerUser(), "CUSTOMER");
+
+    // when
+    for (var i = 0; i < SOME_TINY_CAPACITY; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY);
+  }
+
+  @Test
+  void shouldRejectRequestAfterCapacityWith429RetryAfterAndApiError() throws Exception {
+    // given
+    authenticateAs(someCustomerUser(), "CUSTOMER");
+    for (var i = 0; i < SOME_TINY_CAPACITY; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+    var response = new MockHttpServletResponse();
+    var expectedBody = new ApiError("STBLPAY-4001", "Rate limit exceeded", FIXED_NOW);
+
+    // when
+    filter.doFilter(getRequest(SOME_ROUTE), response, chain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    assertThat(Long.parseLong(response.getHeader(HttpHeaders.RETRY_AFTER))).isBetween(1L, 60L);
+    assertThat(response.getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+    var actualBody = objectMapper.readValue(response.getContentAsString(), ApiError.class);
+    assertThat(actualBody).usingRecursiveComparison().isEqualTo(expectedBody);
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY);
+  }
+
+  @Test
+  void shouldUseAdminBucketForAdminPrincipal() throws Exception {
+    // given
+    authenticateAs(someAdminUser(), "ADMIN");
+
+    // when
+    for (var i = 0; i < SOME_TINY_CAPACITY + 1; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+
+    // then — admin shares the same tiny capacity in this test fixture
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY);
+  }
+
+  @Test
+  void shouldUseAgentBucketForAgentPrincipal() throws Exception {
+    // given
+    authenticateAs(someAgentUser(), "AGENT");
+
+    // when
+    for (var i = 0; i < SOME_TINY_CAPACITY + 1; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY);
+  }
+
+  @Test
+  void shouldRateLimitPerUserIndependently() throws Exception {
+    // given
+    authenticateAs(someCustomerUser(), "CUSTOMER");
+    for (var i = 0; i < SOME_TINY_CAPACITY; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+    SecurityContextHolder.clearContext();
+
+    // when — a different user should have a fresh bucket
+    authenticateAs(someAdminUser(), "ADMIN");
+    filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY + 1);
+  }
+
+  @Test
+  void shouldRateLimitPerRouteIndependently() throws Exception {
+    // given
+    authenticateAs(someCustomerUser(), "CUSTOMER");
+    for (var i = 0; i < SOME_TINY_CAPACITY; i++) {
+      filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    }
+
+    // when — different route gets a fresh bucket for the same user
+    filter.doFilter(getRequest("/api/v1/dashboard/stats"), new MockHttpServletResponse(), chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY + 1);
+  }
+
+  @Test
+  void shouldNormalizeTrailingSlashAndMatrixParamsForRoute() throws Exception {
+    // given
+    authenticateAs(someCustomerUser(), "CUSTOMER");
+
+    // when — three normalized variants of the same route exhaust the bucket
+    filter.doFilter(getRequest(SOME_ROUTE), new MockHttpServletResponse(), chain);
+    filter.doFilter(getRequest(SOME_ROUTE + "/"), new MockHttpServletResponse(), chain);
+    filter.doFilter(
+        getRequest(SOME_ROUTE + ";jsessionid=abc"), new MockHttpServletResponse(), chain);
+    var fourth = new MockHttpServletResponse();
+    filter.doFilter(getRequest(SOME_ROUTE), fourth, chain);
+
+    // then
+    assertThat(chainInvocations.get()).isEqualTo((int) SOME_TINY_CAPACITY);
+    assertThat(fourth.getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+  }
+
+  private static MockHttpServletRequest getRequest(String uri) {
+    var request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setRequestURI(uri);
+    return request;
+  }
+
+  private static void authenticateAs(AuthenticatedUser user, String role) {
+    var jwt =
+        jwtBuilder()
+            .subject(subjectFor(user))
+            .claim("email", user.email())
+            .claim("roles", List.of(role))
+            .build();
+    var token =
+        new AuthenticatedUserToken(jwt, user, List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+    SecurityContextHolder.getContext().setAuthentication(token);
+  }
+
+  private static String subjectFor(AuthenticatedUser user) {
+    if (user.isAgent()) {
+      return SOME_AGENT_USER_UUID.toString();
+    }
+    if (user.isAdmin()) {
+      return SOME_ADMIN_USER_UUID.toString();
+    }
+    return SOME_CUSTOMER_USER_UUID.toString();
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/ratelimit/fixtures/RateLimitFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/infrastructure/ratelimit/fixtures/RateLimitFixtures.java
@@ -1,0 +1,95 @@
+package io.stablepay.api.infrastructure.ratelimit.fixtures;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.stablepay.api.infrastructure.ratelimit.RateLimitBucketResolver;
+import io.stablepay.api.infrastructure.ratelimit.RateLimitConfig;
+import io.stablepay.api.infrastructure.security.Role;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class RateLimitFixtures {
+
+  public static final long SOME_TINY_CAPACITY = 3L;
+  public static final Duration SOME_LIMIT_WINDOW = Duration.ofMinutes(1);
+
+  private RateLimitFixtures() {}
+
+  public static Map<Role, BucketConfiguration> tinyConfigurationsForAllRoles() {
+    var configurations = new EnumMap<Role, BucketConfiguration>(Role.class);
+    var configuration =
+        BucketConfiguration.builder()
+            .addLimit(
+                limit ->
+                    limit
+                        .capacity(SOME_TINY_CAPACITY)
+                        .refillGreedy(SOME_TINY_CAPACITY, SOME_LIMIT_WINDOW))
+            .build();
+    configurations.put(Role.CUSTOMER, configuration);
+    configurations.put(Role.ADMIN, configuration);
+    configurations.put(Role.AGENT, configuration);
+    return Map.copyOf(configurations);
+  }
+
+  public static Map<Role, BucketConfiguration> productionConfigurationsForAllRoles() {
+    var configurations = new EnumMap<Role, BucketConfiguration>(Role.class);
+    configurations.put(
+        Role.CUSTOMER,
+        BucketConfiguration.builder()
+            .addLimit(
+                limit ->
+                    limit
+                        .capacity(RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE)
+                        .refillGreedy(RateLimitConfig.CUSTOMER_LIMIT_PER_MINUTE, SOME_LIMIT_WINDOW))
+            .build());
+    configurations.put(
+        Role.ADMIN,
+        BucketConfiguration.builder()
+            .addLimit(
+                limit ->
+                    limit
+                        .capacity(RateLimitConfig.ADMIN_LIMIT_PER_MINUTE)
+                        .refillGreedy(RateLimitConfig.ADMIN_LIMIT_PER_MINUTE, SOME_LIMIT_WINDOW))
+            .build());
+    configurations.put(
+        Role.AGENT,
+        BucketConfiguration.builder()
+            .addLimit(
+                limit ->
+                    limit
+                        .capacity(RateLimitConfig.AGENT_LIMIT_PER_MINUTE)
+                        .refillGreedy(RateLimitConfig.AGENT_LIMIT_PER_MINUTE, SOME_LIMIT_WINDOW))
+            .build());
+    return Map.copyOf(configurations);
+  }
+
+  public static InMemoryBucketResolver inMemoryResolverWith(
+      Map<Role, BucketConfiguration> configurations) {
+    return new InMemoryBucketResolver(configurations);
+  }
+
+  public static final class InMemoryBucketResolver implements RateLimitBucketResolver {
+
+    private final Map<Role, BucketConfiguration> configurations;
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public InMemoryBucketResolver(Map<Role, BucketConfiguration> configurations) {
+      this.configurations = configurations;
+    }
+
+    @Override
+    public Bucket resolve(String key, Role role) {
+      return buckets.computeIfAbsent(key, ignored -> newLocalBucket(configurations.get(role)));
+    }
+
+    private static Bucket newLocalBucket(BucketConfiguration configuration) {
+      var builder = Bucket.builder();
+      for (var bandwidth : configuration.getBandwidths()) {
+        builder.addLimit(bandwidth);
+      }
+      return builder.build();
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-st
 namastack-outbox-starter-jdbc = { module = "io.namastack:namastack-outbox-starter-jdbc", version.ref = "namastack-outbox" }
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
 bucket4j-redis = { module = "com.bucket4j:bucket4j_jdk17-redis-common", version.ref = "bucket4j" }
+bucket4j-lettuce = { module = "com.bucket4j:bucket4j_jdk17-lettuce", version.ref = "bucket4j" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -251,6 +251,21 @@ services:
     networks:
       - stablepay_default
 
+  # ─── Redis (Bucket4j rate limiting backend) ───────
+  redis:
+    image: redis:8.0-alpine
+    container_name: stablepay-redis
+    ports:
+      - "6379:6379"
+    mem_limit: 256m
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - stablepay_default
+
   # ─── Auth Service (Spring Boot JWT issuer) ────────
   apps-auth:
     build:


### PR DESCRIPTION
## SPP Issue
Closes #96

## Changes
- Add `RateLimitConfig` building a Lettuce-CAS `LettuceBasedProxyManager` with per-role bandwidths (CUSTOMER 100/min, ADMIN 500/min, AGENT 1000/min).
- Add `RateLimitFilter` (`OncePerRequestFilter`) keying buckets on `(user_id, route)` and ordered AFTER `BearerTokenAuthenticationFilter` via `SecurityConfig.addFilterAfter(...)` so the JWT principal is bound before consumption.
- On bucket exhaustion respond `429 Too Many Requests` with `Retry-After: <seconds>` header and a `STBLPAY-4001` `ApiError` body.
- Introduce `RateLimitBucketResolver` strategy + `RateLimitProperties` for capacity tuning; expose new `STBLPAY-4001` error code on `ApiError`.
- Add `redis:8.0-alpine` service to `infra/docker-compose.yml` (256m mem limit, `redis-cli ping` healthcheck) and Spring Data Redis settings in `application.yml`.
- Wire `bucket4j-redis` + `spring-boot-starter-data-redis` via `gradle/libs.versions.toml` and `apps/api/main/build.gradle.kts`.
- Tests: unit tests for `RateLimitConfig` and `RateLimitFilter` with `RateLimitFixtures` in `testFixtures/`; `RateLimitFilterIT` Testcontainers integration test asserting the 101st CUSTOMER request hits 429 and bucket state survives in Redis.

## Checklist
- [x] Unit tests added (`RateLimitConfigTest`, `RateLimitFilterTest`)
- [x] Integration tests added (`RateLimitFilterIT` with Testcontainers Redis)
- [x] Test fixtures placed under `testFixtures/` (`RateLimitFixtures`)
- [x] Spotless formatting applied
- [ ] `./gradlew build` — please re-run locally before merge
- [ ] ArchUnit rules — re-run as part of `build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting to the API with role-based request quotas. Customers, admins, and agents each have distinct request limits per minute. Requests exceeding the limit receive a 429 response with a retry-after header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->