### PR TITLE
SPP-97: add OpenSearch DSL whitelist validator with typed query shapes

### DIFF
--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AgentSearchRequest.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AgentSearchRequest.java
@@ -19,5 +19,7 @@ public record AgentSearchRequest(
     Objects.requireNonNull(aggs);
     Objects.requireNonNull(size);
     Objects.requireNonNull(sort);
+    aggs = aggs.map(List::copyOf);
+    sort = sort.map(List::copyOf);
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AgentSearchRequest.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AgentSearchRequest.java
@@ -1,0 +1,23 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record AgentSearchRequest(
+    String index,
+    QueryShape query,
+    Optional<List<AggShape>> aggs,
+    Optional<Integer> size,
+    Optional<List<String>> sort) {
+
+  public AgentSearchRequest {
+    Objects.requireNonNull(index);
+    Objects.requireNonNull(query);
+    Objects.requireNonNull(aggs);
+    Objects.requireNonNull(size);
+    Objects.requireNonNull(sort);
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
@@ -14,6 +14,9 @@ public sealed interface AggShape
     public TermsAggShape {
       Objects.requireNonNull(name);
       Objects.requireNonNull(field);
+      if (size <= 0) {
+        throw new IllegalArgumentException("TermsAggShape size must be positive");
+      }
     }
   }
 

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
@@ -1,0 +1,45 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.Objects;
+import lombok.Builder;
+
+public sealed interface AggShape
+    permits AggShape.TermsAggShape,
+        AggShape.DateHistogramAggShape,
+        AggShape.SumAggShape,
+        AggShape.AvgAggShape {
+
+  @Builder(toBuilder = true)
+  record TermsAggShape(String name, String field, int size) implements AggShape {
+    public TermsAggShape {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(field);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record DateHistogramAggShape(String name, String field, String calendarInterval)
+      implements AggShape {
+    public DateHistogramAggShape {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(field);
+      Objects.requireNonNull(calendarInterval);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record SumAggShape(String name, String field) implements AggShape {
+    public SumAggShape {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(field);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record AvgAggShape(String name, String field) implements AggShape {
+    public AvgAggShape {
+      Objects.requireNonNull(name);
+      Objects.requireNonNull(field);
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedQueryShapeRegistry.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedQueryShapeRegistry.java
@@ -1,5 +1,6 @@
 package io.stablepay.api.domain.agent;
 
+import java.util.Locale;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -7,6 +8,9 @@ import org.springframework.stereotype.Component;
 public class AllowedQueryShapeRegistry {
 
   private static final Set<String> ALLOWED_INDICES = Set.of("transactions", "dlq-events");
+
+  private static final Set<String> ALLOWED_CALENDAR_INTERVALS =
+      Set.of("minute", "hour", "day", "week", "month", "quarter", "year");
 
   private static final Set<String> ALLOWED_FIELDS =
       Set.of(
@@ -35,5 +39,9 @@ public class AllowedQueryShapeRegistry {
 
   public boolean isFieldAllowed(String field) {
     return ALLOWED_FIELDS.contains(field);
+  }
+
+  public boolean isCalendarIntervalAllowed(String interval) {
+    return ALLOWED_CALENDAR_INTERVALS.contains(interval.toLowerCase(Locale.ROOT));
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedQueryShapeRegistry.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AllowedQueryShapeRegistry.java
@@ -1,0 +1,39 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AllowedQueryShapeRegistry {
+
+  private static final Set<String> ALLOWED_INDICES = Set.of("transactions", "dlq-events");
+
+  private static final Set<String> ALLOWED_FIELDS =
+      Set.of(
+          "event_id",
+          "customer_id",
+          "account_id",
+          "event_time",
+          "ingest_time",
+          "internal_status",
+          "customer_status",
+          "flow_type",
+          "flow_id",
+          "currency_code",
+          "amount_micros",
+          "error_class",
+          "source_topic",
+          "source_partition",
+          "source_offset",
+          "failed_at",
+          "retry_count",
+          "sink_type");
+
+  public boolean isIndexAllowed(String index) {
+    return ALLOWED_INDICES.contains(index);
+  }
+
+  public boolean isFieldAllowed(String field) {
+    return ALLOWED_FIELDS.contains(field);
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/DslValidationResult.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/DslValidationResult.java
@@ -1,20 +1,16 @@
 package io.stablepay.api.domain.agent;
 
-import java.util.Map;
 import java.util.Objects;
 import lombok.Builder;
-import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
 
 public sealed interface DslValidationResult
     permits DslValidationResult.Valid, DslValidationResult.Invalid {
 
   @Builder(toBuilder = true)
-  record Valid(Query translatedQuery, Map<String, Aggregation> translatedAggs, int size)
+  record Valid(AgentSearchRequest validatedRequest, int resolvedSize)
       implements DslValidationResult {
     public Valid {
-      Objects.requireNonNull(translatedQuery);
-      Objects.requireNonNull(translatedAggs);
+      Objects.requireNonNull(validatedRequest);
     }
   }
 

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/DslValidationResult.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/DslValidationResult.java
@@ -1,0 +1,28 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.Map;
+import java.util.Objects;
+import lombok.Builder;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public sealed interface DslValidationResult
+    permits DslValidationResult.Valid, DslValidationResult.Invalid {
+
+  @Builder(toBuilder = true)
+  record Valid(Query translatedQuery, Map<String, Aggregation> translatedAggs, int size)
+      implements DslValidationResult {
+    public Valid {
+      Objects.requireNonNull(translatedQuery);
+      Objects.requireNonNull(translatedAggs);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record Invalid(String reason, String errorCode) implements DslValidationResult {
+    public Invalid {
+      Objects.requireNonNull(reason);
+      Objects.requireNonNull(errorCode);
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidator.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidator.java
@@ -1,15 +1,9 @@
 package io.stablepay.api.domain.agent;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.opensearch.client.opensearch._types.FieldValue;
-import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
-import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,35 +22,25 @@ public class OpenSearchDslWhitelistValidator {
     }
 
     var fieldResult = validateFields(request.query());
-    if (fieldResult != null) {
-      return fieldResult;
+    if (fieldResult.isPresent()) {
+      return fieldResult.get();
     }
 
-    if (request.sort().isPresent()) {
-      for (var sortField : request.sort().get()) {
-        if (!registry.isFieldAllowed(sortField)) {
-          return new DslValidationResult.Invalid(
-              "Sort field not in allowlist: %s".formatted(sortField), "STBLPAY-6005");
-        }
-      }
+    var sortResult = validateSortFields(request.sort());
+    if (sortResult.isPresent()) {
+      return sortResult.get();
     }
 
-    Map<String, Aggregation> translatedAggs = Map.of();
-    if (request.aggs().isPresent()) {
-      var aggResult = validateAndTranslateAggs(request.aggs().get());
-      if (aggResult instanceof AggTranslation.InvalidAgg invalid) {
-        return new DslValidationResult.Invalid(invalid.reason(), invalid.errorCode());
-      }
-      translatedAggs = ((AggTranslation.ValidAgg) aggResult).aggs();
+    var aggResult = validateAggs(request.aggs());
+    if (aggResult.isPresent()) {
+      return aggResult.get();
     }
 
-    var translatedQuery = translateQuery(request.query());
-    var size = resolveSize(request.size());
-
-    return new DslValidationResult.Valid(translatedQuery, translatedAggs, size);
+    var resolvedSize = resolveSize(request.size());
+    return new DslValidationResult.Valid(request, resolvedSize);
   }
 
-  private DslValidationResult.Invalid validateFields(QueryShape shape) {
+  private Optional<DslValidationResult.Invalid> validateFields(QueryShape shape) {
     return switch (shape) {
       case QueryShape.TermShape term -> validateField(term.field());
       case QueryShape.RangeShape range -> validateField(range.field());
@@ -67,117 +51,50 @@ public class OpenSearchDslWhitelistValidator {
     };
   }
 
-  private DslValidationResult.Invalid validateBoolFields(QueryShape.BoolShape bool) {
-    for (var clause : bool.must()) {
-      var result = validateFields(clause);
-      if (result != null) {
-        return result;
-      }
-    }
-    for (var clause : bool.filter()) {
-      var result = validateFields(clause);
-      if (result != null) {
-        return result;
-      }
-    }
-    for (var clause : bool.mustNot()) {
-      var result = validateFields(clause);
-      if (result != null) {
-        return result;
-      }
-    }
-    return null;
+  private Optional<DslValidationResult.Invalid> validateBoolFields(QueryShape.BoolShape bool) {
+    return Stream.of(bool.must(), bool.filter(), bool.mustNot())
+        .flatMap(List::stream)
+        .map(this::validateFields)
+        .flatMap(Optional::stream)
+        .findFirst();
   }
 
-  private DslValidationResult.Invalid validateField(String field) {
+  private Optional<DslValidationResult.Invalid> validateField(String field) {
     if (!registry.isFieldAllowed(field)) {
-      return new DslValidationResult.Invalid(
-          "Field not in allowlist: %s".formatted(field), "STBLPAY-6002");
+      return Optional.of(
+          new DslValidationResult.Invalid(
+              "Field not in allowlist: %s".formatted(field), "STBLPAY-6002"));
     }
-    return null;
+    return Optional.empty();
   }
 
-  private Query translateQuery(QueryShape shape) {
-    return switch (shape) {
-      case QueryShape.TermShape term -> translateTerm(term);
-      case QueryShape.RangeShape range -> translateRange(range);
-      case QueryShape.MatchPhraseShape matchPhrase -> translateMatchPhrase(matchPhrase);
-      case QueryShape.ExistsShape exists -> translateExists(exists);
-      case QueryShape.TermsShape terms -> translateTerms(terms);
-      case QueryShape.BoolShape bool -> translateBool(bool);
-    };
+  private Optional<DslValidationResult.Invalid> validateSortFields(Optional<List<String>> sort) {
+    return sort.stream()
+        .flatMap(List::stream)
+        .filter(field -> !registry.isFieldAllowed(field))
+        .findFirst()
+        .map(
+            field ->
+                new DslValidationResult.Invalid(
+                    "Sort field not in allowlist: %s".formatted(field), "STBLPAY-6005"));
   }
 
-  private Query translateTerm(QueryShape.TermShape term) {
-    return new Query.Builder()
-        .term(t -> t.field(term.field()).value(FieldValue.of(term.value().toString())))
-        .build();
-  }
-
-  private Query translateRange(QueryShape.RangeShape range) {
-    return new Query.Builder()
-        .range(
-            r -> {
-              var builder = r.field(range.field());
-              range.gte().ifPresent(v -> builder.gte(toFieldValueJson(v)));
-              range.lte().ifPresent(v -> builder.lte(toFieldValueJson(v)));
-              return builder;
-            })
-        .build();
-  }
-
-  private Query translateMatchPhrase(QueryShape.MatchPhraseShape matchPhrase) {
-    return new Query.Builder()
-        .matchPhrase(mp -> mp.field(matchPhrase.field()).query(matchPhrase.phrase()))
-        .build();
-  }
-
-  private Query translateExists(QueryShape.ExistsShape exists) {
-    return new Query.Builder().exists(e -> e.field(exists.field())).build();
-  }
-
-  private Query translateTerms(QueryShape.TermsShape terms) {
-    var fieldValues = terms.values().stream().map(v -> FieldValue.of(v.toString())).toList();
-    return new Query.Builder()
-        .terms(t -> t.field(terms.field()).terms(tv -> tv.value(fieldValues)))
-        .build();
-  }
-
-  private Query translateBool(QueryShape.BoolShape bool) {
-    var builder = new BoolQuery.Builder();
-    for (var clause : bool.must()) {
-      builder.must(translateQuery(clause));
+  private Optional<DslValidationResult.Invalid> validateAggs(Optional<List<AggShape>> aggs) {
+    if (aggs.isEmpty()) {
+      return Optional.empty();
     }
-    for (var clause : bool.filter()) {
-      builder.filter(translateQuery(clause));
-    }
-    for (var clause : bool.mustNot()) {
-      builder.mustNot(translateQuery(clause));
-    }
-    return new Query.Builder().bool(builder.build()).build();
+    return aggs.get().stream().map(this::validateAgg).flatMap(Optional::stream).findFirst();
   }
 
-  private sealed interface AggTranslation
-      permits AggTranslation.ValidAgg, AggTranslation.InvalidAgg {
-    record ValidAgg(Map<String, Aggregation> aggs) implements AggTranslation {}
-
-    record InvalidAgg(String reason, String errorCode) implements AggTranslation {}
-  }
-
-  private AggTranslation validateAndTranslateAggs(List<AggShape> aggs) {
-    var result = new HashMap<String, Aggregation>();
-    for (var agg : aggs) {
-      var fieldCheck = validateAggField(agg);
-      if (fieldCheck != null) {
-        return new AggTranslation.InvalidAgg(fieldCheck.reason(), fieldCheck.errorCode());
-      }
-      var translated = translateAgg(agg);
-      result.put(aggName(agg), translated);
+  private Optional<DslValidationResult.Invalid> validateAgg(AggShape agg) {
+    var fieldResult = validateAggField(agg);
+    if (fieldResult.isPresent()) {
+      return fieldResult;
     }
-    return new AggTranslation.ValidAgg(Map.copyOf(result));
+    return validateAggProperties(agg);
   }
 
-  private DslValidationResult.Invalid validateAggField(AggShape agg) {
+  private Optional<DslValidationResult.Invalid> validateAggField(AggShape agg) {
     var field =
         switch (agg) {
           case AggShape.TermsAggShape a -> a.field();
@@ -188,43 +105,22 @@ public class OpenSearchDslWhitelistValidator {
     return validateField(field);
   }
 
-  private String aggName(AggShape agg) {
+  private Optional<DslValidationResult.Invalid> validateAggProperties(AggShape agg) {
     return switch (agg) {
-      case AggShape.TermsAggShape a -> a.name();
-      case AggShape.DateHistogramAggShape a -> a.name();
-      case AggShape.SumAggShape a -> a.name();
-      case AggShape.AvgAggShape a -> a.name();
+      case AggShape.DateHistogramAggShape a -> {
+        if (!registry.isCalendarIntervalAllowed(a.calendarInterval())) {
+          yield Optional.of(
+              new DslValidationResult.Invalid(
+                  "Calendar interval not allowed: %s".formatted(a.calendarInterval()),
+                  "STBLPAY-6003"));
+        }
+        yield Optional.empty();
+      }
+      default -> Optional.empty();
     };
   }
 
-  private Aggregation translateAgg(AggShape agg) {
-    return switch (agg) {
-      case AggShape.TermsAggShape a ->
-          new Aggregation.Builder().terms(t -> t.field(a.field()).size(a.size())).build();
-      case AggShape.DateHistogramAggShape a ->
-          new Aggregation.Builder()
-              .dateHistogram(
-                  dh ->
-                      dh.field(a.field())
-                          .calendarInterval(toCalendarInterval(a.calendarInterval())))
-              .build();
-      case AggShape.SumAggShape a -> new Aggregation.Builder().sum(s -> s.field(a.field())).build();
-      case AggShape.AvgAggShape a ->
-          new Aggregation.Builder().avg(av -> av.field(a.field())).build();
-    };
-  }
-
-  private int resolveSize(java.util.Optional<Integer> requestedSize) {
-    return requestedSize.map(s -> Math.min(s, MAX_SIZE)).orElse(DEFAULT_SIZE);
-  }
-
-  private static CalendarInterval toCalendarInterval(String interval) {
-    return CalendarInterval.valueOf(
-        interval.substring(0, 1).toUpperCase(Locale.ROOT)
-            + interval.substring(1).toLowerCase(Locale.ROOT));
-  }
-
-  private org.opensearch.client.json.JsonData toFieldValueJson(Object value) {
-    return org.opensearch.client.json.JsonData.of(value);
+  private int resolveSize(Optional<Integer> requestedSize) {
+    return requestedSize.map(s -> Math.max(1, Math.min(s, MAX_SIZE))).orElse(DEFAULT_SIZE);
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidator.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidator.java
@@ -1,0 +1,230 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OpenSearchDslWhitelistValidator {
+
+  static final int DEFAULT_SIZE = 100;
+  static final int MAX_SIZE = 1_000;
+
+  private final AllowedQueryShapeRegistry registry;
+
+  public DslValidationResult validate(AgentSearchRequest request) {
+    if (!registry.isIndexAllowed(request.index())) {
+      return new DslValidationResult.Invalid(
+          "Index not in allowlist: %s".formatted(request.index()), "STBLPAY-6001");
+    }
+
+    var fieldResult = validateFields(request.query());
+    if (fieldResult != null) {
+      return fieldResult;
+    }
+
+    if (request.sort().isPresent()) {
+      for (var sortField : request.sort().get()) {
+        if (!registry.isFieldAllowed(sortField)) {
+          return new DslValidationResult.Invalid(
+              "Sort field not in allowlist: %s".formatted(sortField), "STBLPAY-6005");
+        }
+      }
+    }
+
+    Map<String, Aggregation> translatedAggs = Map.of();
+    if (request.aggs().isPresent()) {
+      var aggResult = validateAndTranslateAggs(request.aggs().get());
+      if (aggResult instanceof AggTranslation.InvalidAgg invalid) {
+        return new DslValidationResult.Invalid(invalid.reason(), invalid.errorCode());
+      }
+      translatedAggs = ((AggTranslation.ValidAgg) aggResult).aggs();
+    }
+
+    var translatedQuery = translateQuery(request.query());
+    var size = resolveSize(request.size());
+
+    return new DslValidationResult.Valid(translatedQuery, translatedAggs, size);
+  }
+
+  private DslValidationResult.Invalid validateFields(QueryShape shape) {
+    return switch (shape) {
+      case QueryShape.TermShape term -> validateField(term.field());
+      case QueryShape.RangeShape range -> validateField(range.field());
+      case QueryShape.MatchPhraseShape matchPhrase -> validateField(matchPhrase.field());
+      case QueryShape.ExistsShape exists -> validateField(exists.field());
+      case QueryShape.TermsShape terms -> validateField(terms.field());
+      case QueryShape.BoolShape bool -> validateBoolFields(bool);
+    };
+  }
+
+  private DslValidationResult.Invalid validateBoolFields(QueryShape.BoolShape bool) {
+    for (var clause : bool.must()) {
+      var result = validateFields(clause);
+      if (result != null) {
+        return result;
+      }
+    }
+    for (var clause : bool.filter()) {
+      var result = validateFields(clause);
+      if (result != null) {
+        return result;
+      }
+    }
+    for (var clause : bool.mustNot()) {
+      var result = validateFields(clause);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  private DslValidationResult.Invalid validateField(String field) {
+    if (!registry.isFieldAllowed(field)) {
+      return new DslValidationResult.Invalid(
+          "Field not in allowlist: %s".formatted(field), "STBLPAY-6002");
+    }
+    return null;
+  }
+
+  private Query translateQuery(QueryShape shape) {
+    return switch (shape) {
+      case QueryShape.TermShape term -> translateTerm(term);
+      case QueryShape.RangeShape range -> translateRange(range);
+      case QueryShape.MatchPhraseShape matchPhrase -> translateMatchPhrase(matchPhrase);
+      case QueryShape.ExistsShape exists -> translateExists(exists);
+      case QueryShape.TermsShape terms -> translateTerms(terms);
+      case QueryShape.BoolShape bool -> translateBool(bool);
+    };
+  }
+
+  private Query translateTerm(QueryShape.TermShape term) {
+    return new Query.Builder()
+        .term(t -> t.field(term.field()).value(FieldValue.of(term.value().toString())))
+        .build();
+  }
+
+  private Query translateRange(QueryShape.RangeShape range) {
+    return new Query.Builder()
+        .range(
+            r -> {
+              var builder = r.field(range.field());
+              range.gte().ifPresent(v -> builder.gte(toFieldValueJson(v)));
+              range.lte().ifPresent(v -> builder.lte(toFieldValueJson(v)));
+              return builder;
+            })
+        .build();
+  }
+
+  private Query translateMatchPhrase(QueryShape.MatchPhraseShape matchPhrase) {
+    return new Query.Builder()
+        .matchPhrase(mp -> mp.field(matchPhrase.field()).query(matchPhrase.phrase()))
+        .build();
+  }
+
+  private Query translateExists(QueryShape.ExistsShape exists) {
+    return new Query.Builder().exists(e -> e.field(exists.field())).build();
+  }
+
+  private Query translateTerms(QueryShape.TermsShape terms) {
+    var fieldValues = terms.values().stream().map(v -> FieldValue.of(v.toString())).toList();
+    return new Query.Builder()
+        .terms(t -> t.field(terms.field()).terms(tv -> tv.value(fieldValues)))
+        .build();
+  }
+
+  private Query translateBool(QueryShape.BoolShape bool) {
+    var builder = new BoolQuery.Builder();
+    for (var clause : bool.must()) {
+      builder.must(translateQuery(clause));
+    }
+    for (var clause : bool.filter()) {
+      builder.filter(translateQuery(clause));
+    }
+    for (var clause : bool.mustNot()) {
+      builder.mustNot(translateQuery(clause));
+    }
+    return new Query.Builder().bool(builder.build()).build();
+  }
+
+  private sealed interface AggTranslation
+      permits AggTranslation.ValidAgg, AggTranslation.InvalidAgg {
+    record ValidAgg(Map<String, Aggregation> aggs) implements AggTranslation {}
+
+    record InvalidAgg(String reason, String errorCode) implements AggTranslation {}
+  }
+
+  private AggTranslation validateAndTranslateAggs(List<AggShape> aggs) {
+    var result = new HashMap<String, Aggregation>();
+    for (var agg : aggs) {
+      var fieldCheck = validateAggField(agg);
+      if (fieldCheck != null) {
+        return new AggTranslation.InvalidAgg(fieldCheck.reason(), fieldCheck.errorCode());
+      }
+      var translated = translateAgg(agg);
+      result.put(aggName(agg), translated);
+    }
+    return new AggTranslation.ValidAgg(Map.copyOf(result));
+  }
+
+  private DslValidationResult.Invalid validateAggField(AggShape agg) {
+    var field =
+        switch (agg) {
+          case AggShape.TermsAggShape a -> a.field();
+          case AggShape.DateHistogramAggShape a -> a.field();
+          case AggShape.SumAggShape a -> a.field();
+          case AggShape.AvgAggShape a -> a.field();
+        };
+    return validateField(field);
+  }
+
+  private String aggName(AggShape agg) {
+    return switch (agg) {
+      case AggShape.TermsAggShape a -> a.name();
+      case AggShape.DateHistogramAggShape a -> a.name();
+      case AggShape.SumAggShape a -> a.name();
+      case AggShape.AvgAggShape a -> a.name();
+    };
+  }
+
+  private Aggregation translateAgg(AggShape agg) {
+    return switch (agg) {
+      case AggShape.TermsAggShape a ->
+          new Aggregation.Builder().terms(t -> t.field(a.field()).size(a.size())).build();
+      case AggShape.DateHistogramAggShape a ->
+          new Aggregation.Builder()
+              .dateHistogram(
+                  dh ->
+                      dh.field(a.field())
+                          .calendarInterval(toCalendarInterval(a.calendarInterval())))
+              .build();
+      case AggShape.SumAggShape a -> new Aggregation.Builder().sum(s -> s.field(a.field())).build();
+      case AggShape.AvgAggShape a ->
+          new Aggregation.Builder().avg(av -> av.field(a.field())).build();
+    };
+  }
+
+  private int resolveSize(java.util.Optional<Integer> requestedSize) {
+    return requestedSize.map(s -> Math.min(s, MAX_SIZE)).orElse(DEFAULT_SIZE);
+  }
+
+  private static CalendarInterval toCalendarInterval(String interval) {
+    return CalendarInterval.valueOf(
+        interval.substring(0, 1).toUpperCase(Locale.ROOT)
+            + interval.substring(1).toLowerCase(Locale.ROOT));
+  }
+
+  private org.opensearch.client.json.JsonData toFieldValueJson(Object value) {
+    return org.opensearch.client.json.JsonData.of(value);
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
@@ -46,6 +46,9 @@ public sealed interface QueryShape
       Objects.requireNonNull(must);
       Objects.requireNonNull(filter);
       Objects.requireNonNull(mustNot);
+      must = List.copyOf(must);
+      filter = List.copyOf(filter);
+      mustNot = List.copyOf(mustNot);
     }
   }
 
@@ -61,6 +64,7 @@ public sealed interface QueryShape
     public TermsShape {
       Objects.requireNonNull(field);
       Objects.requireNonNull(values);
+      values = List.copyOf(values);
     }
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
@@ -1,0 +1,66 @@
+package io.stablepay.api.domain.agent;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Builder;
+
+public sealed interface QueryShape
+    permits QueryShape.TermShape,
+        QueryShape.RangeShape,
+        QueryShape.MatchPhraseShape,
+        QueryShape.BoolShape,
+        QueryShape.ExistsShape,
+        QueryShape.TermsShape {
+
+  @Builder(toBuilder = true)
+  record TermShape(String field, Object value) implements QueryShape {
+    public TermShape {
+      Objects.requireNonNull(field);
+      Objects.requireNonNull(value);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record RangeShape(String field, Optional<Object> gte, Optional<Object> lte)
+      implements QueryShape {
+    public RangeShape {
+      Objects.requireNonNull(field);
+      Objects.requireNonNull(gte);
+      Objects.requireNonNull(lte);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record MatchPhraseShape(String field, String phrase) implements QueryShape {
+    public MatchPhraseShape {
+      Objects.requireNonNull(field);
+      Objects.requireNonNull(phrase);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record BoolShape(List<QueryShape> must, List<QueryShape> filter, List<QueryShape> mustNot)
+      implements QueryShape {
+    public BoolShape {
+      Objects.requireNonNull(must);
+      Objects.requireNonNull(filter);
+      Objects.requireNonNull(mustNot);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record ExistsShape(String field) implements QueryShape {
+    public ExistsShape {
+      Objects.requireNonNull(field);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  record TermsShape(String field, List<Object> values) implements QueryShape {
+    public TermsShape {
+      Objects.requireNonNull(field);
+      Objects.requireNonNull(values);
+    }
+  }
+}

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/opensearch/OpenSearchQueryTranslator.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/opensearch/OpenSearchQueryTranslator.java
@@ -1,0 +1,123 @@
+package io.stablepay.api.infrastructure.opensearch;
+
+import io.stablepay.api.domain.agent.AggShape;
+import io.stablepay.api.domain.agent.QueryShape;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenSearchQueryTranslator {
+
+  public Query translateQuery(QueryShape shape) {
+    return switch (shape) {
+      case QueryShape.TermShape term -> translateTerm(term);
+      case QueryShape.RangeShape range -> translateRange(range);
+      case QueryShape.MatchPhraseShape matchPhrase -> translateMatchPhrase(matchPhrase);
+      case QueryShape.ExistsShape exists -> translateExists(exists);
+      case QueryShape.TermsShape terms -> translateTerms(terms);
+      case QueryShape.BoolShape bool -> translateBool(bool);
+    };
+  }
+
+  public Map<String, Aggregation> translateAggs(List<AggShape> aggs) {
+    var result = new HashMap<String, Aggregation>();
+    for (var agg : aggs) {
+      result.put(aggName(agg), translateAgg(agg));
+    }
+    return Map.copyOf(result);
+  }
+
+  private Query translateTerm(QueryShape.TermShape term) {
+    return new Query.Builder()
+        .term(t -> t.field(term.field()).value(FieldValue.of(term.value().toString())))
+        .build();
+  }
+
+  private Query translateRange(QueryShape.RangeShape range) {
+    return new Query.Builder()
+        .range(
+            r -> {
+              var builder = r.field(range.field());
+              range.gte().ifPresent(v -> builder.gte(toJsonData(v)));
+              range.lte().ifPresent(v -> builder.lte(toJsonData(v)));
+              return builder;
+            })
+        .build();
+  }
+
+  private Query translateMatchPhrase(QueryShape.MatchPhraseShape matchPhrase) {
+    return new Query.Builder()
+        .matchPhrase(mp -> mp.field(matchPhrase.field()).query(matchPhrase.phrase()))
+        .build();
+  }
+
+  private Query translateExists(QueryShape.ExistsShape exists) {
+    return new Query.Builder().exists(e -> e.field(exists.field())).build();
+  }
+
+  private Query translateTerms(QueryShape.TermsShape terms) {
+    var fieldValues = terms.values().stream().map(v -> FieldValue.of(v.toString())).toList();
+    return new Query.Builder()
+        .terms(t -> t.field(terms.field()).terms(tv -> tv.value(fieldValues)))
+        .build();
+  }
+
+  private Query translateBool(QueryShape.BoolShape bool) {
+    var builder = new BoolQuery.Builder();
+    for (var clause : bool.must()) {
+      builder.must(translateQuery(clause));
+    }
+    for (var clause : bool.filter()) {
+      builder.filter(translateQuery(clause));
+    }
+    for (var clause : bool.mustNot()) {
+      builder.mustNot(translateQuery(clause));
+    }
+    return new Query.Builder().bool(builder.build()).build();
+  }
+
+  private Aggregation translateAgg(AggShape agg) {
+    return switch (agg) {
+      case AggShape.TermsAggShape a ->
+          new Aggregation.Builder().terms(t -> t.field(a.field()).size(a.size())).build();
+      case AggShape.DateHistogramAggShape a ->
+          new Aggregation.Builder()
+              .dateHistogram(
+                  dh ->
+                      dh.field(a.field())
+                          .calendarInterval(toCalendarInterval(a.calendarInterval())))
+              .build();
+      case AggShape.SumAggShape a -> new Aggregation.Builder().sum(s -> s.field(a.field())).build();
+      case AggShape.AvgAggShape a ->
+          new Aggregation.Builder().avg(av -> av.field(a.field())).build();
+    };
+  }
+
+  private static String aggName(AggShape agg) {
+    return switch (agg) {
+      case AggShape.TermsAggShape a -> a.name();
+      case AggShape.DateHistogramAggShape a -> a.name();
+      case AggShape.SumAggShape a -> a.name();
+      case AggShape.AvgAggShape a -> a.name();
+    };
+  }
+
+  private static CalendarInterval toCalendarInterval(String interval) {
+    return CalendarInterval.valueOf(
+        interval.substring(0, 1).toUpperCase(Locale.ROOT)
+            + interval.substring(1).toLowerCase(Locale.ROOT));
+  }
+
+  private static JsonData toJsonData(Object value) {
+    return JsonData.of(value);
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidatorTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidatorTest.java
@@ -1,13 +1,21 @@
 package io.stablepay.api.domain.agent;
 
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidAggFieldRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidCalendarIntervalRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidFieldRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidIndexRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidSortFieldRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.negativeSizeRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.oversizedRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validAggsRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validAllAggTypesRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validBoolTermRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validBoolWithMustNotRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validExistsRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validMatchPhraseRequest;
 import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validRangeRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validTermsRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.zeroSizeRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Nested;
@@ -24,28 +32,80 @@ class OpenSearchDslWhitelistValidatorTest {
 
     @Test
     void shouldAcceptValidBoolWithTermQuery() {
+      // given
+      var request = validBoolTermRequest();
+
       // when
-      var result = validator.validate(validBoolTermRequest());
+      var result = validator.validate(request);
 
       // then
-      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
-      var valid = (DslValidationResult.Valid) result;
-      assertThat(valid.size()).isEqualTo(50);
-      assertThat(valid.translatedQuery()).isNotNull();
-      assertThat(valid.translatedQuery().isBool()).isTrue();
+      var expected = new DslValidationResult.Valid(request, 50);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
     void shouldAcceptValidRangeQuery() {
+      // given
+      var request = validRangeRequest();
+
       // when
-      var result = validator.validate(validRangeRequest());
+      var result = validator.validate(request);
 
       // then
-      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
-      var valid = (DslValidationResult.Valid) result;
-      assertThat(valid.size()).isEqualTo(100);
-      assertThat(valid.translatedQuery()).isNotNull();
-      assertThat(valid.translatedQuery().isRange()).isTrue();
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptValidMatchPhraseQuery() {
+      // given
+      var request = validMatchPhraseRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptValidExistsQuery() {
+      // given
+      var request = validExistsRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptValidTermsQuery() {
+      // given
+      var request = validTermsRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptBoolWithMustNotClauses() {
+      // given
+      var request = validBoolWithMustNotRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
   }
 
@@ -92,13 +152,41 @@ class OpenSearchDslWhitelistValidatorTest {
 
     @Test
     void shouldCapSizeAbove1000To1000() {
+      // given
+      var request = oversizedRequest();
+
       // when
-      var result = validator.validate(oversizedRequest());
+      var result = validator.validate(request);
 
       // then
-      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
-      var valid = (DslValidationResult.Valid) result;
-      assertThat(valid.size()).isEqualTo(1000);
+      var expected = new DslValidationResult.Valid(request, 1000);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldClampNegativeSizeTo1() {
+      // given
+      var request = negativeSizeRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 1);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldClampZeroSizeTo1() {
+      // given
+      var request = zeroSizeRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 1);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
   }
 
@@ -107,13 +195,28 @@ class OpenSearchDslWhitelistValidatorTest {
 
     @Test
     void shouldAcceptValidAggregations() {
+      // given
+      var request = validAggsRequest();
+
       // when
-      var result = validator.validate(validAggsRequest());
+      var result = validator.validate(request);
 
       // then
-      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
-      var valid = (DslValidationResult.Valid) result;
-      assertThat(valid.translatedAggs()).containsKeys("by_status", "total_amount");
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldAcceptAllAggregationTypes() {
+      // given
+      var request = validAllAggTypesRequest();
+
+      // when
+      var result = validator.validate(request);
+
+      // then
+      var expected = new DslValidationResult.Valid(request, 100);
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
@@ -124,6 +227,18 @@ class OpenSearchDslWhitelistValidatorTest {
       // then
       var expected =
           new DslValidationResult.Invalid("Field not in allowlist: password_hash", "STBLPAY-6002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectInvalidCalendarInterval() {
+      // when
+      var result = validator.validate(invalidCalendarIntervalRequest());
+
+      // then
+      var expected =
+          new DslValidationResult.Invalid(
+              "Calendar interval not allowed: fortnight", "STBLPAY-6003");
       assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
   }

--- a/apps/api/main/src/test/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidatorTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/domain/agent/OpenSearchDslWhitelistValidatorTest.java
@@ -1,0 +1,130 @@
+package io.stablepay.api.domain.agent;
+
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidAggFieldRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidFieldRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidIndexRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.invalidSortFieldRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.oversizedRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validAggsRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validBoolTermRequest;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.validRangeRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchDslWhitelistValidatorTest {
+
+  private final AllowedQueryShapeRegistry registry = new AllowedQueryShapeRegistry();
+  private final OpenSearchDslWhitelistValidator validator =
+      new OpenSearchDslWhitelistValidator(registry);
+
+  @Nested
+  class ValidQueries {
+
+    @Test
+    void shouldAcceptValidBoolWithTermQuery() {
+      // when
+      var result = validator.validate(validBoolTermRequest());
+
+      // then
+      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
+      var valid = (DslValidationResult.Valid) result;
+      assertThat(valid.size()).isEqualTo(50);
+      assertThat(valid.translatedQuery()).isNotNull();
+      assertThat(valid.translatedQuery().isBool()).isTrue();
+    }
+
+    @Test
+    void shouldAcceptValidRangeQuery() {
+      // when
+      var result = validator.validate(validRangeRequest());
+
+      // then
+      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
+      var valid = (DslValidationResult.Valid) result;
+      assertThat(valid.size()).isEqualTo(100);
+      assertThat(valid.translatedQuery()).isNotNull();
+      assertThat(valid.translatedQuery().isRange()).isTrue();
+    }
+  }
+
+  @Nested
+  class RejectedQueries {
+
+    @Test
+    void shouldRejectInvalidIndex() {
+      // when
+      var result = validator.validate(invalidIndexRequest());
+
+      // then
+      var expected =
+          new DslValidationResult.Invalid("Index not in allowlist: secret-data", "STBLPAY-6001");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectInvalidField() {
+      // when
+      var result = validator.validate(invalidFieldRequest());
+
+      // then
+      var expected =
+          new DslValidationResult.Invalid("Field not in allowlist: password_hash", "STBLPAY-6002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRejectInvalidSortField() {
+      // when
+      var result = validator.validate(invalidSortFieldRequest());
+
+      // then
+      var expected =
+          new DslValidationResult.Invalid(
+              "Sort field not in allowlist: password_hash", "STBLPAY-6005");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class SizeHandling {
+
+    @Test
+    void shouldCapSizeAbove1000To1000() {
+      // when
+      var result = validator.validate(oversizedRequest());
+
+      // then
+      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
+      var valid = (DslValidationResult.Valid) result;
+      assertThat(valid.size()).isEqualTo(1000);
+    }
+  }
+
+  @Nested
+  class AggregationValidation {
+
+    @Test
+    void shouldAcceptValidAggregations() {
+      // when
+      var result = validator.validate(validAggsRequest());
+
+      // then
+      assertThat(result).isInstanceOf(DslValidationResult.Valid.class);
+      var valid = (DslValidationResult.Valid) result;
+      assertThat(valid.translatedAggs()).containsKeys("by_status", "total_amount");
+    }
+
+    @Test
+    void shouldRejectAggregationWithInvalidField() {
+      // when
+      var result = validator.validate(invalidAggFieldRequest());
+
+      // then
+      var expected =
+          new DslValidationResult.Invalid("Field not in allowlist: password_hash", "STBLPAY-6002");
+      assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/opensearch/OpenSearchQueryTranslatorTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/opensearch/OpenSearchQueryTranslatorTest.java
@@ -1,0 +1,159 @@
+package io.stablepay.api.infrastructure.opensearch;
+
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_AVG_AGG;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_BOOL_TERM_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_BOOL_WITH_MUST_NOT_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_DATE_HISTOGRAM_AGG;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_EXISTS_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_MATCH_PHRASE_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_RANGE_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_SUM_AGG;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_TERMS_AGG;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_TERMS_QUERY;
+import static io.stablepay.api.domain.agent.fixtures.DslValidationFixtures.VALID_TERM_QUERY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OpenSearchQueryTranslatorTest {
+
+  private final OpenSearchQueryTranslator translator = new OpenSearchQueryTranslator();
+
+  @Nested
+  class QueryTranslation {
+
+    @Test
+    void shouldTranslateTermQuery() {
+      // when
+      var result = translator.translateQuery(VALID_TERM_QUERY);
+
+      // then
+      assertThat(result.isTerm()).isTrue();
+      assertThat(result.term().field()).isEqualTo("customer_id");
+      assertThat(result.term().value().stringValue()).isEqualTo("cust-001");
+    }
+
+    @Test
+    void shouldTranslateRangeQuery() {
+      // when
+      var result = translator.translateQuery(VALID_RANGE_QUERY);
+
+      // then
+      assertThat(result.isRange()).isTrue();
+      assertThat(result.range().field()).isEqualTo("event_time");
+    }
+
+    @Test
+    void shouldTranslateMatchPhraseQuery() {
+      // when
+      var result = translator.translateQuery(VALID_MATCH_PHRASE_QUERY);
+
+      // then
+      assertThat(result.isMatchPhrase()).isTrue();
+      assertThat(result.matchPhrase().field()).isEqualTo("flow_type");
+      assertThat(result.matchPhrase().query()).isEqualTo("ON_RAMP");
+    }
+
+    @Test
+    void shouldTranslateExistsQuery() {
+      // when
+      var result = translator.translateQuery(VALID_EXISTS_QUERY);
+
+      // then
+      assertThat(result.isExists()).isTrue();
+      assertThat(result.exists().field()).isEqualTo("error_class");
+    }
+
+    @Test
+    void shouldTranslateTermsQuery() {
+      // when
+      var result = translator.translateQuery(VALID_TERMS_QUERY);
+
+      // then
+      assertThat(result.isTerms()).isTrue();
+      assertThat(result.terms().field()).isEqualTo("internal_status");
+    }
+
+    @Test
+    void shouldTranslateBoolQuery() {
+      // when
+      var result = translator.translateQuery(VALID_BOOL_TERM_QUERY);
+
+      // then
+      assertThat(result.isBool()).isTrue();
+      assertThat(result.bool().must()).hasSize(1);
+      assertThat(result.bool().filter()).hasSize(1);
+      assertThat(result.bool().mustNot()).isEmpty();
+    }
+
+    @Test
+    void shouldTranslateBoolQueryWithMustNot() {
+      // when
+      var result = translator.translateQuery(VALID_BOOL_WITH_MUST_NOT_QUERY);
+
+      // then
+      assertThat(result.isBool()).isTrue();
+      assertThat(result.bool().must()).hasSize(1);
+      assertThat(result.bool().filter()).isEmpty();
+      assertThat(result.bool().mustNot()).hasSize(1);
+    }
+  }
+
+  @Nested
+  class AggregationTranslation {
+
+    @Test
+    void shouldTranslateTermsAgg() {
+      // when
+      var result = translator.translateAggs(List.of(VALID_TERMS_AGG));
+
+      // then
+      assertThat(result).containsKey("by_status");
+      assertThat(result.get("by_status").isTerms()).isTrue();
+    }
+
+    @Test
+    void shouldTranslateDateHistogramAgg() {
+      // when
+      var result = translator.translateAggs(List.of(VALID_DATE_HISTOGRAM_AGG));
+
+      // then
+      assertThat(result).containsKey("over_time");
+      assertThat(result.get("over_time").isDateHistogram()).isTrue();
+    }
+
+    @Test
+    void shouldTranslateSumAgg() {
+      // when
+      var result = translator.translateAggs(List.of(VALID_SUM_AGG));
+
+      // then
+      assertThat(result).containsKey("total_amount");
+      assertThat(result.get("total_amount").isSum()).isTrue();
+    }
+
+    @Test
+    void shouldTranslateAvgAgg() {
+      // when
+      var result = translator.translateAggs(List.of(VALID_AVG_AGG));
+
+      // then
+      assertThat(result).containsKey("avg_amount");
+      assertThat(result.get("avg_amount").isAvg()).isTrue();
+    }
+
+    @Test
+    void shouldTranslateMultipleAggs() {
+      // when
+      var result =
+          translator.translateAggs(
+              List.of(VALID_TERMS_AGG, VALID_DATE_HISTOGRAM_AGG, VALID_SUM_AGG, VALID_AVG_AGG));
+
+      // then
+      assertThat(result).hasSize(4);
+      assertThat(result).containsKeys("by_status", "over_time", "total_amount", "avg_amount");
+    }
+  }
+}

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/DslValidationFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/DslValidationFixtures.java
@@ -19,11 +19,26 @@ public final class DslValidationFixtures {
       new QueryShape.RangeShape(
           "event_time", Optional.of(1700000000000L), Optional.of(1700100000000L));
 
+  public static final QueryShape.MatchPhraseShape VALID_MATCH_PHRASE_QUERY =
+      new QueryShape.MatchPhraseShape("flow_type", "ON_RAMP");
+
+  public static final QueryShape.ExistsShape VALID_EXISTS_QUERY =
+      new QueryShape.ExistsShape("error_class");
+
+  public static final QueryShape.TermsShape VALID_TERMS_QUERY =
+      new QueryShape.TermsShape("internal_status", List.of("COMPLETED", "FAILED"));
+
   public static final QueryShape.BoolShape VALID_BOOL_TERM_QUERY =
       new QueryShape.BoolShape(
           List.of(new QueryShape.TermShape("customer_id", "cust-001")),
           List.of(new QueryShape.TermShape("flow_type", "ON_RAMP")),
           List.of());
+
+  public static final QueryShape.BoolShape VALID_BOOL_WITH_MUST_NOT_QUERY =
+      new QueryShape.BoolShape(
+          List.of(new QueryShape.TermShape("customer_id", "cust-001")),
+          List.of(),
+          List.of(new QueryShape.TermShape("internal_status", "CANCELLED")));
 
   public static final QueryShape.TermShape INVALID_FIELD_QUERY =
       new QueryShape.TermShape("password_hash", "secret");
@@ -47,6 +62,9 @@ public final class DslValidationFixtures {
   public static final AggShape.SumAggShape INVALID_AGG_FIELD =
       new AggShape.SumAggShape("bad_agg", "password_hash");
 
+  public static final AggShape.DateHistogramAggShape INVALID_CALENDAR_INTERVAL_AGG =
+      new AggShape.DateHistogramAggShape("over_time", "event_time", "fortnight");
+
   public static AgentSearchRequest validBoolTermRequest() {
     return AgentSearchRequest.builder()
         .index(VALID_INDEX_TRANSACTIONS)
@@ -62,7 +80,47 @@ public final class DslValidationFixtures {
         .index(VALID_INDEX_TRANSACTIONS)
         .query(VALID_RANGE_QUERY)
         .aggs(Optional.empty())
-        .size(Optional.of(100))
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validMatchPhraseRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_MATCH_PHRASE_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validExistsRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_DLQ)
+        .query(VALID_EXISTS_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validTermsRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERMS_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validBoolWithMustNotRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_BOOL_WITH_MUST_NOT_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
         .sort(Optional.empty())
         .build();
   }
@@ -97,6 +155,26 @@ public final class DslValidationFixtures {
         .build();
   }
 
+  public static AgentSearchRequest negativeSizeRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.of(-5))
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest zeroSizeRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.of(0))
+        .sort(Optional.empty())
+        .build();
+  }
+
   public static AgentSearchRequest validSortRequest() {
     return AgentSearchRequest.builder()
         .index(VALID_INDEX_TRANSACTIONS)
@@ -127,11 +205,33 @@ public final class DslValidationFixtures {
         .build();
   }
 
+  public static AgentSearchRequest validAllAggTypesRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(
+            Optional.of(
+                List.of(VALID_TERMS_AGG, VALID_DATE_HISTOGRAM_AGG, VALID_SUM_AGG, VALID_AVG_AGG)))
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
   public static AgentSearchRequest invalidAggFieldRequest() {
     return AgentSearchRequest.builder()
         .index(VALID_INDEX_TRANSACTIONS)
         .query(VALID_TERM_QUERY)
         .aggs(Optional.of(List.of(INVALID_AGG_FIELD)))
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest invalidCalendarIntervalRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.of(List.of(INVALID_CALENDAR_INTERVAL_AGG)))
         .size(Optional.empty())
         .sort(Optional.empty())
         .build();

--- a/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/DslValidationFixtures.java
+++ b/apps/api/main/src/testFixtures/java/io/stablepay/api/domain/agent/fixtures/DslValidationFixtures.java
@@ -1,0 +1,141 @@
+package io.stablepay.api.domain.agent.fixtures;
+
+import io.stablepay.api.domain.agent.AgentSearchRequest;
+import io.stablepay.api.domain.agent.AggShape;
+import io.stablepay.api.domain.agent.QueryShape;
+import java.util.List;
+import java.util.Optional;
+
+public final class DslValidationFixtures {
+
+  public static final String VALID_INDEX_TRANSACTIONS = "transactions";
+  public static final String VALID_INDEX_DLQ = "dlq-events";
+  public static final String INVALID_INDEX = "secret-data";
+
+  public static final QueryShape.TermShape VALID_TERM_QUERY =
+      new QueryShape.TermShape("customer_id", "cust-001");
+
+  public static final QueryShape.RangeShape VALID_RANGE_QUERY =
+      new QueryShape.RangeShape(
+          "event_time", Optional.of(1700000000000L), Optional.of(1700100000000L));
+
+  public static final QueryShape.BoolShape VALID_BOOL_TERM_QUERY =
+      new QueryShape.BoolShape(
+          List.of(new QueryShape.TermShape("customer_id", "cust-001")),
+          List.of(new QueryShape.TermShape("flow_type", "ON_RAMP")),
+          List.of());
+
+  public static final QueryShape.TermShape INVALID_FIELD_QUERY =
+      new QueryShape.TermShape("password_hash", "secret");
+
+  public static final QueryShape.BoolShape NESTED_INVALID_FIELD_QUERY =
+      new QueryShape.BoolShape(
+          List.of(new QueryShape.TermShape("password_hash", "secret")), List.of(), List.of());
+
+  public static final AggShape.TermsAggShape VALID_TERMS_AGG =
+      new AggShape.TermsAggShape("by_status", "internal_status", 10);
+
+  public static final AggShape.DateHistogramAggShape VALID_DATE_HISTOGRAM_AGG =
+      new AggShape.DateHistogramAggShape("over_time", "event_time", "day");
+
+  public static final AggShape.SumAggShape VALID_SUM_AGG =
+      new AggShape.SumAggShape("total_amount", "amount_micros");
+
+  public static final AggShape.AvgAggShape VALID_AVG_AGG =
+      new AggShape.AvgAggShape("avg_amount", "amount_micros");
+
+  public static final AggShape.SumAggShape INVALID_AGG_FIELD =
+      new AggShape.SumAggShape("bad_agg", "password_hash");
+
+  public static AgentSearchRequest validBoolTermRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_BOOL_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.of(50))
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validRangeRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_RANGE_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.of(100))
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest invalidIndexRequest() {
+    return AgentSearchRequest.builder()
+        .index(INVALID_INDEX)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest invalidFieldRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(INVALID_FIELD_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest oversizedRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.of(5000))
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest validSortRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.of(List.of("event_time")))
+        .build();
+  }
+
+  public static AgentSearchRequest invalidSortFieldRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.empty())
+        .size(Optional.empty())
+        .sort(Optional.of(List.of("password_hash")))
+        .build();
+  }
+
+  public static AgentSearchRequest validAggsRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.of(List.of(VALID_TERMS_AGG, VALID_SUM_AGG)))
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  public static AgentSearchRequest invalidAggFieldRequest() {
+    return AgentSearchRequest.builder()
+        .index(VALID_INDEX_TRANSACTIONS)
+        .query(VALID_TERM_QUERY)
+        .aggs(Optional.of(List.of(INVALID_AGG_FIELD)))
+        .size(Optional.empty())
+        .sort(Optional.empty())
+        .build();
+  }
+
+  private DslValidationFixtures() {}
+}


### PR DESCRIPTION
## SPP Issue
Closes #103

## Changes
- Add sealed `QueryShape` interface with 6 typed records: `TermShape`, `RangeShape`, `MatchPhraseShape`, `BoolShape`, `ExistsShape`, `TermsShape`
- Add sealed `AggShape` interface with 4 typed records: `TermsAggShape`, `DateHistogramAggShape`, `SumAggShape`, `AvgAggShape`
- Add `AgentSearchRequest` record wrapping index, query, optional aggs/size/sort
- Add `DslValidationResult` sealed interface: `Valid(Query, Map<String,Aggregation>, int)` / `Invalid(reason, errorCode)`
- Add `AllowedQueryShapeRegistry` with index allowlist (2: `transactions`, `dlq-events`), field allowlist (18 fields)
- Add `OpenSearchDslWhitelistValidator` — validates request against allowlists and translates typed shapes to opensearch-java `Query` builders (zero string interpolation)
- Add `DslValidationFixtures` in testFixtures with shared request builders
- Add 8 unit tests covering: valid bool+term, valid range, invalid index, invalid field, sort field validated, aggs validated, agg invalid field, size > 1000 capped to 1000

## Design Notes
- Script_score/script_query/painless/raw JSON rejection is **compile-time** via sealed interfaces — no `ScriptScoreShape` exists to construct
- Mirrors the `TrinoSqlAllowlistValidator` pattern: domain-layer validator, sealed result type, error codes `STBLPAY-6001`–`STBLPAY-6005`
- Translations use opensearch-java 3.0.0 typed builder API (same library used by `OpenSearchTransactionRepository`)

## Checklist
- [x] `./gradlew :apps:api:main:build` passes (unit + integration + business + spotless)
- [x] Unit tests added (8 tests across 4 nested classes)
- [ ] Integration tests added/updated (not applicable — pure domain validator, no Spring context)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)