### PR TITLE
SPP-110: add data layer — typed fetchers, TanStack Query hooks, and terminal status

### DIFF
--- a/apps/web/src/lib/api-client/client-fetch.test.ts
+++ b/apps/web/src/lib/api-client/client-fetch.test.ts
@@ -1,0 +1,70 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, describe, expect, it } from 'vitest';
+import { server } from '~/test/msw-server';
+import { clientFetch, resetTokenCache } from './client-fetch';
+
+describe('clientFetch', () => {
+  afterEach(() => {
+    resetTokenCache();
+  });
+
+  it('fetches data with authorization header from session', async () => {
+    // arrange
+    let capturedAuth = '';
+    server.use(
+      http.get('/api/v1/test', ({ request }) => {
+        capturedAuth = request.headers.get('Authorization') ?? '';
+        return HttpResponse.json({ result: 'ok' });
+      }),
+    );
+
+    // act
+    const data = await clientFetch<{ result: string }>('/api/v1/test');
+
+    // assert
+    expect(data).toEqual({ result: 'ok' });
+    expect(capturedAuth).toBe('Bearer test-access-token');
+  });
+
+  it('throws with error_code from API error response', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/failing', () =>
+        HttpResponse.json(
+          { error_code: 'STBLPAY-4040', message: 'Not found' },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    // act / assert
+    await expect(clientFetch('/api/v1/failing')).rejects.toThrow('STBLPAY-4040');
+  });
+
+  it('throws STBLPAY-1999 when error response has no body', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/empty-error', () => new HttpResponse(null, { status: 500 })),
+    );
+
+    // act / assert
+    await expect(clientFetch('/api/v1/empty-error')).rejects.toThrow('STBLPAY-1999');
+  });
+
+  it('works without access token when session endpoint fails', async () => {
+    // arrange
+    server.use(
+      http.get('/api/auth/session', () => new HttpResponse(null, { status: 500 })),
+      http.get('/api/v1/public', ({ request }) => {
+        const auth = request.headers.get('Authorization');
+        return HttpResponse.json({ hasAuth: !!auth });
+      }),
+    );
+
+    // act
+    const data = await clientFetch<{ hasAuth: boolean }>('/api/v1/public');
+
+    // assert
+    expect(data).toEqual({ hasAuth: false });
+  });
+});

--- a/apps/web/src/lib/api-client/client-fetch.ts
+++ b/apps/web/src/lib/api-client/client-fetch.ts
@@ -1,0 +1,47 @@
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+async function getAccessToken(): Promise<string | undefined> {
+  if (cachedToken && Date.now() < tokenExpiresAt) {
+    return cachedToken;
+  }
+
+  const response = await fetch('/api/auth/session');
+  if (!response.ok) return undefined;
+
+  const session = (await response.json()) as { accessToken?: string };
+  if (session.accessToken) {
+    cachedToken = session.accessToken;
+    tokenExpiresAt = Date.now() + 30_000;
+    return cachedToken;
+  }
+
+  return undefined;
+}
+
+export function resetTokenCache() {
+  cachedToken = null;
+  tokenExpiresAt = 0;
+}
+
+export async function clientFetch<T>(path: string): Promise<T> {
+  const token = await getAccessToken();
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(path, { headers });
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as {
+      error_code?: string;
+      message?: string;
+    } | null;
+    throw new Error(error?.error_code ?? 'STBLPAY-1999');
+  }
+
+  return (await response.json()) as T;
+}

--- a/apps/web/src/lib/api-client/fetcher.ts
+++ b/apps/web/src/lib/api-client/fetcher.ts
@@ -1,0 +1,92 @@
+import 'server-only';
+import { auth } from '~/server/auth';
+import type { ApiError } from '~/types/api';
+
+const BASE_URL = process.env.STABLEPAY_API_INTERNAL_URL ?? 'http://apps-api:8080';
+
+export class ApiResponseError extends Error {
+  constructor(
+    public readonly errorCode: string,
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ApiResponseError';
+  }
+}
+
+interface FetchOptions {
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+async function getAuthHeader(): Promise<string | undefined> {
+  const session = await auth();
+  return session?.accessToken ? `Bearer ${session.accessToken}` : undefined;
+}
+
+export async function apiFetch<T>(path: string, options: FetchOptions = {}): Promise<T> {
+  const authorization = await getAuthHeader();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...options.headers,
+  };
+  if (authorization) {
+    headers.Authorization = authorization;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as ApiError | null;
+    throw new ApiResponseError(
+      error?.error_code ?? 'STBLPAY-1999',
+      error?.message ?? `API request failed with status ${response.status}`,
+      response.status,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function apiFetchNullable<T>(
+  path: string,
+  options: FetchOptions = {},
+): Promise<T | null> {
+  const authorization = await getAuthHeader();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...options.headers,
+  };
+  if (authorization) {
+    headers.Authorization = authorization;
+  }
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as ApiError | null;
+    throw new ApiResponseError(
+      error?.error_code ?? 'STBLPAY-1999',
+      error?.message ?? `API request failed with status ${response.status}`,
+      response.status,
+    );
+  }
+
+  return (await response.json()) as T;
+}

--- a/apps/web/src/lib/data/customer-summary.ts
+++ b/apps/web/src/lib/data/customer-summary.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+import { apiFetchNullable } from '~/lib/api-client/fetcher';
+import type { CustomerSummaryDto } from '~/types/api';
+
+export async function fetchCustomerSummary(customerId: string): Promise<CustomerSummaryDto | null> {
+  return apiFetchNullable<CustomerSummaryDto>(
+    `/api/v1/customers/${encodeURIComponent(customerId)}/summary`,
+  );
+}
+
+export async function fetchAdminCustomerSummary(
+  customerId: string,
+): Promise<CustomerSummaryDto | null> {
+  return apiFetchNullable<CustomerSummaryDto>(
+    `/api/v1/admin/customers/${encodeURIComponent(customerId)}/summary`,
+  );
+}

--- a/apps/web/src/lib/data/dashboard-stats.ts
+++ b/apps/web/src/lib/data/dashboard-stats.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+import { apiFetch } from '~/lib/api-client/fetcher';
+import type { DashboardStatsDto } from '~/types/api';
+
+export async function fetchDashboardStats(): Promise<DashboardStatsDto> {
+  return apiFetch<DashboardStatsDto>('/api/v1/dashboard/stats');
+}
+
+export async function fetchAdminDashboardStats(): Promise<DashboardStatsDto> {
+  return apiFetch<DashboardStatsDto>('/api/v1/admin/dashboard/stats');
+}

--- a/apps/web/src/lib/data/dlq.ts
+++ b/apps/web/src/lib/data/dlq.ts
@@ -1,0 +1,16 @@
+import 'server-only';
+import { apiFetch, apiFetchNullable } from '~/lib/api-client/fetcher';
+import type { CursorPage, DlqEntryDto, DlqSummaryDto } from '~/types/api';
+
+export async function fetchDlqList(cursor?: string): Promise<CursorPage<DlqEntryDto>> {
+  const params = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+  return apiFetch<CursorPage<DlqEntryDto>>(`/api/v1/admin/dlq${params}`);
+}
+
+export async function fetchDlqEntry(id: string): Promise<DlqEntryDto | null> {
+  return apiFetchNullable<DlqEntryDto>(`/api/v1/admin/dlq/${encodeURIComponent(id)}`);
+}
+
+export async function fetchDlqSummary(): Promise<DlqSummaryDto> {
+  return apiFetch<DlqSummaryDto>('/api/v1/admin/dlq/summary');
+}

--- a/apps/web/src/lib/data/flows.ts
+++ b/apps/web/src/lib/data/flows.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+import { apiFetchNullable } from '~/lib/api-client/fetcher';
+import type { FlowDto } from '~/types/api';
+
+export async function fetchFlow(id: string): Promise<FlowDto | null> {
+  return apiFetchNullable<FlowDto>(`/api/v1/flows/${encodeURIComponent(id)}`);
+}
+
+export async function fetchAdminFlow(id: string): Promise<FlowDto | null> {
+  return apiFetchNullable<FlowDto>(`/api/v1/admin/flows/${encodeURIComponent(id)}`);
+}

--- a/apps/web/src/lib/data/index.ts
+++ b/apps/web/src/lib/data/index.ts
@@ -1,0 +1,6 @@
+export { fetchAdminCustomerSummary, fetchCustomerSummary } from './customer-summary';
+export { fetchAdminDashboardStats, fetchDashboardStats } from './dashboard-stats';
+export { fetchDlqEntry, fetchDlqList, fetchDlqSummary } from './dlq';
+export { fetchAdminFlow, fetchFlow } from './flows';
+export { fetchStuckList } from './stuck';
+export { fetchAdminTransaction, fetchTransaction, fetchTransactionsList } from './transactions';

--- a/apps/web/src/lib/data/stuck.ts
+++ b/apps/web/src/lib/data/stuck.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+import { apiFetch } from '~/lib/api-client/fetcher';
+import type { StuckPaymentDto } from '~/types/api';
+
+export async function fetchStuckList(): Promise<StuckPaymentDto[]> {
+  return apiFetch<StuckPaymentDto[]>('/api/v1/admin/stuck');
+}

--- a/apps/web/src/lib/data/transactions.ts
+++ b/apps/web/src/lib/data/transactions.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+import { apiFetch, apiFetchNullable } from '~/lib/api-client/fetcher';
+import type { CursorPage, TransactionDto, TransactionListCriteria } from '~/types/api';
+
+export async function fetchTransactionsList(
+  criteria: TransactionListCriteria = {},
+): Promise<CursorPage<TransactionDto>> {
+  const params = new URLSearchParams();
+  if (criteria.cursor) params.set('cursor', criteria.cursor);
+  if (criteria.limit) params.set('limit', String(criteria.limit));
+  if (criteria.status) params.set('status', criteria.status);
+  if (criteria.direction) params.set('direction', criteria.direction);
+  if (criteria.type) params.set('type', criteria.type);
+  if (criteria.search) params.set('search', criteria.search);
+  if (criteria.from) params.set('from', criteria.from);
+  if (criteria.to) params.set('to', criteria.to);
+
+  const query = params.toString();
+  return apiFetch<CursorPage<TransactionDto>>(`/api/v1/transactions${query ? `?${query}` : ''}`);
+}
+
+export async function fetchTransaction(ref: string): Promise<TransactionDto | null> {
+  return apiFetchNullable<TransactionDto>(`/api/v1/transactions/${encodeURIComponent(ref)}`);
+}
+
+export async function fetchAdminTransaction(ref: string): Promise<TransactionDto | null> {
+  return apiFetchNullable<TransactionDto>(`/api/v1/admin/transactions/${encodeURIComponent(ref)}`);
+}

--- a/apps/web/src/lib/hooks/index.ts
+++ b/apps/web/src/lib/hooks/index.ts
@@ -1,0 +1,7 @@
+export { useDashboardStats } from './use-dashboard-stats';
+export { useDlqDetail } from './use-dlq-detail';
+export { useDlqList } from './use-dlq-list';
+export { useFlowDetail } from './use-flow-detail';
+export { useStuckList } from './use-stuck-list';
+export { useTransactionDetail } from './use-transaction-detail';
+export { useTransactionsList } from './use-transactions-list';

--- a/apps/web/src/lib/hooks/use-dashboard-stats.test.ts
+++ b/apps/web/src/lib/hooks/use-dashboard-stats.test.ts
@@ -1,0 +1,51 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createDashboardStats } from '~/test/fixtures/dashboard';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useDashboardStats } from './use-dashboard-stats';
+
+describe('useDashboardStats', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const stats = createDashboardStats();
+
+    // act
+    const { result } = renderHook(() => useDashboardStats(stats));
+
+    // assert
+    expect(result.current.data).toEqual(stats);
+  });
+
+  it('fetches dashboard stats from the API', async () => {
+    // arrange
+    const stats = createDashboardStats({ transaction_count_24h: 99 });
+    server.use(http.get('/api/v1/dashboard/stats', () => HttpResponse.json(stats)));
+
+    // act
+    const { result } = renderHook(() => useDashboardStats());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.transaction_count_24h).toBe(99);
+    });
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/dashboard/stats', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useDashboardStats());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-dashboard-stats.ts
+++ b/apps/web/src/lib/hooks/use-dashboard-stats.ts
@@ -1,21 +1,14 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import type { DashboardStatsDto } from '~/types/api';
-
-async function fetchDashboardStats(): Promise<DashboardStatsDto> {
-  const response = await fetch('/api/v1/dashboard/stats');
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<DashboardStatsDto>;
-}
 
 export function useDashboardStats(initialData?: DashboardStatsDto) {
   return useQuery({
     queryKey: ['dashboard-stats'],
     initialData,
-    queryFn: fetchDashboardStats,
+    queryFn: () => clientFetch<DashboardStatsDto>('/api/v1/dashboard/stats'),
     refetchInterval: 10_000,
     staleTime: 5_000,
   });

--- a/apps/web/src/lib/hooks/use-dashboard-stats.ts
+++ b/apps/web/src/lib/hooks/use-dashboard-stats.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { DashboardStatsDto } from '~/types/api';
+
+async function fetchDashboardStats(): Promise<DashboardStatsDto> {
+  const response = await fetch('/api/v1/dashboard/stats');
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<DashboardStatsDto>;
+}
+
+export function useDashboardStats(initialData?: DashboardStatsDto) {
+  return useQuery({
+    queryKey: ['dashboard-stats'],
+    initialData,
+    queryFn: fetchDashboardStats,
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-dlq-detail.test.ts
+++ b/apps/web/src/lib/hooks/use-dlq-detail.test.ts
@@ -1,0 +1,52 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createDlqEntry } from '~/test/fixtures/dlq';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useDlqDetail } from './use-dlq-detail';
+
+describe('useDlqDetail', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const entry = createDlqEntry({ id: 'DLQ-100' });
+
+    // act
+    const { result } = renderHook(() => useDlqDetail('DLQ-100', entry));
+
+    // assert
+    expect(result.current.data).toEqual(entry);
+  });
+
+  it('fetches DLQ entry from the API when no initial data provided', async () => {
+    // arrange
+    const entry = createDlqEntry({ id: 'DLQ-200', retry_count: 1 });
+    server.use(http.get('/api/v1/admin/dlq/DLQ-200', () => HttpResponse.json(entry)));
+
+    // act
+    const { result } = renderHook(() => useDlqDetail('DLQ-200'));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.retry_count).toBe(1);
+    });
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    const initial = createDlqEntry({ id: 'DLQ-ERR' });
+    server.use(
+      http.get('/api/v1/admin/dlq/DLQ-ERR', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useDlqDetail('DLQ-ERR', initial));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-dlq-detail.ts
+++ b/apps/web/src/lib/hooks/use-dlq-detail.ts
@@ -1,21 +1,14 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import type { DlqEntryDto } from '~/types/api';
-
-async function fetchDlqEntry(id: string): Promise<DlqEntryDto> {
-  const response = await fetch(`/api/v1/admin/dlq/${encodeURIComponent(id)}`);
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<DlqEntryDto>;
-}
 
 export function useDlqDetail(id: string, initialData?: DlqEntryDto) {
   return useQuery({
-    queryKey: ['dlq', id],
+    queryKey: ['dlq', 'detail', id],
     initialData,
-    queryFn: () => fetchDlqEntry(id),
+    queryFn: () => clientFetch<DlqEntryDto>(`/api/v1/admin/dlq/${encodeURIComponent(id)}`),
     staleTime: 5_000,
   });
 }

--- a/apps/web/src/lib/hooks/use-dlq-detail.ts
+++ b/apps/web/src/lib/hooks/use-dlq-detail.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { DlqEntryDto } from '~/types/api';
+
+async function fetchDlqEntry(id: string): Promise<DlqEntryDto> {
+  const response = await fetch(`/api/v1/admin/dlq/${encodeURIComponent(id)}`);
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<DlqEntryDto>;
+}
+
+export function useDlqDetail(id: string, initialData?: DlqEntryDto) {
+  return useQuery({
+    queryKey: ['dlq', id],
+    initialData,
+    queryFn: () => fetchDlqEntry(id),
+    staleTime: 5_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-dlq-list.test.ts
+++ b/apps/web/src/lib/hooks/use-dlq-list.test.ts
@@ -1,0 +1,71 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createDlqPage } from '~/test/fixtures/dlq';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useDlqList } from './use-dlq-list';
+
+describe('useDlqList', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const page = createDlqPage();
+
+    // act
+    const { result } = renderHook(() => useDlqList(undefined, page));
+
+    // assert
+    expect(result.current.data).toEqual(page);
+  });
+
+  it('fetches DLQ list from the API', async () => {
+    // arrange
+    const page = createDlqPage({ has_more: true, next_cursor: 'cursor-1' });
+    server.use(http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)));
+
+    // act
+    const { result } = renderHook(() => useDlqList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.has_more).toBe(true);
+    });
+  });
+
+  it('passes cursor parameter to the API', async () => {
+    // arrange
+    let capturedUrl = '';
+    server.use(
+      http.get('/api/v1/admin/dlq', ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json(createDlqPage());
+      }),
+    );
+
+    // act
+    const { result } = renderHook(() => useDlqList('page-2'));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(capturedUrl).toContain('cursor=page-2');
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/admin/dlq', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-4030' }, { status: 403 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useDlqList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-dlq-list.ts
+++ b/apps/web/src/lib/hooks/use-dlq-list.ts
@@ -1,22 +1,15 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import type { CursorPage, DlqEntryDto } from '~/types/api';
 
-async function fetchDlqList(cursor?: string): Promise<CursorPage<DlqEntryDto>> {
-  const params = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
-  const response = await fetch(`/api/v1/admin/dlq${params}`);
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<CursorPage<DlqEntryDto>>;
-}
-
 export function useDlqList(cursor?: string, initialData?: CursorPage<DlqEntryDto>) {
+  const params = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
   return useQuery({
-    queryKey: ['dlq', cursor],
+    queryKey: ['dlq', 'list', cursor],
     initialData,
-    queryFn: () => fetchDlqList(cursor),
+    queryFn: () => clientFetch<CursorPage<DlqEntryDto>>(`/api/v1/admin/dlq${params}`),
     staleTime: 5_000,
   });
 }

--- a/apps/web/src/lib/hooks/use-dlq-list.ts
+++ b/apps/web/src/lib/hooks/use-dlq-list.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { CursorPage, DlqEntryDto } from '~/types/api';
+
+async function fetchDlqList(cursor?: string): Promise<CursorPage<DlqEntryDto>> {
+  const params = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+  const response = await fetch(`/api/v1/admin/dlq${params}`);
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<CursorPage<DlqEntryDto>>;
+}
+
+export function useDlqList(cursor?: string, initialData?: CursorPage<DlqEntryDto>) {
+  return useQuery({
+    queryKey: ['dlq', cursor],
+    initialData,
+    queryFn: () => fetchDlqList(cursor),
+    staleTime: 5_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-flow-detail.test.ts
+++ b/apps/web/src/lib/hooks/use-flow-detail.test.ts
@@ -1,0 +1,66 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createFlow } from '~/test/fixtures/flow';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useFlowDetail } from './use-flow-detail';
+
+describe('useFlowDetail', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const flow = createFlow({ id: 'FLOW-100' });
+
+    // act
+    const { result } = renderHook(() => useFlowDetail('FLOW-100', flow));
+
+    // assert
+    expect(result.current.data).toEqual(flow);
+  });
+
+  it('fetches flow data from the API when no initial data provided', async () => {
+    // arrange
+    const flow = createFlow({ id: 'FLOW-200', status: 'COMPLETED' });
+    server.use(http.get('/api/v1/flows/FLOW-200', () => HttpResponse.json(flow)));
+
+    // act
+    const { result } = renderHook(() => useFlowDetail('FLOW-200'));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.status).toBe('COMPLETED');
+    });
+  });
+
+  it('stops polling when status is terminal', async () => {
+    // arrange
+    const flow = createFlow({ status: 'FAILED' });
+    server.use(http.get('/api/v1/flows/FLOW-001', () => HttpResponse.json(flow)));
+
+    // act
+    const { result } = renderHook(() => useFlowDetail('FLOW-001', flow));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data).toEqual(flow);
+    });
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    const initial = createFlow({ id: 'FLOW-ERR', status: 'INITIATED' });
+    server.use(
+      http.get('/api/v1/flows/FLOW-ERR', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useFlowDetail('FLOW-ERR', initial));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-flow-detail.ts
+++ b/apps/web/src/lib/hooks/use-flow-detail.ts
@@ -1,22 +1,15 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import { isTerminal } from '~/lib/terminal-status';
 import type { FlowDto } from '~/types/api';
-
-async function fetchFlow(id: string): Promise<FlowDto> {
-  const response = await fetch(`/api/v1/flows/${encodeURIComponent(id)}`);
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<FlowDto>;
-}
 
 export function useFlowDetail(id: string, initialData?: FlowDto) {
   return useQuery({
     queryKey: ['flow', id],
     initialData,
-    queryFn: () => fetchFlow(id),
+    queryFn: () => clientFetch<FlowDto>(`/api/v1/flows/${encodeURIComponent(id)}`),
     refetchInterval: (query) => (isTerminal(query.state.data?.status) ? false : 3_000),
     staleTime: 1_000,
   });

--- a/apps/web/src/lib/hooks/use-flow-detail.ts
+++ b/apps/web/src/lib/hooks/use-flow-detail.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { isTerminal } from '~/lib/terminal-status';
+import type { FlowDto } from '~/types/api';
+
+async function fetchFlow(id: string): Promise<FlowDto> {
+  const response = await fetch(`/api/v1/flows/${encodeURIComponent(id)}`);
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<FlowDto>;
+}
+
+export function useFlowDetail(id: string, initialData?: FlowDto) {
+  return useQuery({
+    queryKey: ['flow', id],
+    initialData,
+    queryFn: () => fetchFlow(id),
+    refetchInterval: (query) => (isTerminal(query.state.data?.status) ? false : 3_000),
+    staleTime: 1_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-stuck-list.test.ts
+++ b/apps/web/src/lib/hooks/use-stuck-list.test.ts
@@ -1,0 +1,67 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createStuckPayment } from '~/test/fixtures/stuck';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useStuckList } from './use-stuck-list';
+
+describe('useStuckList', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const stuck = [createStuckPayment()];
+
+    // act
+    const { result } = renderHook(() => useStuckList(stuck));
+
+    // assert
+    expect(result.current.data).toEqual(stuck);
+  });
+
+  it('fetches stuck list from the API', async () => {
+    // arrange
+    const stuck = [
+      createStuckPayment({ transaction_ref: 'TXN-S1' }),
+      createStuckPayment({ transaction_ref: 'TXN-S2' }),
+    ];
+    server.use(http.get('/api/v1/admin/stuck', () => HttpResponse.json(stuck)));
+
+    // act
+    const { result } = renderHook(() => useStuckList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2);
+    });
+  });
+
+  it('returns empty array when no stuck payments', async () => {
+    // arrange
+    server.use(http.get('/api/v1/admin/stuck', () => HttpResponse.json([])));
+
+    // act
+    const { result } = renderHook(() => useStuckList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/admin/stuck', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useStuckList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-stuck-list.ts
+++ b/apps/web/src/lib/hooks/use-stuck-list.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { StuckPaymentDto } from '~/types/api';
+
+async function fetchStuckList(): Promise<StuckPaymentDto[]> {
+  const response = await fetch('/api/v1/admin/stuck');
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<StuckPaymentDto[]>;
+}
+
+export function useStuckList(initialData?: StuckPaymentDto[]) {
+  return useQuery({
+    queryKey: ['stuck'],
+    initialData,
+    queryFn: fetchStuckList,
+    staleTime: 10_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-stuck-list.ts
+++ b/apps/web/src/lib/hooks/use-stuck-list.ts
@@ -1,21 +1,14 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import type { StuckPaymentDto } from '~/types/api';
-
-async function fetchStuckList(): Promise<StuckPaymentDto[]> {
-  const response = await fetch('/api/v1/admin/stuck');
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<StuckPaymentDto[]>;
-}
 
 export function useStuckList(initialData?: StuckPaymentDto[]) {
   return useQuery({
     queryKey: ['stuck'],
     initialData,
-    queryFn: fetchStuckList,
+    queryFn: () => clientFetch<StuckPaymentDto[]>('/api/v1/admin/stuck'),
     staleTime: 10_000,
   });
 }

--- a/apps/web/src/lib/hooks/use-transaction-detail.test.ts
+++ b/apps/web/src/lib/hooks/use-transaction-detail.test.ts
@@ -1,0 +1,69 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createTransaction } from '~/test/fixtures/transaction';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useTransactionDetail } from './use-transaction-detail';
+
+describe('useTransactionDetail', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const transaction = createTransaction({ ref: 'TXN-100' });
+
+    // act
+    const { result } = renderHook(() => useTransactionDetail('TXN-100', transaction));
+
+    // assert
+    expect(result.current.data).toEqual(transaction);
+  });
+
+  it('fetches data from the API when no initial data provided', async () => {
+    // arrange
+    const transaction = createTransaction({ ref: 'TXN-200', internal_status: 'COMPLETED' });
+    server.use(http.get('/api/v1/transactions/TXN-200', () => HttpResponse.json(transaction)));
+
+    // act
+    const { result } = renderHook(() => useTransactionDetail('TXN-200'));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.internal_status).toBe('COMPLETED');
+    });
+  });
+
+  it('stops polling when status is terminal', async () => {
+    // arrange
+    const transaction = createTransaction({ internal_status: 'COMPLETED' });
+    server.use(http.get('/api/v1/transactions/TXN-001', () => HttpResponse.json(transaction)));
+
+    // act
+    const { result } = renderHook(() => useTransactionDetail('TXN-001', transaction));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data).toEqual(transaction);
+    });
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    const initial = createTransaction({ ref: 'TXN-ERR', internal_status: 'INITIATED' });
+    server.use(
+      http.get('/api/v1/transactions/TXN-ERR', () =>
+        HttpResponse.json(
+          { error_code: 'STBLPAY-5000', message: 'Internal error' },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useTransactionDetail('TXN-ERR', initial));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-transaction-detail.ts
+++ b/apps/web/src/lib/hooks/use-transaction-detail.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { isTerminal } from '~/lib/terminal-status';
+import type { TransactionDto } from '~/types/api';
+
+async function fetchTransaction(ref: string): Promise<TransactionDto> {
+  const response = await fetch(`/api/v1/transactions/${encodeURIComponent(ref)}`);
+  if (!response.ok) {
+    throw new Error(`STBLPAY-1999`);
+  }
+  return response.json() as Promise<TransactionDto>;
+}
+
+export function useTransactionDetail(ref: string, initialData?: TransactionDto) {
+  return useQuery({
+    queryKey: ['transaction', ref],
+    initialData,
+    queryFn: () => fetchTransaction(ref),
+    refetchInterval: (query) => (isTerminal(query.state.data?.internal_status) ? false : 3_000),
+    staleTime: 1_000,
+  });
+}

--- a/apps/web/src/lib/hooks/use-transaction-detail.ts
+++ b/apps/web/src/lib/hooks/use-transaction-detail.ts
@@ -1,22 +1,16 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import { isTerminal } from '~/lib/terminal-status';
 import type { TransactionDto } from '~/types/api';
-
-async function fetchTransaction(ref: string): Promise<TransactionDto> {
-  const response = await fetch(`/api/v1/transactions/${encodeURIComponent(ref)}`);
-  if (!response.ok) {
-    throw new Error(`STBLPAY-1999`);
-  }
-  return response.json() as Promise<TransactionDto>;
-}
 
 export function useTransactionDetail(ref: string, initialData?: TransactionDto) {
   return useQuery({
     queryKey: ['transaction', ref],
     initialData,
-    queryFn: () => fetchTransaction(ref),
+    queryFn: () =>
+      clientFetch<TransactionDto>(`/api/v1/transactions/${encodeURIComponent(ref)}`),
     refetchInterval: (query) => (isTerminal(query.state.data?.internal_status) ? false : 3_000),
     staleTime: 1_000,
   });

--- a/apps/web/src/lib/hooks/use-transactions-list.test.ts
+++ b/apps/web/src/lib/hooks/use-transactions-list.test.ts
@@ -1,0 +1,72 @@
+import { waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { createTransactionPage } from '~/test/fixtures/transaction';
+import { server } from '~/test/msw-server';
+import { renderHook } from '~/test/render';
+import { useTransactionsList } from './use-transactions-list';
+
+describe('useTransactionsList', () => {
+  it('returns initial data immediately', () => {
+    // arrange
+    const page = createTransactionPage();
+
+    // act
+    const { result } = renderHook(() => useTransactionsList({}, page));
+
+    // assert
+    expect(result.current.data).toEqual(page);
+  });
+
+  it('fetches transaction list from the API', async () => {
+    // arrange
+    const page = createTransactionPage({ has_more: true, next_cursor: 'abc' });
+    server.use(http.get('/api/v1/transactions', () => HttpResponse.json(page)));
+
+    // act
+    const { result } = renderHook(() => useTransactionsList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.data?.has_more).toBe(true);
+    });
+  });
+
+  it('passes query parameters to the API', async () => {
+    // arrange
+    let capturedUrl = '';
+    server.use(
+      http.get('/api/v1/transactions', ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json(createTransactionPage());
+      }),
+    );
+
+    // act
+    const { result } = renderHook(() => useTransactionsList({ status: 'COMPLETED', limit: 10 }));
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(capturedUrl).toContain('status=COMPLETED');
+    expect(capturedUrl).toContain('limit=10');
+  });
+
+  it('throws on API error', async () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/transactions', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+
+    // act
+    const { result } = renderHook(() => useTransactionsList());
+
+    // assert
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+});

--- a/apps/web/src/lib/hooks/use-transactions-list.ts
+++ b/apps/web/src/lib/hooks/use-transactions-list.ts
@@ -1,11 +1,10 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { clientFetch } from '~/lib/api-client/client-fetch';
 import type { CursorPage, TransactionDto, TransactionListCriteria } from '~/types/api';
 
-async function fetchTransactions(
-  criteria: TransactionListCriteria,
-): Promise<CursorPage<TransactionDto>> {
+function buildTransactionQuery(criteria: TransactionListCriteria): string {
   const params = new URLSearchParams();
   if (criteria.cursor) params.set('cursor', criteria.cursor);
   if (criteria.limit) params.set('limit', String(criteria.limit));
@@ -15,13 +14,8 @@ async function fetchTransactions(
   if (criteria.search) params.set('search', criteria.search);
   if (criteria.from) params.set('from', criteria.from);
   if (criteria.to) params.set('to', criteria.to);
-
   const query = params.toString();
-  const response = await fetch(`/api/v1/transactions${query ? `?${query}` : ''}`);
-  if (!response.ok) {
-    throw new Error('STBLPAY-1999');
-  }
-  return response.json() as Promise<CursorPage<TransactionDto>>;
+  return `/api/v1/transactions${query ? `?${query}` : ''}`;
 }
 
 export function useTransactionsList(
@@ -31,7 +25,7 @@ export function useTransactionsList(
   return useQuery({
     queryKey: ['transactions', criteria],
     initialData,
-    queryFn: () => fetchTransactions(criteria),
+    queryFn: () => clientFetch<CursorPage<TransactionDto>>(buildTransactionQuery(criteria)),
     staleTime: 5_000,
   });
 }

--- a/apps/web/src/lib/hooks/use-transactions-list.ts
+++ b/apps/web/src/lib/hooks/use-transactions-list.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { CursorPage, TransactionDto, TransactionListCriteria } from '~/types/api';
+
+async function fetchTransactions(
+  criteria: TransactionListCriteria,
+): Promise<CursorPage<TransactionDto>> {
+  const params = new URLSearchParams();
+  if (criteria.cursor) params.set('cursor', criteria.cursor);
+  if (criteria.limit) params.set('limit', String(criteria.limit));
+  if (criteria.status) params.set('status', criteria.status);
+  if (criteria.direction) params.set('direction', criteria.direction);
+  if (criteria.type) params.set('type', criteria.type);
+  if (criteria.search) params.set('search', criteria.search);
+  if (criteria.from) params.set('from', criteria.from);
+  if (criteria.to) params.set('to', criteria.to);
+
+  const query = params.toString();
+  const response = await fetch(`/api/v1/transactions${query ? `?${query}` : ''}`);
+  if (!response.ok) {
+    throw new Error('STBLPAY-1999');
+  }
+  return response.json() as Promise<CursorPage<TransactionDto>>;
+}
+
+export function useTransactionsList(
+  criteria: TransactionListCriteria = {},
+  initialData?: CursorPage<TransactionDto>,
+) {
+  return useQuery({
+    queryKey: ['transactions', criteria],
+    initialData,
+    queryFn: () => fetchTransactions(criteria),
+    staleTime: 5_000,
+  });
+}

--- a/apps/web/src/lib/terminal-status.test.ts
+++ b/apps/web/src/lib/terminal-status.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isTerminal } from './terminal-status';
+
+describe('isTerminal', () => {
+  it.each([
+    'COMPLETED',
+    'FAILED',
+    'CANCELLED',
+    'EXPIRED',
+    'REFUND_COMPLETED',
+    'CONFISCATED',
+    'REPLACED',
+  ])('returns true for terminal status %s', (status) => {
+    // arrange / act / assert
+    expect(isTerminal(status)).toBe(true);
+  });
+
+  it.each([
+    'INITIATED',
+    'PENDING_SCREENING',
+    'SCREENING_IN_PROGRESS',
+    'PENDING_APPROVAL',
+    'EXECUTING',
+    'BROADCASTING',
+    'CONFIRMING',
+  ])('returns false for non-terminal status %s', (status) => {
+    // arrange / act / assert
+    expect(isTerminal(status)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    // arrange / act / assert
+    expect(isTerminal(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    // arrange / act / assert
+    expect(isTerminal('')).toBe(false);
+  });
+
+  it('covers exactly 7 terminal states', () => {
+    // arrange
+    const allTerminal = [
+      'COMPLETED',
+      'FAILED',
+      'CANCELLED',
+      'EXPIRED',
+      'REFUND_COMPLETED',
+      'CONFISCATED',
+      'REPLACED',
+    ];
+
+    // act / assert
+    expect(allTerminal.filter((s) => isTerminal(s))).toHaveLength(7);
+  });
+});

--- a/apps/web/src/lib/terminal-status.ts
+++ b/apps/web/src/lib/terminal-status.ts
@@ -1,0 +1,13 @@
+const TERMINAL = new Set([
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+  'EXPIRED',
+  'REFUND_COMPLETED',
+  'CONFISCATED',
+  'REPLACED',
+]);
+
+export function isTerminal(status?: string): boolean {
+  return status != null && TERMINAL.has(status);
+}

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -3,7 +3,7 @@ import { cleanup } from '@testing-library/react';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { server } from '~/test/msw-server';
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   server.resetHandlers();
   cleanup();

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,10 +1,14 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from '~/test/msw-server';
 
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => {
+  server.resetHandlers();
   cleanup();
 });
+afterAll(() => server.close());
 
 // jsdom stubs for browser APIs
 if (typeof window !== 'undefined') {

--- a/apps/web/src/test/fixtures/customer-summary.ts
+++ b/apps/web/src/test/fixtures/customer-summary.ts
@@ -1,0 +1,13 @@
+import type { CustomerSummaryDto } from '~/types/api';
+
+const defaults: CustomerSummaryDto = {
+  customer_id: 'CUST-001',
+  total_transactions: 128,
+  total_volume: { amount: 5_000_000, currency: 'USD' },
+  active_flows: 3,
+  last_activity_at: '2026-01-15T10:30:00Z',
+};
+
+export function createCustomerSummary(overrides?: Partial<CustomerSummaryDto>): CustomerSummaryDto {
+  return { ...defaults, ...overrides };
+}

--- a/apps/web/src/test/fixtures/dashboard.ts
+++ b/apps/web/src/test/fixtures/dashboard.ts
@@ -1,0 +1,13 @@
+import type { DashboardStatsDto } from '~/types/api';
+
+const defaults: DashboardStatsDto = {
+  volume_24h: { amount: 1_250_000, currency: 'USD' },
+  transaction_count_24h: 42,
+  success_rate_24h: 0.95,
+  dlq_count: 3,
+  stuck_count: 1,
+};
+
+export function createDashboardStats(overrides?: Partial<DashboardStatsDto>): DashboardStatsDto {
+  return { ...defaults, ...overrides };
+}

--- a/apps/web/src/test/fixtures/dlq.ts
+++ b/apps/web/src/test/fixtures/dlq.ts
@@ -1,0 +1,40 @@
+import type { CursorPage, DlqEntryDto, DlqSummaryDto } from '~/types/api';
+
+const defaults: DlqEntryDto = {
+  id: 'DLQ-001',
+  topic: 'fiat.payin.events.v1',
+  error_class: 'SCHEMA_INVALID',
+  error_message: 'Missing required field: amount',
+  event_key: 'TXN-FAIL-001',
+  event_payload: '{"ref":"TXN-FAIL-001"}',
+  retry_count: 0,
+  created_at: '2026-01-15T11:00:00Z',
+  updated_at: '2026-01-15T11:00:00Z',
+};
+
+export function createDlqEntry(overrides?: Partial<DlqEntryDto>): DlqEntryDto {
+  return { ...defaults, ...overrides };
+}
+
+export function createDlqPage(
+  overrides?: Partial<CursorPage<DlqEntryDto>>,
+): CursorPage<DlqEntryDto> {
+  return {
+    data: [createDlqEntry()],
+    next_cursor: null,
+    has_more: false,
+    ...overrides,
+  };
+}
+
+export function createDlqSummary(overrides?: Partial<DlqSummaryDto>): DlqSummaryDto {
+  return {
+    total: 3,
+    by_error_class: {
+      SCHEMA_INVALID: 1,
+      PROCESSING_FAILED: 1,
+      LATE_EVENT: 1,
+    },
+    ...overrides,
+  };
+}

--- a/apps/web/src/test/fixtures/flow.ts
+++ b/apps/web/src/test/fixtures/flow.ts
@@ -1,0 +1,34 @@
+import type { FlowDto } from '~/types/api';
+
+const defaults: FlowDto = {
+  id: 'FLOW-001',
+  customer_id: 'CUST-001',
+  flow_type: 'FIAT_PAYOUT',
+  status: 'COMPLETED',
+  source_amount: { amount: 100_000, currency: 'USD' },
+  destination_amount: { amount: 92_000, currency: 'EUR' },
+  legs: [
+    {
+      leg_index: 0,
+      transaction_ref: 'TXN-001',
+      direction: 'PAYIN',
+      type: 'FIAT',
+      status: 'COMPLETED',
+      amount: { amount: 100_000, currency: 'USD' },
+    },
+    {
+      leg_index: 1,
+      transaction_ref: 'TXN-002',
+      direction: 'PAYOUT',
+      type: 'FIAT',
+      status: 'COMPLETED',
+      amount: { amount: 92_000, currency: 'EUR' },
+    },
+  ],
+  created_at: '2026-01-15T10:30:00Z',
+  updated_at: '2026-01-15T10:40:00Z',
+};
+
+export function createFlow(overrides?: Partial<FlowDto>): FlowDto {
+  return { ...defaults, ...overrides };
+}

--- a/apps/web/src/test/fixtures/stuck.ts
+++ b/apps/web/src/test/fixtures/stuck.ts
@@ -1,0 +1,15 @@
+import type { StuckPaymentDto } from '~/types/api';
+
+const defaults: StuckPaymentDto = {
+  transaction_ref: 'TXN-STUCK-001',
+  flow_id: 'FLOW-STUCK-001',
+  customer_id: 'CUST-001',
+  status: 'STUCK',
+  amount: { amount: 50_000, currency: 'USD' },
+  stuck_since: '2026-01-14T08:00:00Z',
+  stuck_reason: 'Partner timeout after 24h',
+};
+
+export function createStuckPayment(overrides?: Partial<StuckPaymentDto>): StuckPaymentDto {
+  return { ...defaults, ...overrides };
+}

--- a/apps/web/src/test/fixtures/transaction.ts
+++ b/apps/web/src/test/fixtures/transaction.ts
@@ -1,0 +1,29 @@
+import type { CursorPage, TransactionDto } from '~/types/api';
+
+const defaults: TransactionDto = {
+  ref: 'TXN-001',
+  flow_id: 'FLOW-001',
+  customer_id: 'CUST-001',
+  direction: 'PAYIN',
+  type: 'FIAT',
+  internal_status: 'COMPLETED',
+  customer_status: 'COMPLETED',
+  amount: { amount: 150_000, currency: 'USD' },
+  created_at: '2026-01-15T10:30:00Z',
+  updated_at: '2026-01-15T10:35:00Z',
+};
+
+export function createTransaction(overrides?: Partial<TransactionDto>): TransactionDto {
+  return { ...defaults, ...overrides };
+}
+
+export function createTransactionPage(
+  overrides?: Partial<CursorPage<TransactionDto>>,
+): CursorPage<TransactionDto> {
+  return {
+    data: [createTransaction()],
+    next_cursor: null,
+    has_more: false,
+    ...overrides,
+  };
+}

--- a/apps/web/src/test/msw-server.ts
+++ b/apps/web/src/test/msw-server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from 'msw/node';
+
+export const server = setupServer();

--- a/apps/web/src/test/msw-server.ts
+++ b/apps/web/src/test/msw-server.ts
@@ -1,3 +1,8 @@
+import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 
-export const server = setupServer();
+export const server = setupServer(
+  http.get('/api/auth/session', () =>
+    HttpResponse.json({ accessToken: 'test-access-token' }),
+  ),
+);

--- a/apps/web/src/test/render.tsx
+++ b/apps/web/src/test/render.tsx
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  type RenderHookOptions,
+  type RenderOptions,
+  render,
+  renderHook,
+} from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function renderWithProviders(ui: ReactElement, options?: RenderOptions) {
+  return render(ui, { wrapper: createWrapper(), ...options });
+}
+
+function renderHookWithProviders<TResult, TProps>(
+  hook: (props: TProps) => TResult,
+  options?: RenderHookOptions<TProps>,
+) {
+  return renderHook(hook, { wrapper: createWrapper(), ...options });
+}
+
+export { renderHookWithProviders as renderHook, renderWithProviders as render };

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -1,0 +1,107 @@
+export interface MoneyDto {
+  amount: number;
+  currency: string;
+}
+
+export interface TransactionDto {
+  ref: string;
+  flow_id: string;
+  customer_id: string;
+  direction: 'PAYIN' | 'PAYOUT';
+  type: 'FIAT' | 'CRYPTO';
+  internal_status: string;
+  customer_status: string;
+  amount: MoneyDto;
+  fee?: MoneyDto;
+  counterparty?: string;
+  blockchain?: string;
+  tx_hash?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CursorPage<T> {
+  data: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface TransactionListCriteria {
+  cursor?: string;
+  limit?: number;
+  status?: string;
+  direction?: string;
+  type?: string;
+  search?: string;
+  from?: string;
+  to?: string;
+}
+
+export interface FlowDto {
+  id: string;
+  customer_id: string;
+  flow_type: string;
+  status: string;
+  source_amount: MoneyDto;
+  destination_amount?: MoneyDto;
+  legs: FlowLegDto[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FlowLegDto {
+  leg_index: number;
+  transaction_ref: string;
+  direction: 'PAYIN' | 'PAYOUT';
+  type: 'FIAT' | 'CRYPTO';
+  status: string;
+  amount: MoneyDto;
+}
+
+export interface DlqEntryDto {
+  id: string;
+  topic: string;
+  error_class: string;
+  error_message: string;
+  event_key: string;
+  event_payload: string;
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DlqSummaryDto {
+  total: number;
+  by_error_class: Record<string, number>;
+}
+
+export interface StuckPaymentDto {
+  transaction_ref: string;
+  flow_id: string;
+  customer_id: string;
+  status: string;
+  amount: MoneyDto;
+  stuck_since: string;
+  stuck_reason: string;
+}
+
+export interface CustomerSummaryDto {
+  customer_id: string;
+  total_transactions: number;
+  total_volume: MoneyDto;
+  active_flows: number;
+  last_activity_at: string;
+}
+
+export interface DashboardStatsDto {
+  volume_24h: MoneyDto;
+  transaction_count_24h: number;
+  success_rate_24h: number;
+  dlq_count: number;
+  stuck_count: number;
+}
+
+export interface ApiError {
+  error_code: string;
+  message: string;
+}


### PR DESCRIPTION
## SPP Issue
Closes #116

## Changes
- Add auth-aware `apiFetch` / `apiFetchNullable` helper in `lib/api-client/fetcher.ts` — handles JWT injection, 404→null, and STBLPAY-XXXX error code preservation
- Add 6 server-side fetchers in `lib/data/` (transactions, flows, dlq, stuck, customer-summary, dashboard-stats) using `import 'server-only'` for RSC usage
- Add 7 TanStack Query hooks in `lib/hooks/` — `useTransactionDetail` and `useFlowDetail` poll every 3s while `!isTerminal(status)` per WEB-05; `useDashboardStats` polls every 10s
- Add `terminal-status.ts` covering all 7 terminal states (COMPLETED, FAILED, CANCELLED, EXPIRED, REFUND_COMPLETED, CONFISCATED, REPLACED)
- Add API response types in `types/api.ts` for all 6 domain surfaces (placeholder until OpenAPI codegen from SPP-104 runs)
- Add test infrastructure: MSW server in global test setup, `renderHook` helper with QueryClientProvider, 6 fixture factories in `test/fixtures/`
- Wire MSW lifecycle (listen/resetHandlers/close) into `test-setup.ts`

## Test Results
- 39 test files, 260 tests — all passing
- 8 new test files covering all hooks + terminal-status
- No new TypeScript errors (4 pre-existing from empty `_generated/`)

## Checklist
- [x] `pnpm vitest run` passes (260/260)
- [x] Biome lint + format clean
- [x] Unit tests added for all hooks and terminal-status
- [x] Co-located test files per FE_TESTING_STANDARDS
- [x] Fixture factories per entity in `test/fixtures/`
- [x] MSW for API mocking (no React Query internal mocking)
- [x] `// arrange`, `// act`, `// assert` markers in all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data fetching capabilities for dashboard statistics, transactions, flows, and dead-letter queue management.
  * Integrated real-time polling for transaction and flow status updates.
  * Enabled pagination support for transaction and DLQ entry lists.

* **Tests**
  * Comprehensive test coverage for data fetching and client-side hooks.

* **Chores**
  * Added test utilities and fixtures for API responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Puneethkumarck/stablepay-payment-pipeline/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->