### PR TITLE
SPP-104: add OpenAPI client codegen via @hey-api/openapi-ts + CI auto-PR workflow

### DIFF
--- a/.github/workflows/ci-openapi-codegen.yml
+++ b/.github/workflows/ci-openapi-codegen.yml
@@ -1,0 +1,64 @@
+name: CI — OpenAPI Client Codegen
+
+on:
+  push:
+    branches: [main]
+    paths: ['apps/api/main/src/main/**', 'apps/api/api/**']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate OpenAPI Client
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: gradle
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '11.0.8'
+
+      - name: Build backend JARs
+        run: ./gradlew :apps:auth:main:bootJar :apps:api:main:bootJar
+
+      - name: Bring up backend dependencies
+        run: |
+          docker compose -f infra/docker-compose.yml up -d postgres redis kafka schema-registry opensearch trino apps-auth apps-api
+          npx wait-on -t 180000 http://localhost:8080/actuator/health
+
+      - name: Regenerate client
+        working-directory: apps/web
+        run: |
+          pnpm install --frozen-lockfile
+          OPENAPI_INPUT=http://localhost:8080/v3/api-docs pnpm exec openapi-ts
+
+      - name: Open PR if diff
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore(web): regenerate OpenAPI client'
+          title: 'chore(web): regenerate OpenAPI client'
+          body: 'API spec changed — review the diff and merge to update the web client.'
+          branch: auto/openapi-codegen
+          add-paths: 'apps/web/src/lib/api-client/_generated/**'
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f infra/docker-compose.yml down -v

--- a/.github/workflows/ci-openapi-codegen.yml
+++ b/.github/workflows/ci-openapi-codegen.yml
@@ -18,23 +18,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
           cache: gradle
 
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: '11.0.8'
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Build backend JARs
         run: ./gradlew :apps:auth:main:bootJar :apps:api:main:bootJar
@@ -51,7 +53,7 @@ jobs:
           OPENAPI_INPUT=http://localhost:8080/v3/api-docs pnpm exec openapi-ts
 
       - name: Open PR if diff
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'chore(web): regenerate OpenAPI client'
           title: 'chore(web): regenerate OpenAPI client'

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -31,5 +31,12 @@
     "rules": {
       "recommended": true
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/lib/api-client/_generated/**"],
+      "formatter": { "enabled": false },
+      "linter": { "enabled": false }
+    }
+  ]
 }

--- a/apps/web/openapi-ts.config.ts
+++ b/apps/web/openapi-ts.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@hey-api/openapi-ts';
+
+export default defineConfig({
+  input: process.env.OPENAPI_INPUT ?? 'http://apps-api:8080/v3/api-docs',
+  output: {
+    path: 'src/lib/api-client/_generated',
+    postProcess: ['biome:check'],
+  },
+  plugins: [
+    {
+      name: '@hey-api/client-fetch',
+      runtimeConfigPath: './src/lib/api-client/hey-api-config.ts',
+    },
+    {
+      name: '@hey-api/typescript',
+      enums: 'javascript',
+    },
+    '@hey-api/sdk',
+  ],
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@auth/core": "0.41.2",
     "@base-ui/react": "1.4.1",
-    "@hey-api/client-fetch": "0.13.1",
     "@tailwindcss/postcss": "4.2.4",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-query-devtools": "5.100.9",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@auth/core": "0.41.2",
     "@base-ui/react": "1.4.1",
+    "@hey-api/client-fetch": "0.13.1",
     "@tailwindcss/postcss": "4.2.4",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-query-devtools": "5.100.9",

--- a/apps/web/src/lib/api-client/hey-api-config.ts
+++ b/apps/web/src/lib/api-client/hey-api-config.ts
@@ -1,0 +1,11 @@
+import { auth } from '~/server/auth';
+import type { CreateClientConfig } from './_generated/client.gen';
+
+export const createClientConfig: CreateClientConfig = (config) => ({
+  ...config,
+  baseUrl: process.env.STABLEPAY_API_INTERNAL_URL ?? 'http://apps-api:8080',
+  auth: async () => {
+    const session = await auth();
+    return session?.accessToken ? `Bearer ${session.accessToken}` : undefined;
+  },
+});

--- a/apps/web/src/lib/api-client/index.ts
+++ b/apps/web/src/lib/api-client/index.ts
@@ -1,0 +1,2 @@
+export * from './_generated';
+export * from './_generated/sdk.gen';

--- a/justfile
+++ b/justfile
@@ -163,6 +163,12 @@ dlq-replay ID *ARGS:
 dlq-replay-class CLASS *ARGS:
     cd apps/dlq-tools && uv run dlq replay-class {{CLASS}} {{ARGS}}
 
+# ─── Web Codegen ─────────────────────────────────
+
+# Regenerate OpenAPI TypeScript client from running API
+web-codegen:
+    cd apps/web && OPENAPI_INPUT=http://localhost:8080/v3/api-docs pnpm exec openapi-ts
+
 # ─── Stubs (expanded in later phases) ─────────────
 
 # Run all tests

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@base-ui/react':
         specifier: 1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@hey-api/client-fetch':
-        specifier: 0.13.1
-        version: 0.13.1(@hey-api/openapi-ts@0.97.1(typescript@6.0.3))
       '@tailwindcss/postcss':
         specifier: 4.2.4
         version: 4.2.4
@@ -579,12 +576,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@hey-api/client-fetch@0.13.1':
-    resolution: {integrity: sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==}
-    deprecated: Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.
-    peerDependencies:
-      '@hey-api/openapi-ts': < 2
 
   '@hey-api/codegen-core@0.8.1':
     resolution: {integrity: sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==}
@@ -4858,10 +4849,6 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@hey-api/client-fetch@0.13.1(@hey-api/openapi-ts@0.97.1(typescript@6.0.3))':
-    dependencies:
-      '@hey-api/openapi-ts': 0.97.1(typescript@6.0.3)
 
   '@hey-api/codegen-core@0.8.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@base-ui/react':
         specifier: 1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@hey-api/client-fetch':
+        specifier: 0.13.1
+        version: 0.13.1(@hey-api/openapi-ts@0.97.1(typescript@6.0.3))
       '@tailwindcss/postcss':
         specifier: 4.2.4
         version: 4.2.4
@@ -576,6 +579,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@hey-api/client-fetch@0.13.1':
+    resolution: {integrity: sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==}
+    deprecated: Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.
+    peerDependencies:
+      '@hey-api/openapi-ts': < 2
 
   '@hey-api/codegen-core@0.8.1':
     resolution: {integrity: sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==}
@@ -4849,6 +4858,10 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@hey-api/client-fetch@0.13.1(@hey-api/openapi-ts@0.97.1(typescript@6.0.3))':
+    dependencies:
+      '@hey-api/openapi-ts': 0.97.1(typescript@6.0.3)
 
   '@hey-api/codegen-core@0.8.1':
     dependencies:


### PR DESCRIPTION
## SPP Issue
Closes #110

## Changes
- Add `openapi-ts.config.ts` with plugin-based config (`@hey-api/client-fetch`, `@hey-api/typescript`, `@hey-api/sdk`)
- Add `hey-api-config.ts` runtime config that wires Auth.js bearer token into every API request via `runtimeConfigPath`
- Add `index.ts` barrel re-export for the generated client
- Add `_generated/.gitkeep` placeholder directory
- Add `@hey-api/client-fetch@0.13.1` as production dependency (exact pin)
- Add `.github/workflows/ci-openapi-codegen.yml` — path-filtered to `apps/api/**`, brings up full Compose stack (postgres, redis, kafka, schema-registry, opensearch, trino, apps-auth, apps-api), runs codegen, opens auto-PR via `peter-evans/create-pull-request@v7`, tears down stack on `always()`
- Update `biome.json` to disable formatter/linter on `_generated/` via overrides
- Add `web-codegen` justfile recipe for local codegen

## Checklist
- [x] `openapi-ts.config.ts` uses plugin-based config
- [x] `runtimeConfigPath` wires auth (bearer token from Auth.js session)
- [x] `output.postProcess: ['biome:check']` replaces removed `format`/`lint` options
- [x] CI workflow path-filtered to `apps/api/**` changes
- [x] CI workflow uses Node.js 22+
- [x] CI workflow uses pnpm 11.0.8
- [x] CI workflow brings up full Compose stack before codegen
- [x] CI workflow tears down stack with `docker compose down -v` on `always()`
- [x] Workflow opens auto-PR if diff exists
- [x] Generated files excluded from Biome + ESLint linting
- [x] Biome check passes
- [x] Lefthook pre-commit hooks pass (trailing-whitespace, gitleaks, commitlint)