### PR TITLE
SPP-93: add SSE live-activity stream with shared OpenSearch poller

### DIFF
--- a/apps/api/main/build.gradle.kts
+++ b/apps/api/main/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.junit)
     testImplementation(libs.trino.parser)
+    testImplementation(libs.reactor.test)
     testCompileOnly(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 

--- a/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/db/PostgresIdempotencyRepositoryIT.java
+++ b/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/db/PostgresIdempotencyRepositoryIT.java
@@ -61,6 +61,7 @@ class PostgresIdempotencyRepositoryIT {
             .body(new byte[] {1, 2, 3, 4, 5})
             .expiresAt(expiresAt)
             .build();
+    repository.tryAcquire(key, userId, expiresAt);
     repository.save(key, userId, cached);
 
     // when
@@ -83,6 +84,7 @@ class PostgresIdempotencyRepositoryIT {
     var pastExpiry = Instant.now().minusSeconds(60);
     var cached =
         CachedResponse.builder().status(200).body(new byte[] {9}).expiresAt(pastExpiry).build();
+    repository.tryAcquire(key, userId, pastExpiry);
     repository.save(key, userId, cached);
     var expected = Optional.<CachedResponse>empty();
 
@@ -102,15 +104,9 @@ class PostgresIdempotencyRepositoryIT {
     var firstBody = new byte[] {1, 1, 1};
     var first =
         CachedResponse.builder().status(200).body(firstBody).expiresAt(firstExpiresAt).build();
+    repository.tryAcquire(key, userId, firstExpiresAt);
     repository.save(key, userId, first);
-    var secondBody = new byte[] {9, 9, 9};
-    var second =
-        CachedResponse.builder()
-            .status(500)
-            .body(secondBody)
-            .expiresAt(firstExpiresAt.plusSeconds(60))
-            .build();
-    repository.save(key, userId, second);
+    var secondAcquired = repository.tryAcquire(key, userId, firstExpiresAt.plusSeconds(60));
     var expected =
         CachedResponse.builder()
             .status(200)
@@ -122,6 +118,7 @@ class PostgresIdempotencyRepositoryIT {
     var actual = repository.findActive(key, userId, Instant.now());
 
     // then
+    assertThat(secondAcquired).isFalse();
     assertThat(actual)
         .isPresent()
         .get()
@@ -138,10 +135,12 @@ class PostgresIdempotencyRepositoryIT {
     var freshKey = "key-cleanup-fresh-" + UUID.randomUUID();
     var pastExpiry = Instant.now().minusSeconds(120);
     var futureExpiry = Instant.now().plusSeconds(3600);
+    repository.tryAcquire(expiredKey, userId, pastExpiry);
     repository.save(
         expiredKey,
         userId,
         CachedResponse.builder().status(200).body(new byte[] {1}).expiresAt(pastExpiry).build());
+    repository.tryAcquire(freshKey, userId, futureExpiry);
     repository.save(
         freshKey,
         userId,

--- a/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/sse/SseCustomerScopeIT.java
+++ b/apps/api/main/src/integration-test/java/io/stablepay/api/infrastructure/sse/SseCustomerScopeIT.java
@@ -1,0 +1,160 @@
+package io.stablepay.api.infrastructure.sse;
+
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_ID;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_TRANSACTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import io.stablepay.api.application.web.controller.StreamsController;
+import io.stablepay.api.application.web.dto.TransactionEventDto;
+import io.stablepay.api.application.web.mapper.TransactionEventWebMapper;
+import io.stablepay.api.domain.model.CustomerId;
+import io.stablepay.api.domain.port.TransactionRepository;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("integration")
+class SseCustomerScopeIT {
+
+  private static final CustomerId BOB_CUSTOMER_ID =
+      CustomerId.of(UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"));
+
+  @Mock private TransactionRepository transactionRepository;
+
+  private StreamsController controller;
+  private SseTransactionPoller poller;
+
+  @BeforeEach
+  void setUp() {
+    var eventMapper = Mappers.getMapper(TransactionEventMapper.class);
+    var webMapper = Mappers.getMapper(TransactionEventWebMapper.class);
+    poller = new SseTransactionPoller(transactionRepository, eventMapper);
+    controller = new StreamsController(poller, webMapper);
+  }
+
+  @Nested
+  class SseStream {
+
+    @Test
+    void shouldNotDeliverBobsEventToAlice() {
+      // given
+      var alice = someCustomerUser();
+      var bobTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(BOB_CUSTOMER_ID)
+              .eventId("evt-bob-001")
+              .build();
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willReturn(Stream.of(bobTx));
+
+      // when
+      var flux = controller.transactions(alice);
+      poller.poll();
+
+      // then
+      StepVerifier.create(flux.take(1))
+          .expectNextCount(0)
+          .thenCancel()
+          .verify(java.time.Duration.ofMillis(200));
+    }
+
+    @Test
+    void shouldDeliverBothCustomerEventsToAdmin() {
+      // given
+      var admin = someAdminUser();
+      var aliceTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(SOME_CUSTOMER_ID)
+              .eventId("evt-alice-001")
+              .build();
+      var bobTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(BOB_CUSTOMER_ID)
+              .eventId("evt-bob-001")
+              .build();
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willReturn(Stream.of(aliceTx, bobTx));
+
+      // when
+      var flux = controller.transactions(admin);
+      poller.poll();
+
+      // then
+      StepVerifier.create(flux.take(2))
+          .assertNext(
+              sse -> assertThat(sse.data()).extracting(TransactionEventDto::customerId)
+                  .isEqualTo(SOME_CUSTOMER_ID.value().toString()))
+          .assertNext(
+              sse -> assertThat(sse.data()).extracting(TransactionEventDto::customerId)
+                  .isEqualTo(BOB_CUSTOMER_ID.value().toString()))
+          .verifyComplete();
+    }
+  }
+
+  @Nested
+  class PollingFallback {
+
+    @Test
+    void shouldNotReturnBobsEventToAlice() {
+      // given
+      var alice = someCustomerUser();
+      var aliceTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(SOME_CUSTOMER_ID)
+              .eventId("evt-alice-001")
+              .build();
+      var bobTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(BOB_CUSTOMER_ID)
+              .eventId("evt-bob-001")
+              .build();
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 50))
+          .willReturn(Stream.of(aliceTx, bobTx));
+
+      // when
+      var result = controller.recent(alice, null);
+
+      // then
+      assertThat(result).hasSize(1);
+      assertThat(result.getFirst().customerId())
+          .isEqualTo(SOME_CUSTOMER_ID.value().toString());
+    }
+
+    @Test
+    void shouldReturnBothCustomerEventsToAdmin() {
+      // given
+      var admin = someAdminUser();
+      var aliceTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(SOME_CUSTOMER_ID)
+              .eventId("evt-alice-001")
+              .build();
+      var bobTx =
+          SOME_TRANSACTION.toBuilder()
+              .customerId(BOB_CUSTOMER_ID)
+              .eventId("evt-bob-001")
+              .build();
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 50))
+          .willReturn(Stream.of(aliceTx, bobTx));
+
+      // when
+      var result = controller.recent(admin, null);
+
+      // then
+      assertThat(result).hasSize(2);
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
@@ -1,0 +1,67 @@
+package io.stablepay.api.application.web.controller;
+
+import io.stablepay.api.application.security.AuthenticatedUser;
+import io.stablepay.api.application.web.dto.TransactionEventDto;
+import io.stablepay.api.application.web.mapper.TransactionEventWebMapper;
+import io.stablepay.api.domain.model.TransactionEvent;
+import io.stablepay.api.domain.port.TransactionEventSource;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/streams")
+@Secured({"ROLE_CUSTOMER", "ROLE_ADMIN"})
+public class StreamsController {
+
+  private final TransactionEventSource eventSource;
+  private final TransactionEventWebMapper mapper;
+
+  @GetMapping(value = "/transactions", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public Flux<ServerSentEvent<TransactionEventDto>> transactions(
+      @AuthenticationPrincipal AuthenticatedUser user) {
+    var events =
+        eventSource
+            .subscribeAdmin()
+            .filter(e -> isVisibleTo(e, user))
+            .map(
+                e ->
+                    ServerSentEvent.<TransactionEventDto>builder()
+                        .id(e.eventId())
+                        .data(mapper.toDto(e))
+                        .retry(Duration.ofSeconds(2))
+                        .build());
+    var heartbeat =
+        Flux.interval(Duration.ofSeconds(30))
+            .map(__ -> ServerSentEvent.<TransactionEventDto>builder().comment("heartbeat").build());
+    return events.mergeWith(heartbeat);
+  }
+
+  @GetMapping("/transactions/recent")
+  public List<TransactionEventDto> recent(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @RequestParam(required = false) String since) {
+    return eventSource.snapshotSinceAdmin(Optional.ofNullable(since), 50).stream()
+        .filter(e -> isVisibleTo(e, user))
+        .map(mapper::toDto)
+        .toList();
+  }
+
+  private static boolean isVisibleTo(TransactionEvent event, AuthenticatedUser user) {
+    return user.isAdmin()
+        || user.customerId().map(c -> c.value().toString()).orElse("").equals(event.customerId());
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionEventDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionEventDto.java
@@ -1,0 +1,28 @@
+package io.stablepay.api.application.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Objects;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record TransactionEventDto(
+    @JsonProperty("event_id") String eventId,
+    @JsonProperty("customer_id") String customerId,
+    String status,
+    @JsonProperty("event_time") Instant eventTime,
+    @JsonProperty("amount_micros") long amountMicros,
+    @JsonProperty("currency_code") String currencyCode,
+    @JsonProperty("flow_type") String flowType,
+    @JsonProperty("sort_key") String sortKey) {
+
+  public TransactionEventDto {
+    Objects.requireNonNull(eventId, "eventId");
+    Objects.requireNonNull(customerId, "customerId");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(eventTime, "eventTime");
+    Objects.requireNonNull(currencyCode, "currencyCode");
+    Objects.requireNonNull(flowType, "flowType");
+    Objects.requireNonNull(sortKey, "sortKey");
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/mapper/TransactionEventWebMapper.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/mapper/TransactionEventWebMapper.java
@@ -1,0 +1,11 @@
+package io.stablepay.api.application.web.mapper;
+
+import io.stablepay.api.application.web.dto.TransactionEventDto;
+import io.stablepay.api.domain.model.TransactionEvent;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface TransactionEventWebMapper {
+
+  TransactionEventDto toDto(TransactionEvent event);
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/model/TransactionEvent.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/model/TransactionEvent.java
@@ -1,0 +1,27 @@
+package io.stablepay.api.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record TransactionEvent(
+    String eventId,
+    String customerId,
+    String status,
+    Instant eventTime,
+    long amountMicros,
+    String currencyCode,
+    String flowType,
+    String sortKey) {
+
+  public TransactionEvent {
+    Objects.requireNonNull(eventId, "eventId");
+    Objects.requireNonNull(customerId, "customerId");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(eventTime, "eventTime");
+    Objects.requireNonNull(currencyCode, "currencyCode");
+    Objects.requireNonNull(flowType, "flowType");
+    Objects.requireNonNull(sortKey, "sortKey");
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/port/TransactionEventSource.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/port/TransactionEventSource.java
@@ -1,0 +1,13 @@
+package io.stablepay.api.domain.port;
+
+import io.stablepay.api.domain.model.TransactionEvent;
+import java.util.List;
+import java.util.Optional;
+import reactor.core.publisher.Flux;
+
+public interface TransactionEventSource {
+
+  Flux<TransactionEvent> subscribeAdmin();
+
+  List<TransactionEvent> snapshotSinceAdmin(Optional<String> since, int limit);
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/SseTransactionPoller.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/SseTransactionPoller.java
@@ -35,7 +35,10 @@ public class SseTransactionPoller implements TransactionEventSource {
           tx -> {
             var sortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
             var event = mapper.toEvent(tx).toBuilder().sortKey(sortKey).build();
-            sink.tryEmitNext(event);
+            var result = sink.tryEmitNext(event);
+            if (result.isFailure()) {
+              log.warn("SSE event emission failed: {}", result);
+            }
             lastSortValue.set(Optional.of(sortKey));
           });
     } catch (Exception e) {

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/SseTransactionPoller.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/SseTransactionPoller.java
@@ -1,0 +1,63 @@
+package io.stablepay.api.infrastructure.sse;
+
+import io.stablepay.api.domain.model.TransactionEvent;
+import io.stablepay.api.domain.port.TransactionEventSource;
+import io.stablepay.api.domain.port.TransactionRepository;
+import io.stablepay.api.infrastructure.cursor.Base64PipeCursor;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseTransactionPoller implements TransactionEventSource {
+
+  private final TransactionRepository transactionRepository;
+  private final TransactionEventMapper mapper;
+
+  private final Sinks.Many<TransactionEvent> sink =
+      Sinks.many().multicast().onBackpressureBuffer(256);
+
+  private final AtomicReference<Optional<String>> lastSortValue =
+      new AtomicReference<>(Optional.empty());
+
+  @Scheduled(fixedDelay = 1000)
+  void poll() {
+    try (var stream = transactionRepository.tailSinceSortValueAdmin(lastSortValue.get(), 100)) {
+      stream.forEach(
+          tx -> {
+            var sortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+            var event = mapper.toEvent(tx).toBuilder().sortKey(sortKey).build();
+            sink.tryEmitNext(event);
+            lastSortValue.set(Optional.of(sortKey));
+          });
+    } catch (Exception e) {
+      log.warn("SSE poll failed: {}", e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public Flux<TransactionEvent> subscribeAdmin() {
+    return sink.asFlux();
+  }
+
+  @Override
+  public List<TransactionEvent> snapshotSinceAdmin(Optional<String> since, int limit) {
+    try (var stream = transactionRepository.tailSinceSortValueAdmin(since, limit)) {
+      return stream
+          .map(
+              tx -> {
+                var sortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+                return mapper.toEvent(tx).toBuilder().sortKey(sortKey).build();
+              })
+          .toList();
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/TransactionEventMapper.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/sse/TransactionEventMapper.java
@@ -1,0 +1,17 @@
+package io.stablepay.api.infrastructure.sse;
+
+import io.stablepay.api.domain.model.Transaction;
+import io.stablepay.api.domain.model.TransactionEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface TransactionEventMapper {
+
+  @Mapping(target = "customerId", expression = "java(tx.customerId().value().toString())")
+  @Mapping(target = "status", source = "customerStatus")
+  @Mapping(target = "amountMicros", expression = "java(tx.amount().toMicros())")
+  @Mapping(target = "currencyCode", expression = "java(tx.amount().currency().name())")
+  @Mapping(target = "sortKey", constant = "")
+  TransactionEvent toEvent(Transaction tx);
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/application/web/controller/StreamsControllerTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/application/web/controller/StreamsControllerTest.java
@@ -1,0 +1,183 @@
+package io.stablepay.api.application.web.controller;
+
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_ID;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.someAdminUser;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.someCustomerUser;
+import static io.stablepay.api.domain.model.fixtures.TransactionEventFixtures.SOME_OTHER_CUSTOMER_EVENT;
+import static io.stablepay.api.domain.model.fixtures.TransactionEventFixtures.SOME_TRANSACTION_EVENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import io.stablepay.api.application.web.dto.TransactionEventDto;
+import io.stablepay.api.application.web.mapper.TransactionEventWebMapper;
+import io.stablepay.api.domain.model.TransactionEvent;
+import io.stablepay.api.domain.port.TransactionEventSource;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class StreamsControllerTest {
+
+  @Mock private TransactionEventSource eventSource;
+
+  @Spy
+  private final TransactionEventWebMapper mapper =
+      Mappers.getMapper(TransactionEventWebMapper.class);
+
+  @InjectMocks private StreamsController controller;
+
+  @Nested
+  class SseStream {
+
+    @Test
+    void shouldFilterEventsToCustomerScope() {
+      // given
+      var user = someCustomerUser();
+      var ownEvent =
+          SOME_TRANSACTION_EVENT.toBuilder()
+              .customerId(SOME_CUSTOMER_ID.value().toString())
+              .build();
+      var otherEvent = SOME_OTHER_CUSTOMER_EVENT;
+      given(eventSource.subscribeAdmin()).willReturn(Flux.just(ownEvent, otherEvent));
+
+      // when
+      var result = controller.transactions(user);
+
+      // then
+      StepVerifier.create(result.take(1))
+          .assertNext(
+              sse -> {
+                assertThat(sse.id()).isEqualTo(ownEvent.eventId());
+                assertThat(sse.data())
+                    .usingRecursiveComparison()
+                    .isEqualTo(toExpectedDto(ownEvent));
+              })
+          .verifyComplete();
+    }
+
+    @Test
+    void shouldPassAllEventsToAdmin() {
+      // given
+      var user = someAdminUser();
+      var event1 =
+          SOME_TRANSACTION_EVENT.toBuilder()
+              .customerId(SOME_CUSTOMER_ID.value().toString())
+              .build();
+      var event2 = SOME_OTHER_CUSTOMER_EVENT;
+      given(eventSource.subscribeAdmin()).willReturn(Flux.just(event1, event2));
+
+      // when
+      var result = controller.transactions(user);
+
+      // then
+      StepVerifier.create(result.take(2))
+          .assertNext(
+              sse ->
+                  assertThat(sse.data())
+                      .usingRecursiveComparison()
+                      .isEqualTo(toExpectedDto(event1)))
+          .assertNext(
+              sse ->
+                  assertThat(sse.data())
+                      .usingRecursiveComparison()
+                      .isEqualTo(toExpectedDto(event2)))
+          .verifyComplete();
+    }
+
+    @Test
+    void shouldIncludeRetryDirective() {
+      // given
+      var user = someAdminUser();
+      given(eventSource.subscribeAdmin()).willReturn(Flux.just(SOME_TRANSACTION_EVENT));
+
+      // when
+      var result = controller.transactions(user);
+
+      // then
+      StepVerifier.create(result.take(1))
+          .assertNext(sse -> assertThat(sse.retry()).isEqualTo(java.time.Duration.ofSeconds(2)))
+          .verifyComplete();
+    }
+  }
+
+  @Nested
+  class PollingFallback {
+
+    @Test
+    void shouldFilterRecentEventsToCustomerScope() {
+      // given
+      var user = someCustomerUser();
+      var ownEvent =
+          SOME_TRANSACTION_EVENT.toBuilder()
+              .customerId(SOME_CUSTOMER_ID.value().toString())
+              .build();
+      var otherEvent = SOME_OTHER_CUSTOMER_EVENT;
+      given(eventSource.snapshotSinceAdmin(Optional.empty(), 50))
+          .willReturn(List.of(ownEvent, otherEvent));
+
+      // when
+      var result = controller.recent(user, null);
+
+      // then
+      assertThat(result).usingRecursiveComparison().isEqualTo(List.of(toExpectedDto(ownEvent)));
+    }
+
+    @Test
+    void shouldReturnAllRecentEventsForAdmin() {
+      // given
+      var user = someAdminUser();
+      var event1 =
+          SOME_TRANSACTION_EVENT.toBuilder()
+              .customerId(SOME_CUSTOMER_ID.value().toString())
+              .build();
+      var event2 = SOME_OTHER_CUSTOMER_EVENT;
+      given(eventSource.snapshotSinceAdmin(Optional.empty(), 50))
+          .willReturn(List.of(event1, event2));
+
+      // when
+      var result = controller.recent(user, null);
+
+      // then
+      assertThat(result)
+          .usingRecursiveComparison()
+          .isEqualTo(List.of(toExpectedDto(event1), toExpectedDto(event2)));
+    }
+
+    @Test
+    void shouldPassSinceParameterToSource() {
+      // given
+      var user = someAdminUser();
+      var cursor = "some-cursor";
+      given(eventSource.snapshotSinceAdmin(Optional.of(cursor), 50)).willReturn(List.of());
+
+      // when
+      var result = controller.recent(user, cursor);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+
+  private static TransactionEventDto toExpectedDto(TransactionEvent event) {
+    return TransactionEventDto.builder()
+        .eventId(event.eventId())
+        .customerId(event.customerId())
+        .status(event.status())
+        .eventTime(event.eventTime())
+        .amountMicros(event.amountMicros())
+        .currencyCode(event.currencyCode())
+        .flowType(event.flowType())
+        .sortKey(event.sortKey())
+        .build();
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/application/web/mapper/TransactionEventWebMapperTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/application/web/mapper/TransactionEventWebMapperTest.java
@@ -1,0 +1,37 @@
+package io.stablepay.api.application.web.mapper;
+
+import static io.stablepay.api.domain.model.fixtures.TransactionEventFixtures.SOME_TRANSACTION_EVENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stablepay.api.application.web.dto.TransactionEventDto;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class TransactionEventWebMapperTest {
+
+  private final TransactionEventWebMapper mapper =
+      Mappers.getMapper(TransactionEventWebMapper.class);
+
+  @Test
+  void shouldMapDomainEventToDto() {
+    // given
+    var event = SOME_TRANSACTION_EVENT;
+
+    // when
+    var result = mapper.toDto(event);
+
+    // then
+    var expected =
+        TransactionEventDto.builder()
+            .eventId(event.eventId())
+            .customerId(event.customerId())
+            .status(event.status())
+            .eventTime(event.eventTime())
+            .amountMicros(event.amountMicros())
+            .currencyCode(event.currencyCode())
+            .flowType(event.flowType())
+            .sortKey(event.sortKey())
+            .build();
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/idempotency/IdempotencyAspectTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/idempotency/IdempotencyAspectTest.java
@@ -237,5 +237,4 @@ class IdempotencyAspectTest {
       then(pjp).shouldHaveNoInteractions();
     }
   }
-
 }

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/SseTransactionPollerTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/SseTransactionPollerTest.java
@@ -90,13 +90,22 @@ class SseTransactionPollerTest {
     @Test
     void shouldNotCrashOnException() {
       // given
+      var tx = SOME_TRANSACTION;
       given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
-          .willThrow(new RuntimeException("OpenSearch down"));
+          .willThrow(new RuntimeException("OpenSearch down"))
+          .willReturn(Stream.of(tx));
+      var expectedSortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+      var expected = buildExpectedEvent(tx, expectedSortKey);
 
-      // when — poll catches the exception internally
+      // when
+      poller.poll();
+      var flux = poller.subscribeAdmin();
       poller.poll();
 
-      // then — poller is still functional after exception
+      // then
+      StepVerifier.create(flux.take(1))
+          .assertNext(event -> assertThat(event).usingRecursiveComparison().isEqualTo(expected))
+          .verifyComplete();
     }
   }
 

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/SseTransactionPollerTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/SseTransactionPollerTest.java
@@ -1,0 +1,149 @@
+package io.stablepay.api.infrastructure.sse;
+
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_TRANSACTION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import io.stablepay.api.domain.model.Transaction;
+import io.stablepay.api.domain.model.TransactionEvent;
+import io.stablepay.api.domain.port.TransactionRepository;
+import io.stablepay.api.infrastructure.cursor.Base64PipeCursor;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class SseTransactionPollerTest {
+
+  @Mock private TransactionRepository transactionRepository;
+
+  @Spy
+  private final TransactionEventMapper mapper = Mappers.getMapper(TransactionEventMapper.class);
+
+  @InjectMocks private SseTransactionPoller poller;
+
+  @Nested
+  class Poll {
+
+    @Test
+    void shouldEmitMappedEventsToSubscribers() {
+      // given
+      var tx = SOME_TRANSACTION;
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willReturn(Stream.of(tx));
+      var expectedSortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+      var expected = buildExpectedEvent(tx, expectedSortKey);
+
+      // when
+      var flux = poller.subscribeAdmin();
+      poller.poll();
+
+      // then
+      StepVerifier.create(flux.take(1))
+          .assertNext(event -> assertThat(event).usingRecursiveComparison().isEqualTo(expected))
+          .verifyComplete();
+    }
+
+    @Test
+    void shouldNotEmitWhenNoNewTransactions() {
+      // given
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willReturn(Stream.empty());
+
+      // when
+      poller.poll();
+
+      // then
+      StepVerifier.create(poller.subscribeAdmin().take(1))
+          .expectNextCount(0)
+          .thenCancel()
+          .verify(Duration.ofMillis(100));
+    }
+
+    @Test
+    void shouldUpdateLastSortValueAfterPoll() {
+      // given
+      var tx = SOME_TRANSACTION;
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willReturn(Stream.of(tx));
+      var expectedCursor = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+
+      // when
+      poller.poll();
+
+      // then — second poll uses updated cursor
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.of(expectedCursor), 100))
+          .willReturn(Stream.empty());
+      poller.poll();
+    }
+
+    @Test
+    void shouldNotCrashOnException() {
+      // given
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 100))
+          .willThrow(new RuntimeException("OpenSearch down"));
+
+      // when — poll catches the exception internally
+      poller.poll();
+
+      // then — poller is still functional after exception
+    }
+  }
+
+  @Nested
+  class SnapshotSince {
+
+    @Test
+    void shouldReturnMappedEventsFromRepository() {
+      // given
+      var tx = SOME_TRANSACTION;
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.empty(), 50))
+          .willReturn(Stream.of(tx));
+      var expectedSortKey = Base64PipeCursor.encode(tx.eventTime().toEpochMilli(), tx.eventId());
+      var expected = buildExpectedEvent(tx, expectedSortKey);
+
+      // when
+      var result = poller.snapshotSinceAdmin(Optional.empty(), 50);
+
+      // then
+      assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
+    }
+
+    @Test
+    void shouldPassCursorToRepository() {
+      // given
+      var cursor = "some-cursor-value";
+      given(transactionRepository.tailSinceSortValueAdmin(Optional.of(cursor), 50))
+          .willReturn(Stream.empty());
+
+      // when
+      var result = poller.snapshotSinceAdmin(Optional.of(cursor), 50);
+
+      // then
+      assertThat(result).isEmpty();
+    }
+  }
+
+  private static TransactionEvent buildExpectedEvent(Transaction tx, String sortKey) {
+    return TransactionEvent.builder()
+        .eventId(tx.eventId())
+        .customerId(tx.customerId().value().toString())
+        .status(tx.customerStatus())
+        .eventTime(tx.eventTime())
+        .amountMicros(tx.amount().toMicros())
+        .currencyCode(tx.amount().currency().name())
+        .flowType(tx.flowType())
+        .sortKey(sortKey)
+        .build();
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/TransactionEventMapperTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/sse/TransactionEventMapperTest.java
@@ -1,0 +1,36 @@
+package io.stablepay.api.infrastructure.sse;
+
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_TRANSACTION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.stablepay.api.domain.model.TransactionEvent;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class TransactionEventMapperTest {
+
+  private final TransactionEventMapper mapper = Mappers.getMapper(TransactionEventMapper.class);
+
+  @Test
+  void shouldMapTransactionToCompactEvent() {
+    // given
+    var tx = SOME_TRANSACTION;
+
+    // when
+    var result = mapper.toEvent(tx);
+
+    // then
+    var expected =
+        TransactionEvent.builder()
+            .eventId(tx.eventId())
+            .customerId(tx.customerId().value().toString())
+            .status(tx.customerStatus())
+            .eventTime(tx.eventTime())
+            .amountMicros(tx.amount().toMicros())
+            .currencyCode(tx.amount().currency().name())
+            .flowType(tx.flowType())
+            .sortKey("")
+            .build();
+    assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/model/fixtures/TransactionEventFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/model/fixtures/TransactionEventFixtures.java
@@ -1,0 +1,40 @@
+package io.stablepay.api.domain.model.fixtures;
+
+import static io.stablepay.api.domain.model.fixtures.MoneyFixtures.SOME_MONEY;
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_EVENT_TIME;
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_TRANSACTION;
+import static io.stablepay.api.domain.model.fixtures.TransactionFixtures.SOME_TRANSACTION_CUSTOMER_ID;
+
+import io.stablepay.api.domain.model.TransactionEvent;
+import java.util.UUID;
+
+public final class TransactionEventFixtures {
+
+  public static final String SOME_OTHER_CUSTOMER_ID =
+      UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee").toString();
+
+  public static final TransactionEvent SOME_TRANSACTION_EVENT =
+      TransactionEvent.builder()
+          .eventId(SOME_TRANSACTION.eventId())
+          .customerId(SOME_TRANSACTION_CUSTOMER_ID.value().toString())
+          .status(SOME_TRANSACTION.customerStatus())
+          .eventTime(SOME_EVENT_TIME)
+          .amountMicros(SOME_MONEY.toMicros())
+          .currencyCode(SOME_MONEY.currency().name())
+          .flowType(SOME_TRANSACTION.flowType())
+          .sortKey("c29ydC1rZXk")
+          .build();
+
+  public static final TransactionEvent SOME_OTHER_CUSTOMER_EVENT =
+      SOME_TRANSACTION_EVENT.toBuilder()
+          .eventId("evt-other-0001")
+          .customerId(SOME_OTHER_CUSTOMER_ID)
+          .sortKey("b3RoZXIta2V5")
+          .build();
+
+  private TransactionEventFixtures() {}
+
+  public static TransactionEvent.TransactionEventBuilder someTransactionEvent() {
+    return SOME_TRANSACTION_EVENT.toBuilder();
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,6 +96,7 @@ springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openap
 trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 trino-parser = { module = "io.trino:trino-parser", version.ref = "trino-jdbc" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
 
 [plugins]
 avro = { id = "com.github.davidmc24.gradle.plugin.avro", version.ref = "avro-plugin" }


### PR DESCRIPTION
## SPP Issue
Closes #99

## Changes
- Add `TransactionEvent` domain model and `TransactionEventSource` port for SSE event projection
- Implement `SseTransactionPoller` — single shared @Scheduled poller backed by Reactor Sinks.Many multicast, with Base64PipeCursor tracking and exception resilience
- Add `StreamsController` with SSE stream endpoint (`GET /api/v1/streams/transactions`) and polling fallback (`GET /api/v1/streams/transactions/recent`), both with per-subscriber customer-scope filtering
- Add MapStruct mappers at infrastructure (Transaction → TransactionEvent) and application (TransactionEvent → TransactionEventDto) layer boundaries
- Add `reactor-test` dependency for StepVerifier-based reactive stream testing

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time transaction event streaming via Server-Sent Events with automatic 30-second heartbeat monitoring
  * Polling endpoint for retrieving up to 50 recent transaction events with optional date filtering
  * Customer-scoped event filtering ensures customers only receive their own transaction events; admins view all events

* **Tests**
  * Added comprehensive integration and unit tests validating streaming, polling, and customer-scoped visibility controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->