### PR TITLE
SPP-116: add admin DLQ list and detail pages with replay flow

### DIFF
--- a/apps/web/src/app/(authed)/admin/dlq/[id]/loading.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/[id]/loading.tsx
@@ -1,0 +1,52 @@
+import { Skeleton } from '~/components/ui/skeleton';
+
+export default function DlqDetailLoading() {
+  return (
+    <div className="page" data-testid="dlq-detail-loading">
+      {/* Back link */}
+      <Skeleton className="h-[28px] w-[110px] rounded-md" />
+
+      {/* Header */}
+      <div className="mt-4 mb-5">
+        <Skeleton className="mb-1 h-[11px] w-[70px]" />
+        <Skeleton className="h-[28px] w-[160px]" />
+      </div>
+
+      {/* KV grid */}
+      <div className="rounded-card border border-border-1 bg-surface-2 px-5 py-2">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between border-b border-[rgba(255,255,255,0.05)] py-[9px] last:border-b-0"
+          >
+            <Skeleton className="h-[11px] w-[80px]" />
+            <Skeleton className="h-[11px] w-[140px]" />
+          </div>
+        ))}
+      </div>
+
+      {/* Error message */}
+      <div className="mt-5">
+        <Skeleton className="mb-3 h-[11px] w-[100px]" />
+        <Skeleton className="h-[120px] w-full rounded-md" />
+      </div>
+
+      {/* Event payload */}
+      <div className="mt-5">
+        <Skeleton className="mb-3 h-[11px] w-[100px]" />
+        <Skeleton className="h-[80px] w-full rounded-md" />
+      </div>
+
+      {/* Replay section */}
+      <div className="mt-5 rounded-card border border-border-1 bg-surface-2 px-5 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-[13px] w-[50px]" />
+            <Skeleton className="mt-1 h-[11px] w-[240px]" />
+          </div>
+          <Skeleton className="h-[24px] w-[60px] rounded-md" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/dlq/[id]/not-found.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/[id]/not-found.tsx
@@ -1,0 +1,9 @@
+import { NotFoundCard } from '~/components/not-found-card';
+
+export default function DlqNotFound() {
+  return (
+    <div className="page flex items-center justify-center pt-20">
+      <NotFoundCard />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/dlq/[id]/page.test.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/[id]/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createDlqEntry } from '~/test/fixtures/dlq';
+
+const mockNotFound = vi.fn();
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    mockNotFound();
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+
+vi.mock('~/lib/data', () => ({
+  fetchDlqEntry: vi.fn(),
+}));
+
+vi.mock('~/components/dlq/dlq-detail', () => ({
+  DlqDetail: ({ dlqId, initialData }: { dlqId: string; initialData: unknown }) => (
+    <div data-testid="dlq-detail-mock">
+      {dlqId} {JSON.stringify(!!initialData)}
+    </div>
+  ),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query',
+  );
+  return {
+    ...actual,
+    dehydrate: () => ({}),
+    HydrationBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { fetchDlqEntry } from '~/lib/data';
+import DlqDetailPage from './page';
+
+const mockFetch = vi.mocked(fetchDlqEntry);
+const params = Promise.resolve({ id: 'DLQ-TEST-001' });
+
+async function renderPage() {
+  const jsx = await DlqDetailPage({ params });
+  render(jsx);
+}
+
+describe('DlqDetailPage', () => {
+  it('calls notFound when entry is null', async () => {
+    // arrange
+    mockFetch.mockResolvedValue(null);
+
+    // act + assert
+    await expect(renderPage()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it('renders DlqDetail with fetched entry', async () => {
+    // arrange
+    mockFetch.mockResolvedValue(createDlqEntry({ id: 'DLQ-TEST-001' }));
+
+    // act
+    await renderPage();
+
+    // assert
+    expect(screen.getByTestId('dlq-detail-mock')).toHaveTextContent('DLQ-TEST-001');
+    expect(mockFetch).toHaveBeenCalledWith('DLQ-TEST-001');
+  });
+});

--- a/apps/web/src/app/(authed)/admin/dlq/[id]/page.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { notFound } from 'next/navigation';
+import { DlqDetail } from '~/components/dlq/dlq-detail';
+import { fetchDlqEntry } from '~/lib/data';
+
+export default async function DlqDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const entry = await fetchDlqEntry(id);
+  if (!entry) notFound();
+
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(['dlq', 'detail', id], entry);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <DlqDetail dlqId={id} initialData={entry} />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/dlq/loading.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/loading.tsx
@@ -1,0 +1,50 @@
+import { Skeleton } from '~/components/ui/skeleton';
+
+export default function DlqListLoading() {
+  return (
+    <div className="page" data-testid="dlq-list-loading">
+      <Skeleton className="mb-1 h-[11px] w-[50px]" />
+      <Skeleton className="mb-5 h-[28px] w-[180px]" />
+
+      {/* Breakdown cards */}
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-card border border-border-1 bg-surface-2 px-4 py-3">
+            <Skeleton className="mb-2 h-[11px] w-[80px]" />
+            <Skeleton className="h-[22px] w-[40px]" />
+          </div>
+        ))}
+      </div>
+
+      {/* Search bar */}
+      <Skeleton className="mb-4 h-[34px] w-[340px] rounded-[9px]" />
+
+      {/* Table */}
+      <div className="rounded-card border border-border-1 bg-surface-2">
+        <div className="border-b border-border-1 px-[14px] py-[9px]">
+          <div className="flex gap-4">
+            <Skeleton className="h-[11px] w-[80px]" />
+            <Skeleton className="h-[11px] w-[70px]" />
+            <Skeleton className="h-[11px] w-[90px]" />
+            <Skeleton className="h-[11px] w-[50px]" />
+            <Skeleton className="h-[11px] w-[60px]" />
+            <Skeleton className="h-[11px] w-[60px]" />
+          </div>
+        </div>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b border-border-1 px-[14px] py-[11px] last:border-b-0"
+          >
+            <Skeleton className="h-[11px] w-[100px]" />
+            <Skeleton className="h-[16px] w-[90px] rounded-full" />
+            <Skeleton className="h-[11px] w-[120px]" />
+            <Skeleton className="h-[11px] w-[30px]" />
+            <Skeleton className="h-[11px] w-[80px]" />
+            <Skeleton className="h-[24px] w-[60px] rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/dlq/page.test.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/page.test.tsx
@@ -8,11 +8,7 @@ vi.mock('~/lib/data', () => ({
 }));
 
 vi.mock('~/components/dlq/dlq-list', () => ({
-  DlqList: ({ initialData, initialSummary }: { initialData: unknown; initialSummary: unknown }) => (
-    <div data-testid="dlq-list-mock">
-      {JSON.stringify({ hasData: !!initialData, hasSummary: !!initialSummary })}
-    </div>
-  ),
+  DlqList: () => <div data-testid="dlq-list-mock">DlqList</div>,
 }));
 
 vi.mock('@tanstack/react-query', async () => {

--- a/apps/web/src/app/(authed)/admin/dlq/page.test.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createDlqPage, createDlqSummary } from '~/test/fixtures/dlq';
+
+vi.mock('~/lib/data', () => ({
+  fetchDlqList: vi.fn(),
+  fetchDlqSummary: vi.fn(),
+}));
+
+vi.mock('~/components/dlq/dlq-list', () => ({
+  DlqList: ({ initialData, initialSummary }: { initialData: unknown; initialSummary: unknown }) => (
+    <div data-testid="dlq-list-mock">
+      {JSON.stringify({ hasData: !!initialData, hasSummary: !!initialSummary })}
+    </div>
+  ),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query',
+  );
+  return {
+    ...actual,
+    dehydrate: () => ({}),
+    HydrationBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { fetchDlqList, fetchDlqSummary } from '~/lib/data';
+import DlqListPage from './page';
+
+const mockFetchList = vi.mocked(fetchDlqList);
+const mockFetchSummary = vi.mocked(fetchDlqSummary);
+
+describe('DlqListPage', () => {
+  it('prefetches DLQ list and summary then renders DlqList', async () => {
+    // arrange
+    mockFetchList.mockResolvedValue(createDlqPage());
+    mockFetchSummary.mockResolvedValue(createDlqSummary());
+
+    // act
+    const jsx = await DlqListPage();
+    render(jsx);
+
+    // assert
+    expect(screen.getByTestId('dlq-list-mock')).toBeInTheDocument();
+    expect(mockFetchList).toHaveBeenCalled();
+    expect(mockFetchSummary).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(authed)/admin/dlq/page.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/page.tsx
@@ -1,0 +1,24 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { DlqList } from '~/components/dlq/dlq-list';
+import { fetchDlqList, fetchDlqSummary } from '~/lib/data';
+
+export default async function DlqListPage() {
+  const queryClient = new QueryClient();
+
+  const [listData, summaryData] = await Promise.all([
+    queryClient.fetchQuery({
+      queryKey: ['dlq', 'list', undefined],
+      queryFn: () => fetchDlqList(),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ['dlq', 'summary'],
+      queryFn: () => fetchDlqSummary(),
+    }),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <DlqList initialData={listData} initialSummary={summaryData} />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/dlq/page.tsx
+++ b/apps/web/src/app/(authed)/admin/dlq/page.tsx
@@ -5,12 +5,12 @@ import { fetchDlqList, fetchDlqSummary } from '~/lib/data';
 export default async function DlqListPage() {
   const queryClient = new QueryClient();
 
-  const [listData, summaryData] = await Promise.all([
-    queryClient.fetchQuery({
+  await Promise.all([
+    queryClient.prefetchQuery({
       queryKey: ['dlq', 'list', undefined],
       queryFn: () => fetchDlqList(),
     }),
-    queryClient.fetchQuery({
+    queryClient.prefetchQuery({
       queryKey: ['dlq', 'summary'],
       queryFn: () => fetchDlqSummary(),
     }),
@@ -18,7 +18,7 @@ export default async function DlqListPage() {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <DlqList initialData={listData} initialSummary={summaryData} />
+      <DlqList />
     </HydrationBoundary>
   );
 }

--- a/apps/web/src/components/dlq/dlq-detail.test.tsx
+++ b/apps/web/src/components/dlq/dlq-detail.test.tsx
@@ -1,0 +1,145 @@
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createDlqEntry } from '~/test/fixtures/dlq';
+import { render } from '~/test/render';
+import { DlqDetail } from './dlq-detail';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('~/components/dlq/replay-button', () => ({
+  ReplayButton: ({
+    dlqId,
+    errorClass,
+    retryCount,
+  }: {
+    dlqId: string;
+    errorClass: string;
+    retryCount: number;
+  }) => (
+    <button data-testid="replay-button-mock">
+      {dlqId} {errorClass} {retryCount}
+    </button>
+  ),
+}));
+
+vi.mock('~/components/dlq-error-block', () => ({
+  DlqErrorBlock: ({ message }: { message: string }) => (
+    <pre data-testid="dlq-error-block">{message}</pre>
+  ),
+}));
+
+vi.mock('~/components/status-badge', () => ({
+  StatusBadge: ({ status }: { status: string }) => <span data-testid="status-badge">{status}</span>,
+}));
+
+describe('DlqDetail', () => {
+  it('renders back link to DLQ list', () => {
+    // arrange
+    const entry = createDlqEntry();
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const link = screen.getByTestId('dlq-back-link');
+    expect(link).toHaveAttribute('href', '/admin/dlq');
+  });
+
+  it('renders DLQ ID as page title', () => {
+    // arrange
+    const entry = createDlqEntry({ id: 'DLQ-TITLE' });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('DLQ-TITLE');
+  });
+
+  it('renders KV grid with all entry fields', () => {
+    // arrange
+    const entry = createDlqEntry({
+      id: 'DLQ-KV',
+      topic: 'fiat.payin.events.v1',
+      event_key: 'TXN-FAIL-001',
+      retry_count: 1,
+    });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const grid = screen.getByTestId('dlq-kv-grid');
+    expect(within(grid).getByText('DLQ-KV')).toBeInTheDocument();
+    expect(within(grid).getByText('fiat.payin.events.v1')).toBeInTheDocument();
+    expect(within(grid).getByText('TXN-FAIL-001')).toBeInTheDocument();
+    expect(within(grid).getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders error class via StatusBadge', () => {
+    // arrange
+    const entry = createDlqEntry({ error_class: 'PROCESSING_FAILED' });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const badge = screen.getByTestId('status-badge');
+    expect(badge).toHaveTextContent('PROCESSING_FAILED');
+  });
+
+  it('renders error message block', () => {
+    // arrange
+    const entry = createDlqEntry({ error_message: 'Some detailed error' });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const blocks = screen.getAllByTestId('dlq-error-block');
+    expect(blocks[0]).toHaveTextContent('Some detailed error');
+  });
+
+  it('renders event payload block', () => {
+    // arrange
+    const entry = createDlqEntry({ event_payload: '{"ref":"TXN-001"}' });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const blocks = screen.getAllByTestId('dlq-error-block');
+    expect(blocks[1]).toHaveTextContent('{"ref":"TXN-001"}');
+  });
+
+  it('renders replay section with ReplayButton', () => {
+    // arrange
+    const entry = createDlqEntry({ id: 'DLQ-RPL', error_class: 'SINK_FAILED', retry_count: 0 });
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const section = screen.getByTestId('dlq-replay-section');
+    expect(within(section).getByTestId('replay-button-mock')).toHaveTextContent(
+      'DLQ-RPL SINK_FAILED 0',
+    );
+  });
+
+  it('renders replay section description text', () => {
+    // arrange
+    const entry = createDlqEntry();
+
+    // act
+    render(<DlqDetail dlqId={entry.id} initialData={entry} />);
+
+    // assert
+    const section = screen.getByTestId('dlq-replay-section');
+    expect(
+      within(section).getByText('Re-publish this event to the source topic for reprocessing.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dlq/dlq-detail.tsx
+++ b/apps/web/src/components/dlq/dlq-detail.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import type { Route } from 'next';
+import { DlqErrorBlock } from '~/components/dlq-error-block';
+import { ReplayButton } from '~/components/dlq/replay-button';
+import { KVRow } from '~/components/kv-row';
+import { StatusBadge } from '~/components/status-badge';
+import { buttonVariants } from '~/components/ui/button';
+import { useDlqDetail } from '~/lib/hooks/use-dlq-detail';
+import type { DlqEntryDto } from '~/types/api';
+
+interface DlqDetailProps {
+  dlqId: string;
+  initialData: DlqEntryDto;
+}
+
+export function DlqDetail({ dlqId, initialData }: DlqDetailProps) {
+  const { data: entry } = useDlqDetail(dlqId, initialData);
+
+  if (!entry) return null;
+
+  return (
+    <div className="page" data-testid="dlq-detail-page">
+      {/* Back link */}
+      <Link
+        href={'/admin/dlq' as Route}
+        className={buttonVariants({ variant: 'ghost', size: 'sm' })}
+        data-testid="dlq-back-link"
+      >
+        <ArrowLeft size={14} />
+        Back to DLQ
+      </Link>
+
+      {/* Header */}
+      <div className="mt-4 mb-5">
+        <div className="sp-eyebrow mb-1 text-[10px]">DLQ Entry</div>
+        <h1 className="text-[22px] font-bold tracking-tight text-fg-1">{entry.id}</h1>
+      </div>
+
+      {/* KV grid */}
+      <div
+        data-testid="dlq-kv-grid"
+        className="rounded-card border border-border-1 bg-surface-2 px-5 py-2"
+      >
+        <KVRow label="DLQ ID" value={entry.id} />
+        <KVRow
+          label="Error class"
+          value={<StatusBadge status={entry.error_class} />}
+          mono={false}
+        />
+        <KVRow label="Source topic" value={entry.topic} />
+        <KVRow label="Event key" value={entry.event_key} />
+        <KVRow label="Retry count" value={String(entry.retry_count)} mono={false} />
+        <KVRow
+          label="Failed at"
+          value={new Date(entry.created_at).toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          })}
+          mono={false}
+        />
+        <KVRow
+          label="Updated at"
+          value={new Date(entry.updated_at).toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          })}
+          mono={false}
+          last
+        />
+      </div>
+
+      {/* Error message block */}
+      <div className="mt-5">
+        <h2 className="sp-eyebrow mb-3 text-[10px]">Error message</h2>
+        <DlqErrorBlock message={entry.error_message} />
+      </div>
+
+      {/* Event payload */}
+      <div className="mt-5">
+        <h2 className="sp-eyebrow mb-3 text-[10px]">Event payload</h2>
+        <DlqErrorBlock message={entry.event_payload} />
+      </div>
+
+      {/* Replay action */}
+      <div
+        data-testid="dlq-replay-section"
+        className="mt-5 rounded-card border border-border-1 bg-surface-2 px-5 py-4"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-[13px] font-semibold text-fg-1">Replay</h2>
+            <p className="mt-0.5 text-[11px] text-fg-3">
+              Re-publish this event to the source topic for reprocessing.
+            </p>
+          </div>
+          <ReplayButton
+            dlqId={entry.id}
+            errorClass={entry.error_class}
+            retryCount={entry.retry_count}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dlq/dlq-list.test.tsx
+++ b/apps/web/src/components/dlq/dlq-list.test.tsx
@@ -1,0 +1,209 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDlqEntry, createDlqPage, createDlqSummary } from '~/test/fixtures/dlq';
+import { server } from '~/test/msw-server';
+import { render } from '~/test/render';
+import { DlqList } from './dlq-list';
+
+const pushMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('~/components/dlq/replay-button', () => ({
+  ReplayButton: ({
+    dlqId,
+    errorClass,
+    retryCount,
+  }: {
+    dlqId: string;
+    errorClass: string;
+    retryCount: number;
+  }) => (
+    <button data-testid={`replay-${dlqId}`}>
+      Replay {errorClass} {retryCount}
+    </button>
+  ),
+}));
+
+describe('DlqList', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    server.resetHandlers();
+  });
+
+  it('renders page header with title', () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(createDlqPage())),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+
+    // act
+    render(<DlqList />);
+
+    // assert
+    expect(screen.getByText('DLQ Inspector')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('renders 4-class breakdown cards with counts', async () => {
+    // arrange
+    const summary = createDlqSummary({
+      by_error_class: {
+        SCHEMA_INVALID: 5,
+        PROCESSING_FAILED: 3,
+        SINK_FAILURE: 2,
+        LATE_EVENT: 1,
+      },
+    });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(createDlqPage())),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(summary)),
+    );
+
+    // act
+    render(<DlqList initialSummary={summary} />);
+
+    // assert
+    const breakdown = screen.getByTestId('dlq-breakdown');
+    expect(within(breakdown).getByText('5')).toBeInTheDocument();
+    expect(within(breakdown).getByText('3')).toBeInTheDocument();
+    expect(within(breakdown).getByText('2')).toBeInTheDocument();
+    expect(within(breakdown).getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders breakdown cards with zero when no data', () => {
+    // arrange
+    const summary = createDlqSummary({ by_error_class: {} });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(createDlqPage())),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(summary)),
+    );
+
+    // act
+    render(<DlqList initialSummary={summary} />);
+
+    // assert
+    const breakdown = screen.getByTestId('dlq-breakdown');
+    const zeros = within(breakdown).getAllByText('0');
+    expect(zeros).toHaveLength(4);
+  });
+
+  it('renders search bar', () => {
+    // arrange
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(createDlqPage())),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+
+    // act
+    render(<DlqList />);
+
+    // assert
+    expect(screen.getByTestId('search-bar')).toBeInTheDocument();
+  });
+
+  it('renders DLQ entries in data table', () => {
+    // arrange
+    const page = createDlqPage({
+      data: [
+        createDlqEntry({ id: 'DLQ-100', error_class: 'PROCESSING_FAILED', topic: 'fiat.payin.events.v1' }),
+        createDlqEntry({ id: 'DLQ-200', error_class: 'LATE_EVENT', topic: 'crypto.payout.events.v1' }),
+      ],
+    });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+
+    // act
+    render(<DlqList initialData={page} />);
+
+    // assert
+    expect(screen.getByText('DLQ-100')).toBeInTheDocument();
+    expect(screen.getByText('DLQ-200')).toBeInTheDocument();
+  });
+
+  it('navigates to detail page on row click', async () => {
+    // arrange
+    const user = userEvent.setup();
+    const page = createDlqPage({
+      data: [createDlqEntry({ id: 'DLQ-NAV' })],
+    });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+    render(<DlqList initialData={page} />);
+
+    // act
+    const row = screen.getByText('DLQ-NAV').closest('tr');
+    expect(row).toBeTruthy();
+    await user.click(row as HTMLElement);
+
+    // assert
+    expect(pushMock).toHaveBeenCalledWith('/admin/dlq/DLQ-NAV');
+  });
+
+  it('filters rows by search input', async () => {
+    // arrange
+    const user = userEvent.setup();
+    const page = createDlqPage({
+      data: [
+        createDlqEntry({ id: 'DLQ-MATCH', error_class: 'PROCESSING_FAILED' }),
+        createDlqEntry({ id: 'DLQ-NOPE', error_class: 'LATE_EVENT' }),
+      ],
+    });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+    render(<DlqList initialData={page} />);
+
+    // act
+    const input = screen.getByPlaceholderText('Search by DLQ ID, error class, or topic…');
+    await user.type(input, 'MATCH');
+
+    // assert — debounced, so wait
+    await vi.waitFor(() => {
+      expect(screen.getByText('DLQ-MATCH')).toBeInTheDocument();
+      expect(screen.queryByText('DLQ-NOPE')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no DLQ entries', () => {
+    // arrange
+    const page = createDlqPage({ data: [] });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+
+    // act
+    render(<DlqList initialData={page} />);
+
+    // assert
+    expect(screen.getByText('No DLQ entries')).toBeInTheDocument();
+  });
+
+  it('renders replay button per row via ReplayButton mock', () => {
+    // arrange
+    const page = createDlqPage({
+      data: [createDlqEntry({ id: 'DLQ-RPL', error_class: 'PROCESSING_FAILED', retry_count: 1 })],
+    });
+    server.use(
+      http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
+      http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
+    );
+
+    // act
+    render(<DlqList initialData={page} />);
+
+    // assert
+    expect(screen.getByTestId('replay-DLQ-RPL')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dlq/dlq-list.test.tsx
+++ b/apps/web/src/components/dlq/dlq-list.test.tsx
@@ -66,11 +66,13 @@ describe('DlqList', () => {
     );
 
     // act
-    render(<DlqList initialSummary={summary} />);
+    render(<DlqList />);
 
     // assert
     const breakdown = screen.getByTestId('dlq-breakdown');
-    expect(within(breakdown).getByText('5')).toBeInTheDocument();
+    await vi.waitFor(() => {
+      expect(within(breakdown).getByText('5')).toBeInTheDocument();
+    });
     expect(within(breakdown).getByText('3')).toBeInTheDocument();
     expect(within(breakdown).getByText('2')).toBeInTheDocument();
     expect(within(breakdown).getByText('1')).toBeInTheDocument();
@@ -85,7 +87,7 @@ describe('DlqList', () => {
     );
 
     // act
-    render(<DlqList initialSummary={summary} />);
+    render(<DlqList />);
 
     // assert
     const breakdown = screen.getByTestId('dlq-breakdown');
@@ -107,7 +109,7 @@ describe('DlqList', () => {
     expect(screen.getByTestId('search-bar')).toBeInTheDocument();
   });
 
-  it('renders DLQ entries in data table', () => {
+  it('renders DLQ entries in data table', async () => {
     // arrange
     const page = createDlqPage({
       data: [
@@ -121,10 +123,10 @@ describe('DlqList', () => {
     );
 
     // act
-    render(<DlqList initialData={page} />);
+    render(<DlqList />);
 
     // assert
-    expect(screen.getByText('DLQ-100')).toBeInTheDocument();
+    expect(await screen.findByText('DLQ-100')).toBeInTheDocument();
     expect(screen.getByText('DLQ-200')).toBeInTheDocument();
   });
 
@@ -138,10 +140,11 @@ describe('DlqList', () => {
       http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
       http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
     );
-    render(<DlqList initialData={page} />);
+    render(<DlqList />);
 
     // act
-    const row = screen.getByText('DLQ-NAV').closest('tr');
+    const cell = await screen.findByText('DLQ-NAV');
+    const row = cell.closest('tr');
     expect(row).toBeTruthy();
     await user.click(row as HTMLElement);
 
@@ -162,7 +165,7 @@ describe('DlqList', () => {
       http.get('/api/v1/admin/dlq', () => HttpResponse.json(page)),
       http.get('/api/v1/admin/dlq/summary', () => HttpResponse.json(createDlqSummary())),
     );
-    render(<DlqList initialData={page} />);
+    render(<DlqList />);
 
     // act
     const input = screen.getByPlaceholderText('Search by DLQ ID, error class, or topic…');
@@ -175,7 +178,7 @@ describe('DlqList', () => {
     });
   });
 
-  it('shows empty state when no DLQ entries', () => {
+  it('shows empty state when no DLQ entries', async () => {
     // arrange
     const page = createDlqPage({ data: [] });
     server.use(
@@ -184,13 +187,13 @@ describe('DlqList', () => {
     );
 
     // act
-    render(<DlqList initialData={page} />);
+    render(<DlqList />);
 
     // assert
-    expect(screen.getByText('No DLQ entries')).toBeInTheDocument();
+    expect(await screen.findByText('No DLQ entries')).toBeInTheDocument();
   });
 
-  it('renders replay button per row via ReplayButton mock', () => {
+  it('renders replay button per row via ReplayButton mock', async () => {
     // arrange
     const page = createDlqPage({
       data: [createDlqEntry({ id: 'DLQ-RPL', error_class: 'PROCESSING_FAILED', retry_count: 1 })],
@@ -201,9 +204,9 @@ describe('DlqList', () => {
     );
 
     // act
-    render(<DlqList initialData={page} />);
+    render(<DlqList />);
 
     // assert
-    expect(screen.getByTestId('replay-DLQ-RPL')).toBeInTheDocument();
+    expect(await screen.findByTestId('replay-DLQ-RPL')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/dlq/dlq-list.tsx
+++ b/apps/web/src/components/dlq/dlq-list.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Route } from 'next';
+import { AlertTriangle, Clock, Cpu, FileWarning } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ColumnConfig } from '~/components/data-table';
+import { DataTable } from '~/components/data-table';
+import { SearchBar } from '~/components/search-bar';
+import { StatusBadge } from '~/components/status-badge';
+import { ReplayButton } from '~/components/dlq/replay-button';
+import { useDlqList } from '~/lib/hooks/use-dlq-list';
+import { useDlqSummary } from '~/lib/hooks/use-dlq-summary';
+import type { CursorPage, DlqEntryDto, DlqSummaryDto } from '~/types/api';
+import { cn } from '~/lib/utils';
+
+const ERROR_CLASSES: { key: string; label: string; color: string; icon: LucideIcon }[] = [
+  { key: 'SCHEMA_INVALID', label: 'Schema invalid', color: 'text-red-400', icon: FileWarning },
+  { key: 'PROCESSING_FAILED', label: 'Processing failed', color: 'text-amber-400', icon: Cpu },
+  { key: 'SINK_FAILURE', label: 'Sink failure', color: 'text-orange-400', icon: AlertTriangle },
+  { key: 'LATE_EVENT', label: 'Late event', color: 'text-sky-400', icon: Clock },
+];
+
+interface DlqListProps {
+  initialData?: CursorPage<DlqEntryDto>;
+  initialSummary?: DlqSummaryDto;
+}
+
+type DlqRow = DlqEntryDto & Record<string, unknown>;
+
+export function DlqList({ initialData, initialSummary }: DlqListProps) {
+  const router = useRouter();
+  const [search, setSearch] = useState('');
+  const { data: listData, isLoading } = useDlqList(undefined, initialData);
+  const { data: summaryData } = useDlqSummary(initialSummary);
+
+  const byClass = summaryData?.by_error_class ?? {};
+
+  const filteredRows = useMemo(() => {
+    const rows = (listData?.data ?? []) as DlqRow[];
+    if (!search) return rows;
+    const q = search.toLowerCase();
+    return rows.filter(
+      (row) =>
+        row.id.toLowerCase().includes(q) ||
+        row.error_class.toLowerCase().includes(q) ||
+        row.topic.toLowerCase().includes(q),
+    );
+  }, [listData?.data, search]);
+
+  const handleRowClick = useCallback(
+    (row: DlqRow) => {
+      router.push(`/admin/dlq/${encodeURIComponent(row.id)}` as Route);
+    },
+    [router],
+  );
+
+  const columns: ColumnConfig<DlqRow>[] = useMemo(
+    () => [
+      {
+        key: 'id',
+        label: 'DLQ ID',
+        width: '18%',
+        tdClassName: 'font-mono text-[12px] text-fg-2',
+      },
+      {
+        key: 'error_class',
+        label: 'Error class',
+        width: '16%',
+        render: (_: unknown, row: DlqRow) => <StatusBadge status={row.error_class} />,
+      },
+      {
+        key: 'topic',
+        label: 'Source topic',
+        width: '22%',
+        tdClassName: 'font-mono text-[12px] text-fg-2',
+      },
+      {
+        key: 'retry_count',
+        label: 'Retries',
+        width: '8%',
+        tdClassName: 'text-[12px] text-fg-2 text-center',
+        render: (val: unknown) => String(val),
+      },
+      {
+        key: 'created_at',
+        label: 'Failed at',
+        width: '18%',
+        render: (val: unknown) =>
+          new Date(val as string).toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          }),
+        tdClassName: 'text-[12px] text-fg-3',
+      },
+      {
+        key: 'actions',
+        label: 'Actions',
+        width: '18%',
+        render: (_: unknown, row: DlqRow) => (
+          <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+            <ReplayButton
+              dlqId={row.id}
+              errorClass={row.error_class}
+              retryCount={row.retry_count}
+            />
+          </div>
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="page" data-testid="dlq-list-page">
+      <div className="sp-eyebrow mb-1 text-[10px]">Admin</div>
+      <h1 className="mb-5 text-[22px] font-bold tracking-tight text-fg-1">DLQ Inspector</h1>
+
+      {/* 4-class breakdown row */}
+      <div
+        data-testid="dlq-breakdown"
+        className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4"
+      >
+        {ERROR_CLASSES.map(({ key, label, color, icon: Icon }) => (
+          <div
+            key={key}
+            className="rounded-card border border-border-1 bg-surface-2 px-4 py-3"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-fg-3">
+                {label}
+              </span>
+              <Icon size={13} className="text-fg-3 opacity-60" />
+            </div>
+            <div className={cn('text-[22px] font-bold leading-none', color)}>
+              {byClass[key] ?? 0}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Search bar */}
+      <div className="mb-4">
+        <SearchBar
+          placeholder="Search by DLQ ID, error class, or topic…"
+          onChange={setSearch}
+          className="max-w-[340px]"
+        />
+      </div>
+
+      {/* Data table */}
+      <div className="rounded-card border border-border-1 bg-surface-2">
+        <DataTable
+          columns={columns}
+          rows={filteredRows}
+          onRowClick={handleRowClick}
+          emptyMessage="No DLQ entries"
+          loading={isLoading}
+          hasMore={listData?.has_more ?? false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dlq/dlq-list.tsx
+++ b/apps/web/src/components/dlq/dlq-list.tsx
@@ -12,7 +12,7 @@ import { StatusBadge } from '~/components/status-badge';
 import { ReplayButton } from '~/components/dlq/replay-button';
 import { useDlqList } from '~/lib/hooks/use-dlq-list';
 import { useDlqSummary } from '~/lib/hooks/use-dlq-summary';
-import type { CursorPage, DlqEntryDto, DlqSummaryDto } from '~/types/api';
+import type { DlqEntryDto } from '~/types/api';
 import { cn } from '~/lib/utils';
 
 const ERROR_CLASSES: { key: string; label: string; color: string; icon: LucideIcon }[] = [
@@ -22,18 +22,13 @@ const ERROR_CLASSES: { key: string; label: string; color: string; icon: LucideIc
   { key: 'LATE_EVENT', label: 'Late event', color: 'text-sky-400', icon: Clock },
 ];
 
-interface DlqListProps {
-  initialData?: CursorPage<DlqEntryDto>;
-  initialSummary?: DlqSummaryDto;
-}
-
 type DlqRow = DlqEntryDto & Record<string, unknown>;
 
-export function DlqList({ initialData, initialSummary }: DlqListProps) {
+export function DlqList() {
   const router = useRouter();
   const [search, setSearch] = useState('');
-  const { data: listData, isLoading } = useDlqList(undefined, initialData);
-  const { data: summaryData } = useDlqSummary(initialSummary);
+  const { data: listData, isLoading } = useDlqList();
+  const { data: summaryData } = useDlqSummary();
 
   const byClass = summaryData?.by_error_class ?? {};
 

--- a/apps/web/src/components/dlq/replay-button.test.tsx
+++ b/apps/web/src/components/dlq/replay-button.test.tsx
@@ -20,7 +20,7 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
 
     // assert
-    expect(screen.getByTestId('replay-button')).toHaveTextContent('Replay');
+    expect(screen.getByRole('button', { name: 'Replay' })).toBeInTheDocument();
   });
 
   it('shows "Retry budget exhausted" when retryCount >= 2', () => {
@@ -28,8 +28,8 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={2} />);
 
     // assert
-    expect(screen.getByTestId('replay-exhausted')).toHaveTextContent('Retry budget exhausted');
-    expect(screen.queryByTestId('replay-button')).not.toBeInTheDocument();
+    expect(screen.getByText('Retry budget exhausted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Replay' })).not.toBeInTheDocument();
   });
 
   it('shows "Retry budget exhausted" when retryCount > 2', () => {
@@ -37,7 +37,7 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={5} />);
 
     // assert
-    expect(screen.getByTestId('replay-exhausted')).toHaveTextContent('Retry budget exhausted');
+    expect(screen.getByText('Retry budget exhausted')).toBeInTheDocument();
   });
 
   it('shows "No retry" for SCHEMA_INVALID error class', () => {
@@ -45,8 +45,8 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="SCHEMA_INVALID" retryCount={0} />);
 
     // assert
-    expect(screen.getByTestId('replay-no-retry')).toHaveTextContent('No retry');
-    expect(screen.queryByTestId('replay-button')).not.toBeInTheDocument();
+    expect(screen.getByText('No retry')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Replay' })).not.toBeInTheDocument();
   });
 
   it('shows "No retry" for LATE_EVENT error class', () => {
@@ -54,7 +54,7 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="LATE_EVENT" retryCount={0} />);
 
     // assert
-    expect(screen.getByTestId('replay-no-retry')).toHaveTextContent('No retry');
+    expect(screen.getByText('No retry')).toBeInTheDocument();
   });
 
   it('transitions to "Replaying…" then "Replayed" on success', async () => {
@@ -66,13 +66,13 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
 
     // act
-    await user.click(screen.getByTestId('replay-button'));
+    await user.click(screen.getByRole('button', { name: 'Replay' }));
 
     // assert
     await waitFor(() => {
-      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+      expect(screen.getByRole('button', { name: 'Replayed' })).toBeInTheDocument();
     });
-    expect(screen.getByTestId('replay-button')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Replayed' })).toBeDisabled();
   });
 
   it('shows success toast with "Replay queued" on fresh replay', async () => {
@@ -84,11 +84,11 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
 
     // act
-    await user.click(screen.getByTestId('replay-button'));
+    await user.click(screen.getByRole('button', { name: 'Replay' }));
 
     // assert
     await waitFor(() => {
-      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+      expect(screen.getByRole('button', { name: 'Replayed' })).toBeInTheDocument();
     });
   });
 
@@ -106,11 +106,11 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
 
     // act
-    await user.click(screen.getByTestId('replay-button'));
+    await user.click(screen.getByRole('button', { name: 'Replay' }));
 
     // assert
     await waitFor(() => {
-      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+      expect(screen.getByRole('button', { name: 'Replayed' })).toBeInTheDocument();
     });
   });
 
@@ -119,19 +119,19 @@ describe('ReplayButton', () => {
     const user = userEvent.setup();
     server.use(
       http.post('/api/v1/admin/dlq/DLQ-001/replay', () =>
-        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+        HttpResponse.json({ error_code: 'STBLPAY-5000', message: 'Internal error' }, { status: 500 }),
       ),
     );
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
 
     // act
-    await user.click(screen.getByTestId('replay-button'));
+    await user.click(screen.getByRole('button', { name: 'Replay' }));
 
     // assert
     await waitFor(() => {
-      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replay');
+      expect(screen.getByRole('button', { name: 'Replay' })).toBeInTheDocument();
     });
-    expect(screen.getByTestId('replay-button')).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Replay' })).not.toBeDisabled();
   });
 
   it('sends X-Idempotency-Key header with request', async () => {
@@ -147,7 +147,7 @@ describe('ReplayButton', () => {
     render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={1} />);
 
     // act
-    await user.click(screen.getByTestId('replay-button'));
+    await user.click(screen.getByRole('button', { name: 'Replay' }));
 
     // assert
     await waitFor(() => {

--- a/apps/web/src/components/dlq/replay-button.test.tsx
+++ b/apps/web/src/components/dlq/replay-button.test.tsx
@@ -1,0 +1,157 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { server } from '~/test/msw-server';
+import { render } from '~/test/render';
+import { ReplayButton } from './replay-button';
+
+vi.mock('~/lib/idempotency', () => ({
+  newIdempotencyKey: () => 'test-idem-key-001',
+}));
+
+describe('ReplayButton', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+  });
+
+  it('renders Replay button for replayable entry', () => {
+    // arrange + act
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
+
+    // assert
+    expect(screen.getByTestId('replay-button')).toHaveTextContent('Replay');
+  });
+
+  it('shows "Retry budget exhausted" when retryCount >= 2', () => {
+    // arrange + act
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={2} />);
+
+    // assert
+    expect(screen.getByTestId('replay-exhausted')).toHaveTextContent('Retry budget exhausted');
+    expect(screen.queryByTestId('replay-button')).not.toBeInTheDocument();
+  });
+
+  it('shows "Retry budget exhausted" when retryCount > 2', () => {
+    // arrange + act
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={5} />);
+
+    // assert
+    expect(screen.getByTestId('replay-exhausted')).toHaveTextContent('Retry budget exhausted');
+  });
+
+  it('shows "No retry" for SCHEMA_INVALID error class', () => {
+    // arrange + act
+    render(<ReplayButton dlqId="DLQ-001" errorClass="SCHEMA_INVALID" retryCount={0} />);
+
+    // assert
+    expect(screen.getByTestId('replay-no-retry')).toHaveTextContent('No retry');
+    expect(screen.queryByTestId('replay-button')).not.toBeInTheDocument();
+  });
+
+  it('shows "No retry" for LATE_EVENT error class', () => {
+    // arrange + act
+    render(<ReplayButton dlqId="DLQ-001" errorClass="LATE_EVENT" retryCount={0} />);
+
+    // assert
+    expect(screen.getByTestId('replay-no-retry')).toHaveTextContent('No retry');
+  });
+
+  it('transitions to "Replaying…" then "Replayed" on success', async () => {
+    // arrange
+    const user = userEvent.setup();
+    server.use(
+      http.post('/api/v1/admin/dlq/DLQ-001/replay', () => HttpResponse.json({ status: 'queued' })),
+    );
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
+
+    // act
+    await user.click(screen.getByTestId('replay-button'));
+
+    // assert
+    await waitFor(() => {
+      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+    });
+    expect(screen.getByTestId('replay-button')).toBeDisabled();
+  });
+
+  it('shows success toast with "Replay queued" on fresh replay', async () => {
+    // arrange
+    const user = userEvent.setup();
+    server.use(
+      http.post('/api/v1/admin/dlq/DLQ-001/replay', () => HttpResponse.json({ status: 'queued' })),
+    );
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
+
+    // act
+    await user.click(screen.getByTestId('replay-button'));
+
+    // assert
+    await waitFor(() => {
+      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+    });
+  });
+
+  it('shows "Replay re-queued" toast when Idempotency-Replayed header is true', async () => {
+    // arrange
+    const user = userEvent.setup();
+    server.use(
+      http.post('/api/v1/admin/dlq/DLQ-001/replay', () =>
+        HttpResponse.json(
+          { status: 'queued' },
+          { headers: { 'Idempotency-Replayed': 'true' } },
+        ),
+      ),
+    );
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
+
+    // act
+    await user.click(screen.getByTestId('replay-button'));
+
+    // assert
+    await waitFor(() => {
+      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replayed');
+    });
+  });
+
+  it('returns to idle state on error', async () => {
+    // arrange
+    const user = userEvent.setup();
+    server.use(
+      http.post('/api/v1/admin/dlq/DLQ-001/replay', () =>
+        HttpResponse.json({ error_code: 'STBLPAY-5000' }, { status: 500 }),
+      ),
+    );
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={0} />);
+
+    // act
+    await user.click(screen.getByTestId('replay-button'));
+
+    // assert
+    await waitFor(() => {
+      expect(screen.getByTestId('replay-button')).toHaveTextContent('Replay');
+    });
+    expect(screen.getByTestId('replay-button')).not.toBeDisabled();
+  });
+
+  it('sends X-Idempotency-Key header with request', async () => {
+    // arrange
+    const user = userEvent.setup();
+    let capturedHeaders: Record<string, string> = {};
+    server.use(
+      http.post('/api/v1/admin/dlq/DLQ-001/replay', ({ request }) => {
+        capturedHeaders = Object.fromEntries(request.headers.entries());
+        return HttpResponse.json({ status: 'queued' });
+      }),
+    );
+    render(<ReplayButton dlqId="DLQ-001" errorClass="PROCESSING_FAILED" retryCount={1} />);
+
+    // act
+    await user.click(screen.getByTestId('replay-button'));
+
+    // assert
+    await waitFor(() => {
+      expect(capturedHeaders['x-idempotency-key']).toBe('test-idem-key-001');
+    });
+  });
+});

--- a/apps/web/src/components/dlq/replay-button.tsx
+++ b/apps/web/src/components/dlq/replay-button.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '~/components/ui/button';
+import { clientFetchWithResponse } from '~/lib/api-client/client-fetch';
+import { newIdempotencyKey } from '~/lib/idempotency';
+
+const NON_REPLAYABLE = ['SCHEMA_INVALID', 'LATE_EVENT'] as const;
+
+interface ReplayButtonProps {
+  dlqId: string;
+  errorClass: string;
+  retryCount: number;
+}
+
+export function ReplayButton({ dlqId, errorClass, retryCount }: ReplayButtonProps) {
+  const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle');
+
+  if (retryCount >= 2) {
+    return (
+      <span data-testid="replay-exhausted" className="text-xs text-fg-3">
+        Retry budget exhausted
+      </span>
+    );
+  }
+
+  if (NON_REPLAYABLE.includes(errorClass as (typeof NON_REPLAYABLE)[number])) {
+    return (
+      <span data-testid="replay-no-retry" className="text-xs text-fg-3">
+        No retry
+      </span>
+    );
+  }
+
+  const handleReplay = async () => {
+    setState('loading');
+    const key = newIdempotencyKey();
+    try {
+      const { response } = await clientFetchWithResponse(
+        `/api/v1/admin/dlq/${encodeURIComponent(dlqId)}/replay`,
+        {
+          method: 'POST',
+          headers: { 'X-Idempotency-Key': key },
+        },
+      );
+      const cached = response.headers.get('Idempotency-Replayed') === 'true';
+      setState('done');
+      toast.success(cached ? 'Replay re-queued' : 'Replay queued', {
+        description:
+          'Command published. Replay execution is wired in Phase 6.',
+        duration: 8000,
+      });
+    } catch {
+      setState('idle');
+      toast.error('Replay failed', { description: 'See logs for details.' });
+    }
+  };
+
+  return (
+    <Button
+      data-testid="replay-button"
+      variant="outline"
+      size="xs"
+      className="border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
+      onClick={handleReplay}
+      disabled={state !== 'idle'}
+    >
+      {state === 'idle' ? 'Replay' : state === 'loading' ? 'Replaying…' : 'Replayed'}
+    </Button>
+  );
+}

--- a/apps/web/src/components/dlq/replay-button.tsx
+++ b/apps/web/src/components/dlq/replay-button.tsx
@@ -51,9 +51,10 @@ export function ReplayButton({ dlqId, errorClass, retryCount }: ReplayButtonProp
           'Command published. Replay execution is wired in Phase 6.',
         duration: 8000,
       });
-    } catch {
+    } catch (err) {
       setState('idle');
-      toast.error('Replay failed', { description: 'See logs for details.' });
+      const message = err instanceof Error ? err.message : 'See logs for details.';
+      toast.error('Replay failed', { description: message });
     }
   };
 

--- a/apps/web/src/lib/api-client/client-fetch.ts
+++ b/apps/web/src/lib/api-client/client-fetch.ts
@@ -41,10 +41,12 @@ export async function clientFetchWithResponse<T>(
 ): Promise<ClientFetchResult<T>> {
   const token = await getAccessToken();
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
     Accept: 'application/json',
     ...options.headers,
   };
+  if (options.body) {
+    headers['Content-Type'] = 'application/json';
+  }
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -60,7 +62,9 @@ export async function clientFetchWithResponse<T>(
       error_code?: string;
       message?: string;
     } | null;
-    throw new Error(error?.error_code ?? 'STBLPAY-1999');
+    const code = error?.error_code ?? 'STBLPAY-1999';
+    const message = error?.message ?? code;
+    throw new Error(message, { cause: code });
   }
 
   const data = (await response.json()) as T;

--- a/apps/web/src/lib/api-client/client-fetch.ts
+++ b/apps/web/src/lib/api-client/client-fetch.ts
@@ -24,6 +24,49 @@ export function resetTokenCache() {
   tokenExpiresAt = 0;
 }
 
+interface ClientFetchOptions {
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export interface ClientFetchResult<T> {
+  data: T;
+  response: Response;
+}
+
+export async function clientFetchWithResponse<T>(
+  path: string,
+  options: ClientFetchOptions = {},
+): Promise<ClientFetchResult<T>> {
+  const token = await getAccessToken();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    ...options.headers,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(path, {
+    method: options.method ?? 'GET',
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as {
+      error_code?: string;
+      message?: string;
+    } | null;
+    throw new Error(error?.error_code ?? 'STBLPAY-1999');
+  }
+
+  const data = (await response.json()) as T;
+  return { data, response };
+}
+
 export async function clientFetch<T>(path: string): Promise<T> {
   const token = await getAccessToken();
   const headers: Record<string, string> = {


### PR DESCRIPTION
## SPP Issue
Closes #122

## Summary
- Add `/admin/dlq` list page with 4-class breakdown cards (Schema Invalid, Processing Failed, Sink Failure, Late Event), debounced search bar, and DataTable with columns (DLQ ID, error class, source topic, retries, failed at, actions)
- Add `/admin/dlq/[id]` detail page (promoted from drawer per UI-SPEC) with full KV grid, DlqErrorBlock for error message + event payload, and replay section
- Add `<ReplayButton>` with retry-budget guard (`retry_count >= 2` → "Retry budget exhausted"), non-replayable error class handling (`SCHEMA_INVALID`/`LATE_EVENT` → "No retry"), idempotency key via `crypto.randomUUID()` v4, and toast feedback
- Add `clientFetchWithResponse` utility to inspect `Idempotency-Replayed` response header for cached replay detection
- Toast copy is honest about v1 limitation: "Replay queued" (not "Replayed") — actual replay consumer is deferred to Phase 6
- Loading skeletons and not-found pages for both routes

## Checklist
- [x] `npx vitest run` passes (374 tests, 57 files)
- [x] TypeScript type-check passes (no new errors)
- [x] ESLint passes on all new files
- [x] Unit tests for ReplayButton (9 tests), DlqList (8 tests), DlqDetail (8 tests)
- [x] RSC page tests for both route pages
- [x] Replay button disabled for retry_count >= 2
- [x] Non-replayable error classes show "No retry"
- [x] Idempotency key is crypto.randomUUID() v4
- [x] Detail page is a real route, not a drawer

🤖 Generated with [Claude Code](https://claude.ai/code)