### PR TITLE
SPP-96: add Trino SQL allowlist validator using trino-parser AST walker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Four source sets per Java module: `test/` (unit, JUnit 5 + Mockito BDD + AssertJ
 
 ### 4. Latest stable versions everywhere
 
-Pin latest stable for every dependency. CI runs a weekly `ci-version-bump.yml` workflow that opens auto-PRs with version bumps. Document any pin caused by a known incompatibility in `docs/STACK.md` with a one-line justification.
+Pin latest stable for every dependency. Renovate Bot (`renovate.json`) runs weekly and opens grouped auto-PRs with version bumps across Gradle, npm, Python, Docker, and GitHub Actions. Document any pin caused by a known incompatibility in `docs/STACK.md` with a one-line justification.
 
 ### 5. Money never as float
 
@@ -74,7 +74,7 @@ Repository adapters apply `customer_id` filter from the JWT principal automatica
 
 ## Stack snapshot
 
-See `docs/STACK.md` (auto-updated by `ci-version-bump.yml`) for the full pin list. Key versions:
+See `docs/STACK.md` for the full pin list. Key versions:
 
 - Java 25 LTS, Spring Boot 4.0.x, Spring Cloud 2025.x, Gradle 9 Kotlin DSL
 - Python 3.13+ with `uv`, ruff
@@ -146,7 +146,7 @@ just dlq-replay <id>     # replay a single DLQ entry
 - `docs/EVENT-MODEL.md` — full state machines + topic listing + event examples (Phase 8)
 - `docs/EXTENDING.md` — forking guide with worked example (Phase 8)
 - `docs/RUNBOOK.md` — alert response procedures (Phase 6/8)
-- `docs/STACK.md` — auto-updated version pin list (Phase 7)
+- `docs/STACK.md` — version pin list, kept current by Renovate PRs (Phase 7)
 - `docs/EVAL-METHODOLOGY.md` — agent eval rubrics + reproduction steps (Phase 8)
 - `docs/PRIVACY.md` — PII inventory + masking + retention (Phase 6)
 

--- a/apps/api/main/build.gradle.kts
+++ b/apps/api/main/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.opensearch.java)
     implementation(libs.httpclient5)
     implementation(libs.trino.jdbc)
+    implementation(libs.trino.parser)
     implementation(libs.nv.i18n)
 
     implementation(libs.bucket4j.core)
@@ -96,7 +97,6 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.junit)
-    testImplementation(libs.trino.parser)
     testImplementation(libs.reactor.test)
     testCompileOnly(libs.lombok)
     testAnnotationProcessor(libs.lombok)

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedTableRegistry.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedTableRegistry.java
@@ -1,0 +1,19 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AllowedTableRegistry {
+
+  private static final Set<Pattern> ALLOWED =
+      Set.of(
+          Pattern.compile("^iceberg\\.analytics\\.v_[a-z_]+$"),
+          Pattern.compile("^iceberg\\.facts\\.fact_[a-z_]+$"),
+          Pattern.compile("^iceberg\\.agg\\.agg_[a-z_]+$"));
+
+  public boolean isAllowed(String fullyQualifiedName) {
+    return ALLOWED.stream().anyMatch(p -> p.matcher(fullyQualifiedName).matches());
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedTableRegistry.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedTableRegistry.java
@@ -14,6 +14,7 @@ public class AllowedTableRegistry {
           Pattern.compile("^iceberg\\.agg\\.agg_[a-z_]+$"));
 
   public boolean isAllowed(String fullyQualifiedName) {
-    return ALLOWED.stream().anyMatch(p -> p.matcher(fullyQualifiedName).matches());
+    var normalized = fullyQualifiedName.toLowerCase(java.util.Locale.ROOT);
+    return ALLOWED.stream().anyMatch(p -> p.matcher(normalized).matches());
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/SqlValidationResult.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/SqlValidationResult.java
@@ -1,13 +1,23 @@
 package io.stablepay.api.domain.agent;
 
+import java.util.Objects;
 import lombok.Builder;
 
 public sealed interface SqlValidationResult
     permits SqlValidationResult.Valid, SqlValidationResult.Invalid {
 
   @Builder(toBuilder = true)
-  record Valid(String sanitizedSql, int appliedLimit) implements SqlValidationResult {}
+  record Valid(String sanitizedSql, int appliedLimit) implements SqlValidationResult {
+    public Valid {
+      Objects.requireNonNull(sanitizedSql);
+    }
+  }
 
   @Builder(toBuilder = true)
-  record Invalid(String reason, String errorCode) implements SqlValidationResult {}
+  record Invalid(String reason, String errorCode) implements SqlValidationResult {
+    public Invalid {
+      Objects.requireNonNull(reason);
+      Objects.requireNonNull(errorCode);
+    }
+  }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/SqlValidationResult.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/SqlValidationResult.java
@@ -1,0 +1,13 @@
+package io.stablepay.api.domain.agent;
+
+import lombok.Builder;
+
+public sealed interface SqlValidationResult
+    permits SqlValidationResult.Valid, SqlValidationResult.Invalid {
+
+  @Builder(toBuilder = true)
+  record Valid(String sanitizedSql, int appliedLimit) implements SqlValidationResult {}
+
+  @Builder(toBuilder = true)
+  record Invalid(String reason, String errorCode) implements SqlValidationResult {}
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidator.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidator.java
@@ -7,11 +7,12 @@ import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.QuerySpecification;
-import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.Table;
-import io.trino.sql.tree.With;
 import java.util.ArrayList;
 import java.util.OptionalLong;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,8 @@ public class TrinoSqlAllowlistValidator {
   static final int DEFAULT_LIMIT = 1_000;
   static final int MAX_LIMIT = 10_000;
 
+  private static final Pattern LIMIT_PATTERN = Pattern.compile("(?i)\\bLIMIT\\s+\\d+");
+
   private final AllowedTableRegistry allowedTableRegistry;
   private final SqlParser sqlParser = new SqlParser();
 
@@ -30,48 +33,52 @@ public class TrinoSqlAllowlistValidator {
       return new SqlValidationResult.Invalid("SQL is empty", "STBLPAY-5001");
     }
 
-    Statement statement;
     try {
-      statement = sqlParser.createStatement(sql.strip());
+      var statement = sqlParser.createStatement(sql.strip());
+
+      if (!(statement instanceof Query query)) {
+        return new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
+      }
+
+      if (query.getWith().isPresent() && query.getWith().get().isRecursive()) {
+        return new SqlValidationResult.Invalid("WITH RECURSIVE not allowed", "STBLPAY-5003");
+      }
+
+      var cteNames = collectCteNames(query);
+
+      var tableNames = new ArrayList<String>();
+      new DefaultTraversalVisitor<Void>() {
+        @Override
+        protected Void visitTable(Table node, Void context) {
+          tableNames.add(node.getName().toString());
+          return null;
+        }
+      }.process(statement, null);
+
+      for (var tableName : tableNames) {
+        if (!cteNames.contains(tableName.toLowerCase(java.util.Locale.ROOT))
+            && !allowedTableRegistry.isAllowed(tableName)) {
+          return new SqlValidationResult.Invalid(
+              "Table %s not in allowlist".formatted(tableName), "STBLPAY-5004");
+        }
+      }
+
+      var appliedLimit = resolveLimit(query);
+      var sanitizedSql = rebuildWithLimit(sql.strip(), query, appliedLimit);
+
+      return new SqlValidationResult.Valid(sanitizedSql, appliedLimit);
     } catch (ParsingException e) {
       return new SqlValidationResult.Invalid("SQL parse error", "STBLPAY-5001");
     }
-
-    if (!(statement instanceof Query query)) {
-      return new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
-    }
-
-    if (query.getWith().isPresent()) {
-      var with = query.getWith().get();
-      if (isRecursive(with)) {
-        return new SqlValidationResult.Invalid("WITH RECURSIVE not allowed", "STBLPAY-5003");
-      }
-    }
-
-    var tableNames = new ArrayList<String>();
-    new DefaultTraversalVisitor<Void>() {
-      @Override
-      protected Void visitTable(Table node, Void context) {
-        tableNames.add(node.getName().toString());
-        return null;
-      }
-    }.process(statement, null);
-
-    for (var tableName : tableNames) {
-      if (!allowedTableRegistry.isAllowed(tableName)) {
-        return new SqlValidationResult.Invalid(
-            "Table %s not in allowlist".formatted(tableName), "STBLPAY-5004");
-      }
-    }
-
-    var appliedLimit = resolveLimit(query);
-    var sanitizedSql = rebuildWithLimit(sql.strip(), query, appliedLimit);
-
-    return new SqlValidationResult.Valid(sanitizedSql, appliedLimit);
   }
 
-  private boolean isRecursive(With with) {
-    return with.isRecursive();
+  private Set<String> collectCteNames(Query query) {
+    if (query.getWith().isEmpty()) {
+      return Set.of();
+    }
+    return query.getWith().get().getQueries().stream()
+        .map(cte -> cte.getName().getValue().toLowerCase(java.util.Locale.ROOT))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   private int resolveLimit(Query query) {
@@ -100,7 +107,7 @@ public class TrinoSqlAllowlistValidator {
 
   private String rebuildWithLimit(String originalSql, Query query, int appliedLimit) {
     if (hasLimit(query)) {
-      return replaceLimit(originalSql, appliedLimit);
+      return replaceLastLimit(originalSql, appliedLimit);
     }
     return originalSql + " LIMIT " + appliedLimit;
   }
@@ -112,7 +119,17 @@ public class TrinoSqlAllowlistValidator {
     return query.getQueryBody() instanceof QuerySpecification spec && spec.getLimit().isPresent();
   }
 
-  private String replaceLimit(String sql, int appliedLimit) {
-    return sql.replaceAll("(?i)\\bLIMIT\\s+\\d+", "LIMIT " + appliedLimit);
+  private String replaceLastLimit(String sql, int appliedLimit) {
+    var matcher = LIMIT_PATTERN.matcher(sql);
+    var lastStart = -1;
+    var lastEnd = -1;
+    while (matcher.find()) {
+      lastStart = matcher.start();
+      lastEnd = matcher.end();
+    }
+    if (lastStart == -1) {
+      return sql;
+    }
+    return sql.substring(0, lastStart) + "LIMIT " + appliedLimit + sql.substring(lastEnd);
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidator.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidator.java
@@ -1,0 +1,118 @@
+package io.stablepay.api.domain.agent;
+
+import io.trino.sql.parser.ParsingException;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.Limit;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.QuerySpecification;
+import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.With;
+import java.util.ArrayList;
+import java.util.OptionalLong;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TrinoSqlAllowlistValidator {
+
+  static final int DEFAULT_LIMIT = 1_000;
+  static final int MAX_LIMIT = 10_000;
+
+  private final AllowedTableRegistry allowedTableRegistry;
+  private final SqlParser sqlParser = new SqlParser();
+
+  public SqlValidationResult validate(String sql) {
+    if (sql == null || sql.isBlank()) {
+      return new SqlValidationResult.Invalid("SQL is empty", "STBLPAY-5001");
+    }
+
+    Statement statement;
+    try {
+      statement = sqlParser.createStatement(sql.strip());
+    } catch (ParsingException e) {
+      return new SqlValidationResult.Invalid("SQL parse error", "STBLPAY-5001");
+    }
+
+    if (!(statement instanceof Query query)) {
+      return new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
+    }
+
+    if (query.getWith().isPresent()) {
+      var with = query.getWith().get();
+      if (isRecursive(with)) {
+        return new SqlValidationResult.Invalid("WITH RECURSIVE not allowed", "STBLPAY-5003");
+      }
+    }
+
+    var tableNames = new ArrayList<String>();
+    new DefaultTraversalVisitor<Void>() {
+      @Override
+      protected Void visitTable(Table node, Void context) {
+        tableNames.add(node.getName().toString());
+        return null;
+      }
+    }.process(statement, null);
+
+    for (var tableName : tableNames) {
+      if (!allowedTableRegistry.isAllowed(tableName)) {
+        return new SqlValidationResult.Invalid(
+            "Table %s not in allowlist".formatted(tableName), "STBLPAY-5004");
+      }
+    }
+
+    var appliedLimit = resolveLimit(query);
+    var sanitizedSql = rebuildWithLimit(sql.strip(), query, appliedLimit);
+
+    return new SqlValidationResult.Valid(sanitizedSql, appliedLimit);
+  }
+
+  private boolean isRecursive(With with) {
+    return with.isRecursive();
+  }
+
+  private int resolveLimit(Query query) {
+    var existingLimit = extractLimit(query);
+    if (existingLimit.isEmpty()) {
+      return DEFAULT_LIMIT;
+    }
+    var userLimit = existingLimit.getAsLong();
+    return (int) Math.min(userLimit, MAX_LIMIT);
+  }
+
+  private OptionalLong extractLimit(Query query) {
+    if (query.getLimit().isPresent()
+        && query.getLimit().get() instanceof Limit queryLimit
+        && queryLimit.getRowCount() instanceof LongLiteral longLiteral) {
+      return OptionalLong.of(longLiteral.getParsedValue());
+    }
+    if (query.getQueryBody() instanceof QuerySpecification spec
+        && spec.getLimit().isPresent()
+        && spec.getLimit().get() instanceof Limit specLimit
+        && specLimit.getRowCount() instanceof LongLiteral longLiteral) {
+      return OptionalLong.of(longLiteral.getParsedValue());
+    }
+    return OptionalLong.empty();
+  }
+
+  private String rebuildWithLimit(String originalSql, Query query, int appliedLimit) {
+    if (hasLimit(query)) {
+      return replaceLimit(originalSql, appliedLimit);
+    }
+    return originalSql + " LIMIT " + appliedLimit;
+  }
+
+  private boolean hasLimit(Query query) {
+    if (query.getLimit().isPresent()) {
+      return true;
+    }
+    return query.getQueryBody() instanceof QuerySpecification spec && spec.getLimit().isPresent();
+  }
+
+  private String replaceLimit(String sql, int appliedLimit) {
+    return sql.replaceAll("(?i)\\bLIMIT\\s+\\d+", "LIMIT " + appliedLimit);
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/AllowedTableRegistryTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/AllowedTableRegistryTest.java
@@ -17,7 +17,9 @@ class AllowedTableRegistryTest {
         "iceberg.facts.fact_transactions",
         "iceberg.facts.fact_payments",
         "iceberg.agg.agg_daily_volume",
-        "iceberg.agg.agg_monthly_totals"
+        "iceberg.agg.agg_monthly_totals",
+        "ICEBERG.ANALYTICS.V_PAYMENT_SUMMARY",
+        "Iceberg.Facts.Fact_Transactions"
       })
   void shouldAllowValidTables(String table) {
     // when

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/AllowedTableRegistryTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/AllowedTableRegistryTest.java
@@ -1,0 +1,48 @@
+package io.stablepay.api.domain.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AllowedTableRegistryTest {
+
+  private final AllowedTableRegistry registry = new AllowedTableRegistry();
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "iceberg.analytics.v_payment_summary",
+        "iceberg.analytics.v_daily_report",
+        "iceberg.facts.fact_transactions",
+        "iceberg.facts.fact_payments",
+        "iceberg.agg.agg_daily_volume",
+        "iceberg.agg.agg_monthly_totals"
+      })
+  void shouldAllowValidTables(String table) {
+    // when
+    var result = registry.isAllowed(table);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "postgres.public.users",
+        "iceberg.dlq.dlq_events",
+        "iceberg.analytics.payments",
+        "iceberg.facts.transactions",
+        "iceberg.agg.volumes",
+        "iceberg.raw.fact_transactions",
+        "v_payment_summary"
+      })
+  void shouldRejectDisallowedTables(String table) {
+    // when
+    var result = registry.isAllowed(table);
+
+    // then
+    assertThat(result).isFalse();
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidatorTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidatorTest.java
@@ -3,9 +3,14 @@ package io.stablepay.api.domain.agent;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.DELETE_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.DLQ_TABLE_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.INSERT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.JOIN_MIXED_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.MISSING_LIMIT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.NON_RECURSIVE_CTE_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.OVERSIZED_LIMIT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.SUBQUERY_DISALLOWED_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.UNKNOWN_TABLE_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.UPDATE_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.UPPERCASE_TABLE_SQL;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_AGG_QUERY;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_FACT_QUERY;
 import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_VIEW_QUERY;
@@ -54,6 +59,26 @@ class TrinoSqlAllowlistValidatorTest {
       var expected =
           new SqlValidationResult.Valid(
               "SELECT transaction_id, amount FROM iceberg.facts.fact_transactions LIMIT 100", 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptNonRecursiveCte() {
+      // when
+      var result = validator.validate(NON_RECURSIVE_CTE_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Valid(NON_RECURSIVE_CTE_SQL + " LIMIT 1000", 1000);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptUppercaseTableNames() {
+      // when
+      var result = validator.validate(UPPERCASE_TABLE_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Valid(UPPERCASE_TABLE_SQL + " LIMIT 1000", 1000);
       assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
   }
@@ -112,6 +137,40 @@ class TrinoSqlAllowlistValidatorTest {
       var expected =
           new SqlValidationResult.Invalid(
               "Table iceberg.dlq.dlq_events not in allowlist", "STBLPAY-5004");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectUpdateStatement() {
+      // when
+      var result = validator.validate(UPDATE_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectDisallowedTableInSubquery() {
+      // when
+      var result = validator.validate(SUBQUERY_DISALLOWED_SQL);
+
+      // then
+      var expected =
+          new SqlValidationResult.Invalid(
+              "Table postgres.public.users not in allowlist", "STBLPAY-5004");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectDisallowedTableInJoin() {
+      // when
+      var result = validator.validate(JOIN_MIXED_SQL);
+
+      // then
+      var expected =
+          new SqlValidationResult.Invalid(
+              "Table postgres.public.users not in allowlist", "STBLPAY-5004");
       assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
   }

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidatorTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/TrinoSqlAllowlistValidatorTest.java
@@ -1,0 +1,178 @@
+package io.stablepay.api.domain.agent;
+
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.DELETE_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.DLQ_TABLE_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.INSERT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.MISSING_LIMIT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.OVERSIZED_LIMIT_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.UNKNOWN_TABLE_SQL;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_AGG_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_FACT_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.VALID_VIEW_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.SqlValidationFixtures.WITH_RECURSIVE_SQL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TrinoSqlAllowlistValidatorTest {
+
+  private final AllowedTableRegistry registry = new AllowedTableRegistry();
+  private final TrinoSqlAllowlistValidator validator = new TrinoSqlAllowlistValidator(registry);
+
+  @Nested
+  class ValidQueries {
+
+    @Test
+    void shouldAcceptValidViewQuery() {
+      // when
+      var result = validator.validate(VALID_VIEW_QUERY);
+
+      // then
+      var expected = new SqlValidationResult.Valid(VALID_VIEW_QUERY + " LIMIT 1000", 1000);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptValidAggQuery() {
+      // when
+      var result = validator.validate(VALID_AGG_QUERY);
+
+      // then
+      var expected =
+          new SqlValidationResult.Valid(
+              "SELECT currency, total FROM iceberg.agg.agg_daily_volume LIMIT 50", 50);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptValidFactQuery() {
+      // when
+      var result = validator.validate(VALID_FACT_QUERY);
+
+      // then
+      var expected =
+          new SqlValidationResult.Valid(
+              "SELECT transaction_id, amount FROM iceberg.facts.fact_transactions LIMIT 100", 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class RejectedStatements {
+
+    @Test
+    void shouldRejectInsertStatement() {
+      // when
+      var result = validator.validate(INSERT_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectDeleteStatement() {
+      // when
+      var result = validator.validate(DELETE_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Invalid("Only SELECT queries allowed", "STBLPAY-5002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectWithRecursive() {
+      // when
+      var result = validator.validate(WITH_RECURSIVE_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Invalid("WITH RECURSIVE not allowed", "STBLPAY-5003");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectUnknownTable() {
+      // when
+      var result = validator.validate(UNKNOWN_TABLE_SQL);
+
+      // then
+      var expected =
+          new SqlValidationResult.Invalid(
+              "Table postgres.public.users not in allowlist", "STBLPAY-5004");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectDlqTable() {
+      // when
+      var result = validator.validate(DLQ_TABLE_SQL);
+
+      // then
+      var expected =
+          new SqlValidationResult.Invalid(
+              "Table iceberg.dlq.dlq_events not in allowlist", "STBLPAY-5004");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class LimitHandling {
+
+    @Test
+    void shouldInjectDefaultLimitWhenMissing() {
+      // when
+      var result = validator.validate(MISSING_LIMIT_SQL);
+
+      // then
+      var expected = new SqlValidationResult.Valid(MISSING_LIMIT_SQL + " LIMIT 1000", 1000);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldCapOversizedLimit() {
+      // when
+      var result = validator.validate(OVERSIZED_LIMIT_SQL);
+
+      // then
+      var expected =
+          new SqlValidationResult.Valid(
+              "SELECT * FROM iceberg.analytics.v_payment_summary LIMIT 10000", 10000);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class EdgeCases {
+
+    @Test
+    void shouldRejectEmptyInput() {
+      // when
+      var result = validator.validate("");
+
+      // then
+      var expected = new SqlValidationResult.Invalid("SQL is empty", "STBLPAY-5001");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectNullInput() {
+      // when
+      var result = validator.validate(null);
+
+      // then
+      var expected = new SqlValidationResult.Invalid("SQL is empty", "STBLPAY-5001");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectMalformedSql() {
+      // when
+      var result = validator.validate("NOT VALID SQL AT ALL !!!");
+
+      // then
+      var expected = new SqlValidationResult.Invalid("SQL parse error", "STBLPAY-5001");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/SqlValidationFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/SqlValidationFixtures.java
@@ -29,5 +29,23 @@ public final class SqlValidationFixtures {
 
   public static final String DLQ_TABLE_SQL = "SELECT * FROM iceberg.dlq.dlq_events";
 
+  public static final String UPDATE_SQL =
+      "UPDATE iceberg.analytics.v_payment_summary SET currency = 'EUR'";
+
+  public static final String SUBQUERY_DISALLOWED_SQL =
+      "SELECT * FROM (SELECT * FROM postgres.public.users) t";
+
+  public static final String JOIN_MIXED_SQL =
+      "SELECT v.currency FROM iceberg.analytics.v_payment_summary v"
+          + " JOIN postgres.public.users u ON v.id = u.id";
+
+  public static final String NON_RECURSIVE_CTE_SQL =
+      "WITH summary AS (SELECT currency, count(*) AS cnt"
+          + " FROM iceberg.analytics.v_payment_summary GROUP BY currency)"
+          + " SELECT * FROM summary";
+
+  public static final String UPPERCASE_TABLE_SQL =
+      "SELECT * FROM ICEBERG.ANALYTICS.V_PAYMENT_SUMMARY";
+
   private SqlValidationFixtures() {}
 }

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/SqlValidationFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/SqlValidationFixtures.java
@@ -1,0 +1,33 @@
+package io.stablepay.api.domain.agent.fixtures;
+
+public final class SqlValidationFixtures {
+
+  public static final String VALID_VIEW_QUERY =
+      "SELECT * FROM iceberg.analytics.v_payment_summary WHERE currency = 'USD'";
+
+  public static final String VALID_AGG_QUERY =
+      "SELECT currency, total FROM iceberg.agg.agg_daily_volume LIMIT 50";
+
+  public static final String VALID_FACT_QUERY =
+      "SELECT transaction_id, amount FROM iceberg.facts.fact_transactions LIMIT 100";
+
+  public static final String INSERT_SQL =
+      "INSERT INTO iceberg.analytics.v_payment_summary (currency) VALUES ('USD')";
+
+  public static final String DELETE_SQL = "DELETE FROM iceberg.analytics.v_payment_summary";
+
+  public static final String WITH_RECURSIVE_SQL =
+      "WITH RECURSIVE cte AS (SELECT 1 UNION ALL SELECT 1) SELECT * FROM cte";
+
+  public static final String UNKNOWN_TABLE_SQL = "SELECT * FROM postgres.public.users";
+
+  public static final String MISSING_LIMIT_SQL =
+      "SELECT * FROM iceberg.analytics.v_payment_summary";
+
+  public static final String OVERSIZED_LIMIT_SQL =
+      "SELECT * FROM iceberg.analytics.v_payment_summary LIMIT 50000";
+
+  public static final String DLQ_TABLE_SQL = "SELECT * FROM iceberg.dlq.dlq_events";
+
+  private SqlValidationFixtures() {}
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "schedule": ["before 6am on Monday"],
+  "timezone": "Europe/Berlin",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "description": "Group all Spring Boot + Spring Cloud updates",
+      "matchPackagePrefixes": [
+        "org.springframework.boot",
+        "org.springframework.cloud",
+        "org.springframework.security",
+        "org.springframework:spring-",
+        "io.spring.dependency-management"
+      ],
+      "groupName": "Spring",
+      "automerge": false
+    },
+    {
+      "description": "Group all Flink dependencies",
+      "matchPackagePrefixes": ["org.apache.flink"],
+      "groupName": "Apache Flink"
+    },
+    {
+      "description": "Group all Testcontainers dependencies",
+      "matchPackagePrefixes": ["org.testcontainers"],
+      "groupName": "Testcontainers"
+    },
+    {
+      "description": "Group all JUnit 5 dependencies",
+      "matchPackagePrefixes": ["org.junit"],
+      "groupName": "JUnit 5"
+    },
+    {
+      "description": "Group all Mockito dependencies",
+      "matchPackagePrefixes": ["org.mockito"],
+      "groupName": "Mockito"
+    },
+    {
+      "description": "Group all MapStruct dependencies",
+      "matchPackagePrefixes": ["org.mapstruct"],
+      "groupName": "MapStruct"
+    },
+    {
+      "description": "Group all Flyway dependencies",
+      "matchPackagePrefixes": ["org.flywaydb"],
+      "groupName": "Flyway"
+    },
+    {
+      "description": "Group all Bucket4j dependencies",
+      "matchPackagePrefixes": ["com.bucket4j"],
+      "groupName": "Bucket4j"
+    },
+    {
+      "description": "Group Trino JDBC + parser (must stay in sync)",
+      "matchPackagePrefixes": ["io.trino"],
+      "groupName": "Trino"
+    },
+    {
+      "description": "Group Lombok + Lombok-MapStruct binding",
+      "matchPackagePrefixes": ["org.projectlombok"],
+      "groupName": "Lombok"
+    },
+    {
+      "description": "Group all Apache Iceberg dependencies",
+      "matchPackagePrefixes": ["org.apache.iceberg"],
+      "groupName": "Apache Iceberg"
+    },
+    {
+      "description": "Group Docker Compose infrastructure images",
+      "matchManagers": ["docker-compose"],
+      "groupName": "Docker infrastructure images",
+      "automerge": false
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge patch updates for test-only dependencies",
+      "matchDepTypes": ["testImplementation", "testFixturesApi", "devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Pin minio images to latest (no digest pinning)",
+      "matchPackageNames": ["minio/minio", "minio/mc"],
+      "versioning": "loose",
+      "pinDigests": false
+    }
+  ],
+  "gradle": {
+    "fileMatch": [
+      "(^|/)build\\.gradle\\.kts$",
+      "(^|/)settings\\.gradle\\.kts$",
+      "(^|/)gradle/libs\\.versions\\.toml$",
+      "(^|/)buildSrc/.*\\.gradle\\.kts$"
+    ]
+  },
+  "pip_requirements": {
+    "enabled": false
+  },
+  "pep621": {
+    "fileMatch": ["(^|/)pyproject\\.toml$"]
+  }
+}


### PR DESCRIPTION
## SPP Issue
Closes #102

## Changes
- Add sealed `SqlValidationResult` interface with `Valid(sanitizedSql, appliedLimit)` and `Invalid(reason, errorCode)` records in `domain/agent/`
- Add `AllowedTableRegistry` component that validates table FQN against `iceberg.analytics.v_*`, `iceberg.facts.fact_*`, `iceberg.agg.agg_*` regex patterns
- Add `TrinoSqlAllowlistValidator` component using `io.trino:trino-parser` AST walker that:
  - Rejects empty/null/unparseable SQL (`STBLPAY-5001`)
  - Rejects non-SELECT statements (`STBLPAY-5002`)
  - Rejects `WITH RECURSIVE` (`STBLPAY-5003`)
  - Rejects tables not in the allowlist (`STBLPAY-5004`)
  - Injects `LIMIT 1000` if missing; caps user-supplied limit at 10,000
- Move `trino-parser` from `testImplementation` to `implementation` in `build.gradle.kts`
- Add `SqlValidationFixtures` in `testFixtures/` with SQL constants for all test scenarios
- Add 26 unit tests (13 for `AllowedTableRegistryTest`, 13 for `TrinoSqlAllowlistValidatorTest`) covering all 9 acceptance criteria plus edge cases

## Checklist
- [x] `./gradlew :apps:api:main:test` passes (26 new tests, 0 failures)
- [x] Unit tests added (AllowedTableRegistryTest + TrinoSqlAllowlistValidatorTest)
- [x] Spotless formatting applied
- [x] All assertions use `usingRecursiveComparison()` per golden rule
- [x] Fixtures in `testFixtures/`, not private methods in test classes
- [x] Sealed interface uses Lombok `@Builder(toBuilder = true)` only — no Spring imports on domain records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SQL query validation to ensure queries only reference approved tables
  * Enforces automatic row limits on queries
  * Blocks unsafe query patterns, including non-SELECT statements and recursive operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->