### PR TITLE
SPP-99: add OpenAPI 3.1 spec at /v3/api-docs with Swagger UI and tag organization

### DIFF
--- a/apps/api/client/build.gradle.kts
+++ b/apps/api/client/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":schemas"))
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.swagger.annotations)
 
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)

--- a/apps/api/client/src/main/java/io/stablepay/api/client/ApiError.java
+++ b/apps/api/client/src/main/java/io/stablepay/api/client/ApiError.java
@@ -1,7 +1,9 @@
 package io.stablepay.api.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
+@Schema(description = "API error response")
 public record ApiError(
     @JsonProperty("error_code") String errorCode, String message, Instant timestamp) {}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminCustomerController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminCustomerController.java
@@ -3,9 +3,15 @@ package io.stablepay.api.application.web.controller;
 import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.CustomerSummaryDto;
 import io.stablepay.api.application.web.mapper.CustomerSummaryWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.CustomerId;
 import io.stablepay.api.domain.port.CustomerRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +30,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/customers")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminCustomerController {
 
   private final CustomerRepository customerRepository;
   private final CustomerSummaryWebMapper mapper;
 
+  @Operation(summary = "Get customer summary (admin)")
+  @ApiResponse(responseCode = "200", description = "Customer summary returned")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Customer not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}/summary")
   public ResponseEntity<CustomerSummaryDto> summary(
       @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminCustomerController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminCustomerController.java
@@ -8,6 +8,7 @@ import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.CustomerId;
 import io.stablepay.api.domain.port.CustomerRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,7 +45,8 @@ public class AdminCustomerController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}/summary")
   public ResponseEntity<CustomerSummaryDto> summary(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Customer UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return customerRepository
         .findByIdAdmin(CustomerId.of(UUID.fromString(id)))
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDashboardController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDashboardController.java
@@ -4,6 +4,9 @@ import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.DashboardStatsDto;
 import io.stablepay.api.application.web.mapper.DashboardStatsWebMapper;
 import io.stablepay.api.domain.port.DashboardStatsRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.annotation.Secured;
@@ -19,11 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/dashboard")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminDashboardController {
 
   private final DashboardStatsRepository dashboardStatsRepository;
   private final DashboardStatsWebMapper mapper;
 
+  @Operation(summary = "Get admin dashboard statistics")
+  @ApiResponse(responseCode = "200", description = "Admin dashboard stats returned")
   @GetMapping("/stats")
   public DashboardStatsDto stats(@AuthenticationPrincipal AuthenticatedUser user) {
     var stats = dashboardStatsRepository.getStatsAdmin();

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDlqController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDlqController.java
@@ -8,10 +8,16 @@ import io.stablepay.api.application.web.dto.DlqSummaryDto;
 import io.stablepay.api.application.web.dto.PaginatedResponse;
 import io.stablepay.api.application.web.mapper.DlqEventWebMapper;
 import io.stablepay.api.application.web.mapper.DlqSummaryWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.DlqId;
 import io.stablepay.api.domain.port.DlqRepository;
 import io.stablepay.api.domain.service.DlqReplayService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.Clock;
@@ -36,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/dlq")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminDlqController {
 
   private final DlqRepository dlqRepository;
@@ -44,6 +51,8 @@ public class AdminDlqController {
   private final DlqSummaryWebMapper dlqSummaryMapper;
   private final Clock clock;
 
+  @Operation(summary = "List dead-letter queue events")
+  @ApiResponse(responseCode = "200", description = "Paginated DLQ event list")
   @GetMapping
   public PaginatedResponse<DlqEventDto> list(
       @RequestParam Optional<String> cursor,
@@ -53,12 +62,20 @@ public class AdminDlqController {
     return mapper.toResponse(result);
   }
 
+  @Operation(summary = "Get DLQ summary counts by error class")
+  @ApiResponse(responseCode = "200", description = "DLQ summary returned")
   @GetMapping("/summary")
   public DlqSummaryDto summary(@AuthenticationPrincipal AuthenticatedUser user) {
     var summary = dlqRepository.summaryAdmin();
     return dlqSummaryMapper.toDto(summary);
   }
 
+  @Operation(summary = "Find DLQ event by ID")
+  @ApiResponse(responseCode = "200", description = "DLQ event found")
+  @ApiResponse(
+      responseCode = "404",
+      description = "DLQ event not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<DlqEventDto> findById(
       @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
@@ -69,6 +86,16 @@ public class AdminDlqController {
         .orElseThrow(() -> new NotFoundException("DLQ event", id));
   }
 
+  @Operation(summary = "Replay a DLQ event")
+  @ApiResponse(responseCode = "200", description = "Replay accepted")
+  @ApiResponse(
+      responseCode = "404",
+      description = "DLQ event not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(
+      responseCode = "409",
+      description = "Idempotency key conflict",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @PostMapping("/{id}/replay")
   @Idempotent
   public ResponseEntity<DlqReplayResponse> replay(

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDlqController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminDlqController.java
@@ -14,6 +14,7 @@ import io.stablepay.api.domain.model.DlqId;
 import io.stablepay.api.domain.port.DlqRepository;
 import io.stablepay.api.domain.service.DlqReplayService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -55,8 +56,12 @@ public class AdminDlqController {
   @ApiResponse(responseCode = "200", description = "Paginated DLQ event list")
   @GetMapping
   public PaginatedResponse<DlqEventDto> list(
-      @RequestParam Optional<String> cursor,
-      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+      @Parameter(description = "Opaque pagination cursor") @RequestParam Optional<String> cursor,
+      @Parameter(description = "Page size (1–100)")
+          @RequestParam(defaultValue = "20")
+          @Min(1)
+          @Max(100)
+          int size,
       @AuthenticationPrincipal AuthenticatedUser user) {
     var result = dlqRepository.searchAdmin(size, cursor);
     return mapper.toResponse(result);
@@ -78,7 +83,8 @@ public class AdminDlqController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<DlqEventDto> findById(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "DLQ event UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return dlqRepository
         .findByIdAdmin(DlqId.of(UUID.fromString(id)))
         .map(mapper::toDto)
@@ -99,7 +105,8 @@ public class AdminDlqController {
   @PostMapping("/{id}/replay")
   @Idempotent
   public ResponseEntity<DlqReplayResponse> replay(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "DLQ event UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     var dlqId = DlqId.of(UUID.fromString(id));
     dlqReplayService.replay(dlqId, user.userId());
     return ResponseEntity.ok(

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminFlowController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminFlowController.java
@@ -8,6 +8,7 @@ import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.FlowId;
 import io.stablepay.api.domain.port.FlowRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,7 +45,8 @@ public class AdminFlowController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<FlowDto> findById(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Flow UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return flowRepository
         .findByIdAdmin(FlowId.of(UUID.fromString(id)))
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminFlowController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminFlowController.java
@@ -3,9 +3,15 @@ package io.stablepay.api.application.web.controller;
 import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.FlowDto;
 import io.stablepay.api.application.web.mapper.FlowWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.FlowId;
 import io.stablepay.api.domain.port.FlowRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +30,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/flows")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminFlowController {
 
   private final FlowRepository flowRepository;
   private final FlowWebMapper mapper;
 
+  @Operation(summary = "Find payment flow by ID (admin)")
+  @ApiResponse(responseCode = "200", description = "Flow found")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Flow not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<FlowDto> findById(
       @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminStuckController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminStuckController.java
@@ -6,6 +6,7 @@ import io.stablepay.api.application.web.dto.StuckPaymentDto;
 import io.stablepay.api.application.web.mapper.StuckPaymentWebMapper;
 import io.stablepay.api.domain.port.StuckRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -37,8 +38,12 @@ public class AdminStuckController {
   @ApiResponse(responseCode = "200", description = "Paginated stuck payment list")
   @GetMapping
   public PaginatedResponse<StuckPaymentDto> list(
-      @RequestParam Optional<String> cursor,
-      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+      @Parameter(description = "Opaque pagination cursor") @RequestParam Optional<String> cursor,
+      @Parameter(description = "Page size (1–100)")
+          @RequestParam(defaultValue = "20")
+          @Min(1)
+          @Max(100)
+          int size,
       @AuthenticationPrincipal AuthenticatedUser user) {
     var result = stuckRepository.searchAdmin(size, cursor);
     return mapper.toResponse(result);

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminStuckController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminStuckController.java
@@ -5,6 +5,9 @@ import io.stablepay.api.application.web.dto.PaginatedResponse;
 import io.stablepay.api.application.web.dto.StuckPaymentDto;
 import io.stablepay.api.application.web.mapper.StuckPaymentWebMapper;
 import io.stablepay.api.domain.port.StuckRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.util.Optional;
@@ -24,11 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/stuck")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminStuckController {
 
   private final StuckRepository stuckRepository;
   private final StuckPaymentWebMapper mapper;
 
+  @Operation(summary = "List stuck payments")
+  @ApiResponse(responseCode = "200", description = "Paginated stuck payment list")
   @GetMapping
   public PaginatedResponse<StuckPaymentDto> list(
       @RequestParam Optional<String> cursor,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminTransactionController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminTransactionController.java
@@ -3,8 +3,14 @@ package io.stablepay.api.application.web.controller;
 import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.TransactionDto;
 import io.stablepay.api.application.web.mapper.TransactionWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.port.TransactionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +28,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/transactions")
 @Secured("ROLE_ADMIN")
+@Tag(name = "admin")
 public class AdminTransactionController {
 
   private final TransactionRepository transactionRepository;
   private final TransactionWebMapper mapper;
 
+  @Operation(summary = "Find transaction by reference (admin)")
+  @ApiResponse(responseCode = "200", description = "Transaction found")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Transaction not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{ref}")
   public ResponseEntity<TransactionDto> findByReference(
       @PathVariable String ref, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminTransactionController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AdminTransactionController.java
@@ -7,6 +7,7 @@ import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.port.TransactionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -42,7 +43,8 @@ public class AdminTransactionController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{ref}")
   public ResponseEntity<TransactionDto> findByReference(
-      @PathVariable String ref, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Transaction reference") @PathVariable String ref,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return transactionRepository
         .findByReferenceAdmin(ref)
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AgentController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AgentController.java
@@ -15,6 +15,7 @@ import io.stablepay.api.domain.agent.FetchResult;
 import io.stablepay.api.domain.agent.SearchExecutionResult;
 import io.stablepay.api.domain.agent.SqlExecutionResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -128,7 +129,8 @@ public class AgentController {
       description = "Timeline not found",
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/timeline/{ref}")
-  public ResponseEntity<?> fetchTimeline(@PathVariable String ref) {
+  public ResponseEntity<?> fetchTimeline(
+      @Parameter(description = "Transaction reference") @PathVariable String ref) {
     var result = timelineService.fetch(ref);
     return switch (result) {
       case FetchResult.Found found -> {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AgentController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/AgentController.java
@@ -14,6 +14,11 @@ import io.stablepay.api.domain.agent.AgentTimelineService;
 import io.stablepay.api.domain.agent.FetchResult;
 import io.stablepay.api.domain.agent.SearchExecutionResult;
 import io.stablepay.api.domain.agent.SqlExecutionResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.Clock;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/agent")
 @Secured("ROLE_AGENT")
+@Tag(name = "agent")
 public class AgentController {
 
   private final AgentSqlService sqlService;
@@ -42,6 +48,19 @@ public class AgentController {
   private final AgentTimelineService timelineService;
   private final Clock clock;
 
+  @Operation(summary = "Execute a validated Trino SQL query")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Query executed successfully",
+      content = @Content(schema = @Schema(implementation = AgentSqlResponse.class)))
+  @ApiResponse(
+      responseCode = "400",
+      description = "SQL rejected by allowlist validator",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(
+      responseCode = "503",
+      description = "Trino query execution failed",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @PostMapping("/sql")
   public ResponseEntity<?> executeSql(@Valid @RequestBody AgentSqlRequest request) {
     var limit = request.limit().orElse(1_000);
@@ -65,6 +84,19 @@ public class AgentController {
     };
   }
 
+  @Operation(summary = "Execute a validated OpenSearch DSL query")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Search executed successfully",
+      content = @Content(schema = @Schema(implementation = AgentSearchResponse.class)))
+  @ApiResponse(
+      responseCode = "400",
+      description = "DSL rejected by whitelist validator",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
+  @ApiResponse(
+      responseCode = "503",
+      description = "OpenSearch query execution failed",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @PostMapping("/search")
   public ResponseEntity<?> executeSearch(@Valid @RequestBody AgentSearchRequest request) {
     var result = searchService.execute(request);
@@ -86,6 +118,15 @@ public class AgentController {
     };
   }
 
+  @Operation(summary = "Fetch transaction timeline by reference")
+  @ApiResponse(
+      responseCode = "200",
+      description = "Timeline found",
+      content = @Content(schema = @Schema(implementation = AgentTimelineResponse.class)))
+  @ApiResponse(
+      responseCode = "404",
+      description = "Timeline not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/timeline/{ref}")
   public ResponseEntity<?> fetchTimeline(@PathVariable String ref) {
     var result = timelineService.fetch(ref);

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/CustomerController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/CustomerController.java
@@ -3,8 +3,14 @@ package io.stablepay.api.application.web.controller;
 import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.CustomerSummaryDto;
 import io.stablepay.api.application.web.mapper.CustomerSummaryWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.port.CustomerRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +29,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/customers")
 @Secured("ROLE_CUSTOMER")
+@Tag(name = "customer")
 public class CustomerController {
 
   private final CustomerRepository customerRepository;
   private final CustomerSummaryWebMapper mapper;
 
+  @Operation(summary = "Get customer summary")
+  @ApiResponse(responseCode = "200", description = "Customer summary returned")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Customer not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}/summary")
   public ResponseEntity<CustomerSummaryDto> summary(
       @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/CustomerController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/CustomerController.java
@@ -7,6 +7,7 @@ import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.port.CustomerRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -43,7 +44,8 @@ public class CustomerController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}/summary")
   public ResponseEntity<CustomerSummaryDto> summary(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Customer UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     var requestedId = UUID.fromString(id);
     if (!requestedId.equals(user.requireCustomerId().value())) {
       throw new NotFoundException("Customer", id);

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/DashboardController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/DashboardController.java
@@ -4,6 +4,9 @@ import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.DashboardStatsDto;
 import io.stablepay.api.application.web.mapper.DashboardStatsWebMapper;
 import io.stablepay.api.domain.port.DashboardStatsRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.annotation.Secured;
@@ -19,11 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/dashboard")
 @Secured("ROLE_CUSTOMER")
+@Tag(name = "customer")
 public class DashboardController {
 
   private final DashboardStatsRepository dashboardStatsRepository;
   private final DashboardStatsWebMapper mapper;
 
+  @Operation(summary = "Get dashboard statistics for the authenticated customer")
+  @ApiResponse(responseCode = "200", description = "Dashboard stats returned")
   @GetMapping("/stats")
   public DashboardStatsDto stats(@AuthenticationPrincipal AuthenticatedUser user) {
     var stats = dashboardStatsRepository.getStats(user.requireCustomerId());

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/FlowController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/FlowController.java
@@ -3,9 +3,15 @@ package io.stablepay.api.application.web.controller;
 import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.FlowDto;
 import io.stablepay.api.application.web.mapper.FlowWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.FlowId;
 import io.stablepay.api.domain.port.FlowRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +30,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/flows")
 @Secured("ROLE_CUSTOMER")
+@Tag(name = "customer")
 public class FlowController {
 
   private final FlowRepository flowRepository;
   private final FlowWebMapper mapper;
 
+  @Operation(summary = "Find payment flow by ID")
+  @ApiResponse(responseCode = "200", description = "Flow found")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Flow not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<FlowDto> findById(
       @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/FlowController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/FlowController.java
@@ -8,6 +8,7 @@ import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.FlowId;
 import io.stablepay.api.domain.port.FlowRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,7 +45,8 @@ public class FlowController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{id}")
   public ResponseEntity<FlowDto> findById(
-      @PathVariable String id, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Flow UUID") @PathVariable String id,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return flowRepository
         .findById(FlowId.of(UUID.fromString(id)), user.requireCustomerId())
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
@@ -6,6 +6,7 @@ import io.stablepay.api.application.web.mapper.TransactionEventWebMapper;
 import io.stablepay.api.domain.model.TransactionEvent;
 import io.stablepay.api.domain.port.TransactionEventSource;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Duration;
@@ -61,7 +62,8 @@ public class StreamsController {
   @GetMapping("/transactions/recent")
   public List<TransactionEventDto> recent(
       @AuthenticationPrincipal AuthenticatedUser user,
-      @RequestParam(required = false) String since) {
+      @Parameter(description = "Event ID to fetch events after") @RequestParam(required = false)
+          String since) {
     return eventSource.snapshotSinceAdmin(Optional.ofNullable(since), 50).stream()
         .filter(e -> isVisibleTo(e, user))
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/StreamsController.java
@@ -5,6 +5,9 @@ import io.stablepay.api.application.web.dto.TransactionEventDto;
 import io.stablepay.api.application.web.mapper.TransactionEventWebMapper;
 import io.stablepay.api.domain.model.TransactionEvent;
 import io.stablepay.api.domain.port.TransactionEventSource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -25,11 +28,14 @@ import reactor.core.publisher.Flux;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/streams")
 @Secured({"ROLE_CUSTOMER", "ROLE_ADMIN"})
+@Tag(name = "customer")
 public class StreamsController {
 
   private final TransactionEventSource eventSource;
   private final TransactionEventWebMapper mapper;
 
+  @Operation(summary = "Stream real-time transaction events via SSE")
+  @ApiResponse(responseCode = "200", description = "SSE stream opened")
   @GetMapping(value = "/transactions", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public Flux<ServerSentEvent<TransactionEventDto>> transactions(
       @AuthenticationPrincipal AuthenticatedUser user) {
@@ -50,6 +56,8 @@ public class StreamsController {
     return events.mergeWith(heartbeat);
   }
 
+  @Operation(summary = "List recent transaction events")
+  @ApiResponse(responseCode = "200", description = "Recent events returned")
   @GetMapping("/transactions/recent")
   public List<TransactionEventDto> recent(
       @AuthenticationPrincipal AuthenticatedUser user,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/TransactionController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/TransactionController.java
@@ -4,9 +4,15 @@ import io.stablepay.api.application.security.AuthenticatedUser;
 import io.stablepay.api.application.web.dto.PaginatedResponse;
 import io.stablepay.api.application.web.dto.TransactionDto;
 import io.stablepay.api.application.web.mapper.TransactionWebMapper;
+import io.stablepay.api.client.ApiError;
 import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.TransactionSearch;
 import io.stablepay.api.domain.port.TransactionRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.util.Optional;
@@ -28,11 +34,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/transactions")
 @Secured("ROLE_CUSTOMER")
+@Tag(name = "customer")
 public class TransactionController {
 
   private final TransactionRepository transactionRepository;
   private final TransactionWebMapper mapper;
 
+  @Operation(summary = "List transactions for the authenticated customer")
+  @ApiResponse(responseCode = "200", description = "Paginated transaction list")
   @GetMapping
   public PaginatedResponse<TransactionDto> list(
       @RequestParam Optional<String> status,
@@ -54,6 +63,12 @@ public class TransactionController {
     return mapper.toResponse(result);
   }
 
+  @Operation(summary = "Find transaction by reference")
+  @ApiResponse(responseCode = "200", description = "Transaction found")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Transaction not found",
+      content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{ref}")
   public ResponseEntity<TransactionDto> findByReference(
       @PathVariable String ref, @AuthenticationPrincipal AuthenticatedUser user) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/TransactionController.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/controller/TransactionController.java
@@ -9,6 +9,7 @@ import io.stablepay.api.domain.exception.NotFoundException;
 import io.stablepay.api.domain.model.TransactionSearch;
 import io.stablepay.api.domain.port.TransactionRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -44,9 +45,13 @@ public class TransactionController {
   @ApiResponse(responseCode = "200", description = "Paginated transaction list")
   @GetMapping
   public PaginatedResponse<TransactionDto> list(
-      @RequestParam Optional<String> status,
-      @RequestParam Optional<String> cursor,
-      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+      @Parameter(description = "Filter by customer status") @RequestParam Optional<String> status,
+      @Parameter(description = "Opaque pagination cursor") @RequestParam Optional<String> cursor,
+      @Parameter(description = "Page size (1–100)")
+          @RequestParam(defaultValue = "20")
+          @Min(1)
+          @Max(100)
+          int size,
       @AuthenticationPrincipal AuthenticatedUser user) {
     var search =
         TransactionSearch.builder()
@@ -71,7 +76,8 @@ public class TransactionController {
       content = @Content(schema = @Schema(implementation = ApiError.class)))
   @GetMapping("/{ref}")
   public ResponseEntity<TransactionDto> findByReference(
-      @PathVariable String ref, @AuthenticationPrincipal AuthenticatedUser user) {
+      @Parameter(description = "Transaction reference") @PathVariable String ref,
+      @AuthenticationPrincipal AuthenticatedUser user) {
     return transactionRepository
         .findByReference(ref, user.requireCustomerId())
         .map(mapper::toDto)

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSearchResponse.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSearchResponse.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 
+@Schema(description = "Agent OpenSearch query result")
 @Builder(toBuilder = true)
 public record AgentSearchResponse(
     List<Map<String, Object>> hits,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSqlRequest.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSqlRequest.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
 
+@Schema(description = "Agent Trino SQL execution request")
 public record AgentSqlRequest(@NotBlank String sql, Optional<@Min(1) @Max(10_000) Integer> limit) {
 
   public AgentSqlRequest {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSqlResponse.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentSqlResponse.java
@@ -1,9 +1,11 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 
+@Schema(description = "Agent Trino SQL execution result")
 @Builder(toBuilder = true)
 public record AgentSqlResponse(
     List<String> columns,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentTimelineResponse.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AgentTimelineResponse.java
@@ -1,8 +1,10 @@
 package io.stablepay.api.application.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 
+@Schema(description = "Agent transaction timeline")
 @Builder(toBuilder = true)
 public record AgentTimelineResponse(
     String reference, String markdown, List<TimelineEntryDto> entries) {}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AmountDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/AmountDto.java
@@ -1,9 +1,11 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Monetary amount in micros with currency code")
 @Builder(toBuilder = true)
 public record AmountDto(
     @JsonProperty("amount_micros") long amountMicros,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/CustomerSummaryDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/CustomerSummaryDto.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Customer profile summary")
 @Builder(toBuilder = true)
 public record CustomerSummaryDto(
     String id,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DashboardStatsDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DashboardStatsDto.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Dashboard statistics for a time period")
 @Builder(toBuilder = true)
 public record DashboardStatsDto(
     @JsonProperty("volume_24h_micros") long volume24hMicros,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqEventDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqEventDto.java
@@ -1,11 +1,13 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 
+@Schema(description = "Dead-letter queue event details")
 @Builder(toBuilder = true)
 public record DlqEventDto(
     String id,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqReplayResponse.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqReplayResponse.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "DLQ replay operation result")
 @Builder(toBuilder = true)
 public record DlqReplayResponse(
     @JsonProperty("dlq_id") String dlqId, String status, Instant timestamp) {

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqSummaryDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/DlqSummaryDto.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Dead-letter queue summary counts")
 @Builder(toBuilder = true)
 public record DlqSummaryDto(
     @JsonProperty("counts_by_error_class") Map<String, Long> countsByErrorClass,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/FlowDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/FlowDto.java
@@ -1,11 +1,13 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 
+@Schema(description = "Multi-leg payment flow details")
 @Builder(toBuilder = true)
 public record FlowDto(
     String id,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/PaginatedResponse.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/PaginatedResponse.java
@@ -1,11 +1,13 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 
+@Schema(description = "Paginated response wrapper")
 @Builder(toBuilder = true)
 public record PaginatedResponse<T>(
     List<T> items,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/StuckPaymentDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/StuckPaymentDto.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Stuck payment details")
 @Builder(toBuilder = true)
 public record StuckPaymentDto(
     String id,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TimelineEntryDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TimelineEntryDto.java
@@ -1,8 +1,10 @@
 package io.stablepay.api.application.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import lombok.Builder;
 
+@Schema(description = "Single timeline event entry")
 @Builder(toBuilder = true)
 public record TimelineEntryDto(
     String eventId, String source, String status, String detail, Instant timestamp) {}

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionDto.java
@@ -1,11 +1,13 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 
+@Schema(description = "Payment transaction details")
 @Builder(toBuilder = true)
 public record TransactionDto(
     String id,

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionEventDto.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/dto/TransactionEventDto.java
@@ -1,10 +1,12 @@
 package io.stablepay.api.application.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.Objects;
 import lombok.Builder;
 
+@Schema(description = "Real-time transaction event")
 @Builder(toBuilder = true)
 public record TransactionEventDto(
     @JsonProperty("event_id") String eventId,

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/openapi/OpenApiConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/openapi/OpenApiConfig.java
@@ -3,8 +3,10 @@ package io.stablepay.api.infrastructure.openapi;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,5 +32,16 @@ public class OpenApiConfig {
                         .scheme("bearer")
                         .bearerFormat("JWT")))
         .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+  }
+
+  @Bean
+  OperationCustomizer globalAuthResponses() {
+    return (operation, handlerMethod) -> {
+      operation
+          .getResponses()
+          .addApiResponse("401", new ApiResponse().description("Missing or invalid JWT token"))
+          .addApiResponse("403", new ApiResponse().description("Insufficient role permissions"));
+      return operation;
+    };
   }
 }

--- a/apps/api/main/src/main/java/io/stablepay/api/infrastructure/openapi/OpenApiConfig.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/infrastructure/openapi/OpenApiConfig.java
@@ -1,0 +1,34 @@
+package io.stablepay.api.infrastructure.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  OpenAPI stablepayOpenApi() {
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("StablePay API")
+                .version("0.1.0-SNAPSHOT")
+                .description(
+                    "Customer + admin + agent surfaces."
+                        + " JWT bearer auth required for /api/v1/**."))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "bearerAuth",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+  }
+}

--- a/apps/api/main/src/main/resources/application.yml
+++ b/apps/api/main/src/main/resources/application.yml
@@ -40,6 +40,14 @@ stablepay:
 server:
   port: 8080
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    version: openapi_3_1
+  swagger-ui:
+    path: /swagger-ui
+    enabled: true
+
 management:
   endpoints:
     web:

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/openapi/OpenApiConfigTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/openapi/OpenApiConfigTest.java
@@ -1,0 +1,45 @@
+package io.stablepay.api.infrastructure.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigTest {
+
+  private final OpenApiConfig config = new OpenApiConfig();
+
+  @Test
+  void shouldReturnOpenApiWithBearerAuthAndInfo() {
+    // given
+    var expected =
+        new OpenAPI()
+            .info(
+                new Info()
+                    .title("StablePay API")
+                    .version("0.1.0-SNAPSHOT")
+                    .description(
+                        "Customer + admin + agent surfaces."
+                            + " JWT bearer auth required for /api/v1/**."))
+            .components(
+                new Components()
+                    .addSecuritySchemes(
+                        "bearerAuth",
+                        new SecurityScheme()
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")))
+            .security(List.of(new SecurityRequirement().addList("bearerAuth")));
+
+    // when
+    var actual = config.stablepayOpenApi();
+
+    // then
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+}

--- a/apps/api/main/src/test/java/io/stablepay/api/infrastructure/openapi/OpenApiConfigTest.java
+++ b/apps/api/main/src/test/java/io/stablepay/api/infrastructure/openapi/OpenApiConfigTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.List;
@@ -41,5 +44,22 @@ class OpenApiConfigTest {
 
     // then
     assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void shouldAdd401And403ResponsesViaOperationCustomizer() {
+    // given
+    var customizer = config.globalAuthResponses();
+    var operation = new Operation().responses(new ApiResponses());
+    var expected =
+        new ApiResponses()
+            .addApiResponse("401", new ApiResponse().description("Missing or invalid JWT token"))
+            .addApiResponse("403", new ApiResponse().description("Insufficient role permissions"));
+
+    // when
+    var result = customizer.customize(operation, null);
+
+    // then
+    assertThat(result.getResponses()).usingRecursiveComparison().isEqualTo(expected);
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ bucket4j = "8.18.0"
 nimbus-jose-jwt = "10.9"
 flyway = "12.5.0"
 springdoc-openapi = "3.0.0"
+swagger-annotations = "2.2.30"
 trino-jdbc = "475"
 caffeine = "3.2.2"
 
@@ -93,6 +94,7 @@ nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimb
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
+swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations-jakarta", version.ref = "swagger-annotations" }
 trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 trino-parser = { module = "io.trino:trino-parser", version.ref = "trino-jdbc" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }


### PR DESCRIPTION
## SPP Issue
Closes #105

## Changes
- Add `OpenApiConfig` in `infrastructure/openapi/` with bearer auth security scheme and API info
- Add springdoc config to `application.yml` (`/v3/api-docs` OpenAPI 3.1, `/swagger-ui` enabled)
- Annotate all 12 controllers with `@Tag` (customer / admin / agent) and `@Operation` + `@ApiResponse` on every endpoint
- Annotate all 16 DTO records and `ApiError` with `@Schema(description = ...)`
- Add `swagger-annotations` to version catalog and client module for `@Schema` on `ApiError`
- Add `OpenApiConfigTest` verifying the OpenAPI bean structure with `usingRecursiveComparison()`

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied