### PR TITLE
SPP-108: add Compose service + multi-stage Dockerfile for apps-web

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.git
+.github
+.planning
+.claude
+META-INF
+
+# Java / Gradle
+apps/api
+apps/auth
+apps/flink-jobs
+apps/simulator
+apps/llm-agent
+apps/agent-tools-mcp
+apps/dlq-tools
+apps/lakehouse-jobs
+build
+.gradle
+*.jar
+
+# Node
+**/node_modules
+apps/web/.next
+apps/web/.env*
+
+# Python
+__pycache__
+.venv
+*.pyc
+
+# IDE
+.idea
+.vscode
+*.iml
+
+# Docs & config not needed in image
+docs
+tests
+ops
+schemas
+infra
+*.md
+justfile
+renovate.json

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@11.0.8 --activate
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json apps/web/
+RUN pnpm install --frozen-lockfile
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@11.0.8 --activate
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY . .
+RUN cd apps/web && pnpm exec next build
+
+FROM node:22-alpine AS runner
+RUN apk add --no-cache curl
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
+EXPOSE 3000
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=20s \
+    CMD curl -fs http://localhost:3000/api/health || exit 1
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,1 @@
+export const GET = () => Response.json({ status: 'UP' });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -41,5 +41,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ['/((?!login|api/auth|_next/static|_next/image|favicon|logo-).*)'],
+  matcher: ['/((?!login|api/auth|api/health|_next/static|_next/image|favicon|logo-).*)'],
 };

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -337,6 +337,35 @@ services:
     networks:
       - stablepay_default
 
+  # ─── Web App (Next.js) ─────────────────────────────
+  apps-web:
+    build:
+      context: ..
+      dockerfile: apps/web/Dockerfile
+    container_name: stablepay-web
+    ports:
+      - "3000:3000"
+    environment:
+      STABLEPAY_API_INTERNAL_URL: http://apps-api:8080
+      STABLEPAY_AUTH_INTERNAL_URL: http://apps-auth:9000
+      AUTH_SECRET: ${AUTH_SECRET:-stablepay-dev-secret-change-in-prod}
+      AUTH_TRUST_HOST: "true"
+    depends_on:
+      apps-api:
+        condition: service_healthy
+      apps-auth:
+        condition: service_healthy
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - stablepay_default
+
   # ─── Lakehouse Maintenance Jobs ───────────────────
   # Gated behind the `lakehouse` profile.
   # Run with: docker compose --profile lakehouse up -d lakehouse-jobs

--- a/justfile
+++ b/justfile
@@ -163,6 +163,24 @@ dlq-replay ID *ARGS:
 dlq-replay-class CLASS *ARGS:
     cd apps/dlq-tools && uv run dlq replay-class {{CLASS}} {{ARGS}}
 
+# ─── Web App ──────────────────────────────────────
+
+# Build the web app Docker image
+web-build:
+    docker compose -f infra/docker-compose.yml build apps-web
+
+# Bring up the web app (waits for healthy)
+web-up:
+    docker compose -f infra/docker-compose.yml up -d --wait apps-web
+
+# Follow web app logs
+web-logs:
+    docker compose -f infra/docker-compose.yml logs -f apps-web
+
+# Run Next.js dev server locally (no Docker)
+web-dev:
+    cd apps/web && pnpm dev
+
 # ─── Web Codegen ─────────────────────────────────
 
 # Regenerate OpenAPI TypeScript client from running API


### PR DESCRIPTION
## SPP Issue
Closes #114

## Changes
- Add multi-stage Dockerfile (`deps` → `builder` → `runner`) based on `node:22-alpine` with pnpm 11.0.8, builds Next.js standalone output
- Install `curl` in runner stage for healthcheck (alpine doesn't ship it)
- Add `/api/health` route handler returning `{"status":"UP"}`
- Exclude `/api/health` from Auth.js middleware so Docker healthcheck works unauthenticated
- Add `apps-web` service to `infra/docker-compose.yml` — healthcheck on `/api/health`, depends on `apps-api` + `apps-auth` (`service_healthy`), 512m memory limit, `restart: unless-stopped`
- Add `.dockerignore` at repo root to exclude Java/Python/IDE/docs from build context
- Add justfile recipes: `web-build`, `web-up`, `web-logs`, `web-dev`

## Checklist
- [x] `/api/health` endpoint returns 200 + `{"status":"UP"}`
- [x] Health endpoint excluded from auth middleware
- [x] Docker base image is `node:22-alpine`
- [x] Runner stage installs `curl` (pass-3 fix)
- [x] Service depends on apps-api + apps-auth `service_healthy`
- [x] Memory limit 512m
- [x] `docker compose config` validates successfully
- [x] All 217 existing tests pass (31 test files)
- [x] `just web-dev` runs `pnpm dev` for local development

## Note
Docker image build requires the OpenAPI generated client (`_generated/`) to exist — will work once the CI codegen workflow (SPP-104) runs against a live API.