### PR TITLE
SPP-100: add agent endpoint business tests and fix Jackson/security bugs (#106)

### DIFF
--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointHappyPathBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointHappyPathBT.java
@@ -4,11 +4,14 @@ import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_E
 import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_EVENT_TIME_2;
 import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_REFERENCE;
 import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_TIMELINE_ENTRIES;
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_TIMELINE_ENTRY_1;
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_TIMELINE_ENTRY_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import io.stablepay.api.application.web.dto.AgentSqlResponse;
 import io.stablepay.api.application.web.dto.AgentTimelineResponse;
+import io.stablepay.api.application.web.dto.TimelineEntryDto;
 import io.stablepay.api.config.BusinessTestBase;
 import io.stablepay.api.domain.agent.SqlExecutionResult;
 import java.util.List;
@@ -133,15 +136,29 @@ class AgentEndpointHappyPathBT extends BusinessTestBase {
 
       // then
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-      var body = response.getBody();
-      assertThat(body).isNotNull();
-      assertThat(body.reference()).isEqualTo(SOME_REFERENCE);
-      assertThat(body.markdown()).contains("# Timeline for " + SOME_REFERENCE);
-      assertThat(body.entries()).hasSize(2);
-      assertThat(body.entries().getFirst().eventId())
-          .isEqualTo("evt-aabbccdd-1111-2222-3333-444444444444");
-      assertThat(body.entries().getFirst().timestamp()).isEqualTo(SOME_EVENT_TIME_1);
-      assertThat(body.entries().getLast().timestamp()).isEqualTo(SOME_EVENT_TIME_2);
+      var expected =
+          AgentTimelineResponse.builder()
+              .reference(SOME_REFERENCE)
+              .markdown(response.getBody().markdown())
+              .entries(
+                  List.of(
+                      TimelineEntryDto.builder()
+                          .eventId(SOME_TIMELINE_ENTRY_1.eventId())
+                          .source(SOME_TIMELINE_ENTRY_1.source())
+                          .status(SOME_TIMELINE_ENTRY_1.status())
+                          .detail(SOME_TIMELINE_ENTRY_1.detail())
+                          .timestamp(SOME_EVENT_TIME_1)
+                          .build(),
+                      TimelineEntryDto.builder()
+                          .eventId(SOME_TIMELINE_ENTRY_2.eventId())
+                          .source(SOME_TIMELINE_ENTRY_2.source())
+                          .status(SOME_TIMELINE_ENTRY_2.status())
+                          .detail(SOME_TIMELINE_ENTRY_2.detail())
+                          .timestamp(SOME_EVENT_TIME_2)
+                          .build()))
+              .build();
+      assertThat(response.getBody()).usingRecursiveComparison().isEqualTo(expected);
+      assertThat(response.getBody().markdown()).contains("# Timeline for " + SOME_REFERENCE);
     }
 
     @Test

--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointHappyPathBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointHappyPathBT.java
@@ -1,0 +1,167 @@
+package io.stablepay.api.business;
+
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_EVENT_TIME_1;
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_EVENT_TIME_2;
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_REFERENCE;
+import static io.stablepay.api.domain.agent.fixtures.AgentServiceFixtures.SOME_TIMELINE_ENTRIES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import io.stablepay.api.application.web.dto.AgentSqlResponse;
+import io.stablepay.api.application.web.dto.AgentTimelineResponse;
+import io.stablepay.api.config.BusinessTestBase;
+import io.stablepay.api.domain.agent.SqlExecutionResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+
+class AgentEndpointHappyPathBT extends BusinessTestBase {
+
+  @AfterEach
+  void tearDown() {
+    stubRepositoryConfig.resetAgentStubs();
+  }
+
+  @Nested
+  class SqlEndpoint {
+
+    @Test
+    void shouldReturnRowsForValidSelectQuery() {
+      // given
+      stubRepositoryConfig.setSqlExecutor(
+          (sql, limit) ->
+              new SqlExecutionResult.Success(
+                  List.of("currency", "total"),
+                  List.of(List.of("USD", 12500)),
+                  1,
+                  "q-bt-001",
+                  42L));
+      var client = authenticatedClient(agentJwt());
+      var body =
+          """
+          {"sql": "SELECT currency, total FROM iceberg.analytics.v_payment_summary"}
+          """;
+
+      // when
+      var response =
+          client
+              .post()
+              .uri("/api/v1/agent/sql")
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .toEntity(AgentSqlResponse.class);
+
+      // then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      var expected =
+          AgentSqlResponse.builder()
+              .columns(List.of("currency", "total"))
+              .rows(List.of(List.of("USD", 12500)))
+              .rowCount(1)
+              .queryId("q-bt-001")
+              .tookMs(42L)
+              .build();
+      assertThat(response.getBody()).usingRecursiveComparison().isEqualTo(expected);
+    }
+  }
+
+  @Nested
+  class SearchEndpoint {
+
+    @Test
+    void shouldReturnHitsForValidBoolTermSearch() {
+      // given
+      stubRepositoryConfig.setSearchExecutor(
+          (request, size) ->
+              new io.stablepay.api.domain.agent.SearchExecutionResult.Success(
+                  List.of(Map.of("event_id", "e1", "customer_id", "cust-001")), 1L, size, 15L));
+      var client = authenticatedClient(agentJwt());
+      var body =
+          """
+          {
+            "index": "transactions",
+            "query": {"type": "term", "field": "customer_id", "value": "cust-001"}
+          }
+          """;
+
+      // when
+      var response =
+          client
+              .post()
+              .uri("/api/v1/agent/search")
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .toEntity(String.class);
+
+      // then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(response.getBody()).contains("event_id");
+      assertThat(response.getBody()).contains("cust-001");
+    }
+  }
+
+  @Nested
+  class TimelineEndpoint {
+
+    @Test
+    void shouldReturnTimelineForExistingReference() {
+      // given
+      stubRepositoryConfig.setTimelineLookup(
+          reference -> {
+            if (SOME_REFERENCE.equals(reference)) {
+              return SOME_TIMELINE_ENTRIES;
+            }
+            return List.of();
+          });
+      var client = authenticatedClient(agentJwt());
+
+      // when
+      var response =
+          client
+              .get()
+              .uri("/api/v1/agent/timeline/{ref}", SOME_REFERENCE)
+              .accept(MediaType.APPLICATION_JSON)
+              .retrieve()
+              .toEntity(AgentTimelineResponse.class);
+
+      // then
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      var body = response.getBody();
+      assertThat(body).isNotNull();
+      assertThat(body.reference()).isEqualTo(SOME_REFERENCE);
+      assertThat(body.markdown()).contains("# Timeline for " + SOME_REFERENCE);
+      assertThat(body.entries()).hasSize(2);
+      assertThat(body.entries().getFirst().eventId())
+          .isEqualTo("evt-aabbccdd-1111-2222-3333-444444444444");
+      assertThat(body.entries().getFirst().timestamp()).isEqualTo(SOME_EVENT_TIME_1);
+      assertThat(body.entries().getLast().timestamp()).isEqualTo(SOME_EVENT_TIME_2);
+    }
+
+    @Test
+    void shouldReturn404ForMissingReference() {
+      // given
+      var client = authenticatedClient(agentJwt());
+
+      // when/then
+      var exception =
+          catchThrowableOfType(
+              HttpClientErrorException.class,
+              () ->
+                  client
+                      .get()
+                      .uri("/api/v1/agent/timeline/{ref}", "nonexistent-ref")
+                      .accept(MediaType.APPLICATION_JSON)
+                      .retrieve()
+                      .toEntity(String.class));
+      assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(exception.getResponseBodyAsString()).contains("STBLPAY-3001");
+    }
+  }
+}

--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointSecurityBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentEndpointSecurityBT.java
@@ -1,0 +1,103 @@
+package io.stablepay.api.business;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import io.stablepay.api.config.BusinessTestBase;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+
+class AgentEndpointSecurityBT extends BusinessTestBase {
+
+  @Nested
+  class SqlAllowlistEnforcement {
+
+    @Test
+    void shouldRejectDeleteSqlWith400() {
+      // given
+      var client = authenticatedClient(agentJwt());
+      var body =
+          """
+          {"sql": "DELETE FROM iceberg.analytics.v_payment_summary"}
+          """;
+
+      // when/then
+      var exception =
+          catchThrowableOfType(
+              HttpClientErrorException.class,
+              () ->
+                  client
+                      .post()
+                      .uri("/api/v1/agent/sql")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .body(body)
+                      .retrieve()
+                      .toEntity(String.class));
+      assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(exception.getResponseBodyAsString()).contains("STBLPAY-5002");
+    }
+  }
+
+  @Nested
+  class DslWhitelistEnforcement {
+
+    @Test
+    void shouldRejectNonWhitelistedFieldWith400() {
+      // given
+      var client = authenticatedClient(agentJwt());
+      var body =
+          """
+          {
+            "index": "transactions",
+            "query": {"type":"term", "field": "password_hash", "value": "secret"}
+          }
+          """;
+
+      // when/then
+      var exception =
+          catchThrowableOfType(
+              HttpClientErrorException.class,
+              () ->
+                  client
+                      .post()
+                      .uri("/api/v1/agent/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .body(body)
+                      .retrieve()
+                      .toEntity(String.class));
+      assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+      assertThat(exception.getResponseBodyAsString()).contains("STBLPAY-6002");
+    }
+  }
+
+  @Nested
+  class RoleEnforcement {
+
+    @Test
+    void shouldRejectNonAgentUserWith403() {
+      // given
+      var client = authenticatedClient(aliceJwt());
+      var body =
+          """
+          {"sql": "SELECT * FROM iceberg.analytics.v_payment_summary"}
+          """;
+
+      // when/then
+      var exception =
+          catchThrowableOfType(
+              HttpClientErrorException.class,
+              () ->
+                  client
+                      .post()
+                      .uri("/api/v1/agent/sql")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .body(body)
+                      .retrieve()
+                      .toEntity(String.class));
+      assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentRateLimitBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentRateLimitBT.java
@@ -18,7 +18,7 @@ class AgentRateLimitBT extends BusinessTestBase {
       UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
 
   @Test
-  void agentShouldBeRateLimitedAfterBucketExhausted() {
+  void shouldRejectAgentAfterBucketExhausted() {
     // given — use a dedicated UUID so other agent tests don't deplete the bucket
     var jwt = mintJwt(RATE_LIMIT_AGENT_UUID, "rate-agent@stablepay.io", List.of("AGENT"), null);
     var client = authenticatedClient(jwt);
@@ -29,13 +29,15 @@ class AgentRateLimitBT extends BusinessTestBase {
 
     // when
     for (var i = 0; i < StubRepositoryConfig.BT_RATE_LIMIT_CAPACITY; i++) {
-      client
-          .post()
-          .uri("/api/v1/agent/sql")
-          .contentType(MediaType.APPLICATION_JSON)
-          .body(body)
-          .retrieve()
-          .toEntity(String.class);
+      var ok =
+          client
+              .post()
+              .uri("/api/v1/agent/sql")
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .toEntity(String.class);
+      assertThat(ok.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     // then

--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentRateLimitBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentRateLimitBT.java
@@ -1,0 +1,58 @@
+package io.stablepay.api.business;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import io.stablepay.api.config.BusinessTestBase;
+import io.stablepay.api.config.StubRepositoryConfig;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpClientErrorException;
+
+class AgentRateLimitBT extends BusinessTestBase {
+
+  private static final UUID RATE_LIMIT_AGENT_UUID =
+      UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+  @Test
+  void agentShouldBeRateLimitedAfterBucketExhausted() {
+    // given — use a dedicated UUID so other agent tests don't deplete the bucket
+    var jwt = mintJwt(RATE_LIMIT_AGENT_UUID, "rate-agent@stablepay.io", List.of("AGENT"), null);
+    var client = authenticatedClient(jwt);
+    var body =
+        """
+        {"sql": "SELECT * FROM iceberg.analytics.v_payment_summary"}
+        """;
+
+    // when
+    for (var i = 0; i < StubRepositoryConfig.BT_RATE_LIMIT_CAPACITY; i++) {
+      client
+          .post()
+          .uri("/api/v1/agent/sql")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(body)
+          .retrieve()
+          .toEntity(String.class);
+    }
+
+    // then
+    var exception =
+        catchThrowableOfType(
+            HttpClientErrorException.class,
+            () ->
+                client
+                    .post()
+                    .uri("/api/v1/agent/sql")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toEntity(String.class));
+    assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+    assertThat(exception.getResponseHeaders()).isNotNull();
+    assertThat(exception.getResponseHeaders().getFirst("Retry-After")).isNotNull();
+    assertThat(exception.getResponseBodyAsString()).contains("STBLPAY-4001");
+  }
+}

--- a/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentTimeoutBT.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/business/AgentTimeoutBT.java
@@ -1,0 +1,54 @@
+package io.stablepay.api.business;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+import io.stablepay.api.config.BusinessTestBase;
+import io.stablepay.api.domain.agent.SqlExecutionResult;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.HttpServerErrorException;
+
+class AgentTimeoutBT extends BusinessTestBase {
+
+  private static final UUID TIMEOUT_AGENT_UUID =
+      UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+  @AfterEach
+  void tearDown() {
+    stubRepositoryConfig.resetAgentStubs();
+  }
+
+  @Test
+  void shouldReturn503WhenSqlExecutionTimesOut() {
+    // given
+    stubRepositoryConfig.setSqlExecutor(
+        (sql, limit) ->
+            new SqlExecutionResult.Failed("STBLPAY-5005", "Query execution failed: timeout"));
+    var jwt = mintJwt(TIMEOUT_AGENT_UUID, "timeout-agent@stablepay.io", List.of("AGENT"), null);
+    var client = authenticatedClient(jwt);
+    var body =
+        """
+        {"sql": "SELECT * FROM iceberg.analytics.v_payment_summary"}
+        """;
+
+    // when/then
+    var exception =
+        catchThrowableOfType(
+            HttpServerErrorException.class,
+            () ->
+                client
+                    .post()
+                    .uri("/api/v1/agent/sql")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toEntity(String.class));
+    assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(exception.getResponseBodyAsString()).contains("STBLPAY-5005");
+  }
+}

--- a/apps/api/main/src/business-test/java/io/stablepay/api/config/BusinessTestBase.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/config/BusinessTestBase.java
@@ -2,6 +2,8 @@ package io.stablepay.api.config;
 
 import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_EMAIL;
 import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_ADMIN_USER_UUID;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_EMAIL;
+import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_AGENT_USER_UUID;
 import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_EMAIL;
 import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_USER_UUID;
 import static io.stablepay.api.application.security.fixtures.AuthenticatedUserFixtures.SOME_CUSTOMER_UUID;
@@ -106,6 +108,10 @@ public abstract class BusinessTestBase {
     return mintJwt(SOME_ADMIN_USER_UUID, SOME_ADMIN_EMAIL, List.of("ADMIN"), null);
   }
 
+  protected static String agentJwt() {
+    return mintJwt(SOME_AGENT_USER_UUID, SOME_AGENT_EMAIL, List.of("AGENT"), null);
+  }
+
   protected RestClient authenticatedClient(String jwt) {
     return RestClient.builder()
         .baseUrl("http://localhost:" + port)
@@ -114,7 +120,8 @@ public abstract class BusinessTestBase {
         .build();
   }
 
-  private static String mintJwt(UUID userId, String email, List<String> roles, String customerId) {
+  protected static String mintJwt(
+      UUID userId, String email, List<String> roles, String customerId) {
     try {
       var claimsBuilder =
           new JWTClaimsSet.Builder()

--- a/apps/api/main/src/business-test/java/io/stablepay/api/config/StubRepositoryConfig.java
+++ b/apps/api/main/src/business-test/java/io/stablepay/api/config/StubRepositoryConfig.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +53,47 @@ public class StubRepositoryConfig {
   private final CopyOnWriteArrayList<TransactionEvent> eventBuffer = new CopyOnWriteArrayList<>();
   private final Sinks.Many<TransactionEvent> eventSink =
       Sinks.many().multicast().onBackpressureBuffer(256);
+
+  private final AtomicReference<BiFunction<String, Integer, SqlExecutionResult>> sqlExecutorRef =
+      new AtomicReference<>(
+          (sql, limit) ->
+              new SqlExecutionResult.Success(List.of(), List.of(), 0, "stub-query-id", 0L));
+
+  private final AtomicReference<
+          BiFunction<
+              io.stablepay.api.domain.agent.AgentSearchRequest, Integer, SearchExecutionResult>>
+      searchExecutorRef =
+          new AtomicReference<>(
+              (request, size) -> new SearchExecutionResult.Success(List.of(), 0L, size, 0L));
+
+  private final AtomicReference<
+          java.util.function.Function<String, List<io.stablepay.api.domain.agent.TimelineEntry>>>
+      timelineLookupRef = new AtomicReference<>(reference -> List.of());
+
+  public void setSqlExecutor(BiFunction<String, Integer, SqlExecutionResult> executor) {
+    sqlExecutorRef.set(executor);
+  }
+
+  public void setSearchExecutor(
+      BiFunction<io.stablepay.api.domain.agent.AgentSearchRequest, Integer, SearchExecutionResult>
+          executor) {
+    searchExecutorRef.set(executor);
+  }
+
+  public void setTimelineLookup(
+      java.util.function.Function<String, List<io.stablepay.api.domain.agent.TimelineEntry>>
+          lookup) {
+    timelineLookupRef.set(lookup);
+  }
+
+  public void resetAgentStubs() {
+    sqlExecutorRef.set(
+        (sql, limit) ->
+            new SqlExecutionResult.Success(List.of(), List.of(), 0, "stub-query-id", 0L));
+    searchExecutorRef.set(
+        (request, size) -> new SearchExecutionResult.Success(List.of(), 0L, size, 0L));
+    timelineLookupRef.set(reference -> List.of());
+  }
 
   public void emitEvent(TransactionEvent event) {
     eventBuffer.add(event);
@@ -233,20 +276,19 @@ public class StubRepositoryConfig {
   @Bean
   @Primary
   public TimelineRepository stubTimelineRepository() {
-    return reference -> List.of();
+    return reference -> timelineLookupRef.get().apply(reference);
   }
 
   @Bean
   @Primary
   public AgentSqlExecutor stubAgentSqlExecutor() {
-    return (sql, limit) ->
-        new SqlExecutionResult.Success(List.of(), List.of(), 0, "stub-query-id", 0L);
+    return (sql, limit) -> sqlExecutorRef.get().apply(sql, limit);
   }
 
   @Bean
   @Primary
   public AgentSearchExecutor stubAgentSearchExecutor() {
-    return (request, size) -> new SearchExecutionResult.Success(List.of(), 0L, size, 0L);
+    return (request, size) -> searchExecutorRef.get().apply(request, size);
   }
 
   @Bean

--- a/apps/api/main/src/main/java/io/stablepay/api/application/web/error/GlobalExceptionHandler.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/application/web/error/GlobalExceptionHandler.java
@@ -58,6 +58,12 @@ public class GlobalExceptionHandler {
         .body(new ApiError(ErrorCodes.VALIDATION_FAILED, ex.getMessage(), clock.instant()));
   }
 
+  @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+  public void handleAccessDenied(org.springframework.security.access.AccessDeniedException ex)
+      throws org.springframework.security.access.AccessDeniedException {
+    throw ex;
+  }
+
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiError> handleGeneric(Exception ex) {
     log.error("Unhandled exception", ex);

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/AggShape.java
@@ -1,8 +1,17 @@
 package io.stablepay.api.domain.agent;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Objects;
 import lombok.Builder;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = AggShape.TermsAggShape.class, name = "terms"),
+  @JsonSubTypes.Type(value = AggShape.DateHistogramAggShape.class, name = "date_histogram"),
+  @JsonSubTypes.Type(value = AggShape.SumAggShape.class, name = "sum"),
+  @JsonSubTypes.Type(value = AggShape.AvgAggShape.class, name = "avg")
+})
 public sealed interface AggShape
     permits AggShape.TermsAggShape,
         AggShape.DateHistogramAggShape,

--- a/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
+++ b/apps/api/main/src/main/java/io/stablepay/api/domain/agent/QueryShape.java
@@ -1,10 +1,21 @@
 package io.stablepay.api.domain.agent;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.Builder;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = QueryShape.TermShape.class, name = "term"),
+  @JsonSubTypes.Type(value = QueryShape.RangeShape.class, name = "range"),
+  @JsonSubTypes.Type(value = QueryShape.MatchPhraseShape.class, name = "match_phrase"),
+  @JsonSubTypes.Type(value = QueryShape.BoolShape.class, name = "bool"),
+  @JsonSubTypes.Type(value = QueryShape.ExistsShape.class, name = "exists"),
+  @JsonSubTypes.Type(value = QueryShape.TermsShape.class, name = "terms")
+})
 public sealed interface QueryShape
     permits QueryShape.TermShape,
         QueryShape.RangeShape,


### PR DESCRIPTION
## SPP Issue
Closes #106

## Changes
- Add `AgentEndpointSecurityBT` — DELETE SQL → 400 + STBLPAY-5002, non-whitelisted field → 400 + STBLPAY-6002, non-AGENT role → 403
- Add `AgentEndpointHappyPathBT` — SQL query returns rows (200), search returns hits (200), timeline found with markdown (200), missing reference → 404 + STBLPAY-3001
- Add `AgentRateLimitBT` — exhausts bucket capacity (10 in BT), verifies 429 + STBLPAY-4001
- Add `AgentTimeoutBT` — stub returns `SqlExecutionResult.Failed`, verifies 503
- Fix `QueryShape` and `AggShape` — add `@JsonTypeInfo(use=NAME)` + `@JsonSubTypes` for Jackson polymorphic deserialization (DEDUCTION fails on identical-signature subtypes like SumAgg/AvgAgg)
- Fix `GlobalExceptionHandler` — re-throw `AccessDeniedException` so Spring Security returns 403 instead of catch-all 500
- Make `StubRepositoryConfig` agent stubs configurable via `AtomicReference` holders for SQL executor, search executor, and timeline lookup
- Make `BusinessTestBase.mintJwt` protected and add `agentJwt()` factory; use dedicated UUIDs in rate-limit/timeout tests for bucket isolation

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] Business tests added (4 new classes, 8 test methods)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)