### PR TITLE
SPP-117: add admin stuck page with expandable cards, refund AlertDialog, and agg table

### DIFF
--- a/apps/web/src/app/(authed)/admin/stuck/loading.tsx
+++ b/apps/web/src/app/(authed)/admin/stuck/loading.tsx
@@ -1,0 +1,55 @@
+import { Skeleton } from '~/components/ui/skeleton';
+
+export default function StuckLoading() {
+  return (
+    <div className="page" data-testid="stuck-loading">
+      <Skeleton className="mb-1 h-[11px] w-[50px]" />
+      <Skeleton className="mb-5 h-[28px] w-[200px]" />
+
+      {/* Banner skeleton */}
+      <Skeleton className="mb-5 h-[48px] w-full rounded-card" />
+
+      {/* Expandable cards skeleton */}
+      <div className="mb-6 space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-card border border-border-1 bg-surface-2 px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-[14px] w-[120px]" />
+                <Skeleton className="h-[20px] w-[60px] rounded-full" />
+                <Skeleton className="h-[14px] w-[80px]" />
+              </div>
+              <Skeleton className="size-4" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Agg table skeleton */}
+      <Skeleton className="mb-2 h-[11px] w-[160px]" />
+      <div className="rounded-card border border-border-1 bg-surface-2">
+        <div className="border-b border-border-1 px-[14px] py-[9px]">
+          <div className="flex gap-4">
+            <Skeleton className="h-[11px] w-[100px]" />
+            <Skeleton className="h-[11px] w-[60px]" />
+            <Skeleton className="h-[11px] w-[80px]" />
+            <Skeleton className="h-[11px] w-[90px]" />
+            <Skeleton className="h-[11px] w-[70px]" />
+          </div>
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b border-border-1 px-[14px] py-[11px] last:border-b-0"
+          >
+            <Skeleton className="h-[11px] w-[100px]" />
+            <Skeleton className="h-[16px] w-[70px] rounded-full" />
+            <Skeleton className="h-[11px] w-[80px]" />
+            <Skeleton className="h-[11px] w-[90px]" />
+            <Skeleton className="h-[11px] w-[80px]" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authed)/admin/stuck/page.test.tsx
+++ b/apps/web/src/app/(authed)/admin/stuck/page.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createStuckPayment } from '~/test/fixtures/stuck';
+
+vi.mock('~/lib/data', () => ({
+  fetchStuckList: vi.fn(),
+}));
+
+vi.mock('~/components/stuck/stuck-list', () => ({
+  StuckList: () => <div data-testid="stuck-list-mock">StuckList</div>,
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query',
+  );
+  return {
+    ...actual,
+    dehydrate: () => ({}),
+    HydrationBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { fetchStuckList } from '~/lib/data';
+import StuckPage from './page';
+
+const mockFetchStuckList = vi.mocked(fetchStuckList);
+
+describe('StuckPage', () => {
+  it('prefetches stuck list and renders StuckList', async () => {
+    // arrange
+    mockFetchStuckList.mockResolvedValue([createStuckPayment()]);
+
+    // act
+    const jsx = await StuckPage();
+    render(jsx);
+
+    // assert
+    expect(screen.getByTestId('stuck-list-mock')).toBeInTheDocument();
+    expect(mockFetchStuckList).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(authed)/admin/stuck/page.tsx
+++ b/apps/web/src/app/(authed)/admin/stuck/page.tsx
@@ -1,0 +1,18 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { StuckList } from '~/components/stuck/stuck-list';
+import { fetchStuckList } from '~/lib/data';
+
+export default async function StuckPage() {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['stuck'],
+    queryFn: () => fetchStuckList(),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <StuckList />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/components/stuck/refund-confirmation-dialog.test.tsx
+++ b/apps/web/src/components/stuck/refund-confirmation-dialog.test.tsx
@@ -72,4 +72,21 @@ describe('RefundConfirmationDialog', () => {
       duration: 8000,
     });
   });
+
+  it('closes dialog after confirm', async () => {
+    // arrange
+    const user = userEvent.setup();
+    render(<RefundConfirmationDialog stuckPayment={createStuckPayment()} />);
+
+    // act
+    await user.click(screen.getByTestId('trigger-refund-button'));
+    const confirmButtons = await screen.findAllByText('Trigger refund');
+    const confirmButton = confirmButtons.find(
+      (btn) => btn.closest('[data-slot="alert-dialog-action"]') !== null,
+    );
+    await user.click(confirmButton!);
+
+    // assert
+    expect(screen.queryByText('Trigger refund?')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/stuck/refund-confirmation-dialog.test.tsx
+++ b/apps/web/src/components/stuck/refund-confirmation-dialog.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+import { createStuckPayment } from '~/test/fixtures/stuck';
+import { render } from '~/test/render';
+import { RefundConfirmationDialog } from './refund-confirmation-dialog';
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn() },
+}));
+
+describe('RefundConfirmationDialog', () => {
+  it('renders trigger button', () => {
+    // arrange & act
+    render(<RefundConfirmationDialog stuckPayment={createStuckPayment()} />);
+
+    // assert
+    expect(screen.getByTestId('trigger-refund-button')).toHaveTextContent('Trigger refund');
+  });
+
+  it('opens AlertDialog on trigger click with correct copy', async () => {
+    // arrange
+    const user = userEvent.setup();
+    render(
+      <RefundConfirmationDialog
+        stuckPayment={createStuckPayment({ customer_id: 'CUST-DIALOG' })}
+      />,
+    );
+
+    // act
+    await user.click(screen.getByTestId('trigger-refund-button'));
+
+    // assert
+    expect(await screen.findByText('Trigger refund?')).toBeInTheDocument();
+    expect(screen.getByText(/irreversible refund initiation event/)).toBeInTheDocument();
+    expect(screen.getByText(/CUST-DIALOG/)).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Trigger refund action buttons', async () => {
+    // arrange
+    const user = userEvent.setup();
+    render(<RefundConfirmationDialog stuckPayment={createStuckPayment()} />);
+
+    // act
+    await user.click(screen.getByTestId('trigger-refund-button'));
+
+    // assert
+    expect(await screen.findByText('Cancel')).toBeInTheDocument();
+    const actions = screen.getAllByText('Trigger refund');
+    expect(actions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('fires toast.info stub on confirm', async () => {
+    // arrange
+    const user = userEvent.setup();
+    render(<RefundConfirmationDialog stuckPayment={createStuckPayment()} />);
+
+    // act
+    await user.click(screen.getByTestId('trigger-refund-button'));
+    const confirmButtons = await screen.findAllByText('Trigger refund');
+    const confirmButton = confirmButtons.find(
+      (btn) => btn.closest('[data-slot="alert-dialog-action"]') !== null,
+    );
+    expect(confirmButton).toBeTruthy();
+    await user.click(confirmButton!);
+
+    // assert
+    expect(toast.info).toHaveBeenCalledWith('Refund initiation deferred to Phase 6', {
+      description:
+        'The Stuck refund endpoint is not in REQUIREMENTS v1; backend wiring will be added in Phase 6.',
+      duration: 8000,
+    });
+  });
+});

--- a/apps/web/src/components/stuck/refund-confirmation-dialog.tsx
+++ b/apps/web/src/components/stuck/refund-confirmation-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { toast } from 'sonner';
 import {
   AlertDialog,
@@ -21,9 +22,11 @@ interface RefundConfirmationDialogProps {
 }
 
 export function RefundConfirmationDialog({ stuckPayment }: RefundConfirmationDialogProps) {
+  const [open, setOpen] = useState(false);
   const formattedAmount = formatMoney(stuckPayment.amount.amount, stuckPayment.amount.currency);
 
   const handleConfirmRefund = () => {
+    setOpen(false);
     toast.info('Refund initiation deferred to Phase 6', {
       description:
         'The Stuck refund endpoint is not in REQUIREMENTS v1; backend wiring will be added in Phase 6.',
@@ -32,7 +35,7 @@ export function RefundConfirmationDialog({ stuckPayment }: RefundConfirmationDia
   };
 
   return (
-    <AlertDialog>
+    <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger
         render={
           <Button

--- a/apps/web/src/components/stuck/refund-confirmation-dialog.tsx
+++ b/apps/web/src/components/stuck/refund-confirmation-dialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '~/components/ui/alert-dialog';
+import { Button } from '~/components/ui/button';
+import { formatMoney } from '~/lib/format/money';
+import type { StuckPaymentDto } from '~/types/api';
+
+interface RefundConfirmationDialogProps {
+  stuckPayment: StuckPaymentDto;
+}
+
+export function RefundConfirmationDialog({ stuckPayment }: RefundConfirmationDialogProps) {
+  const formattedAmount = formatMoney(stuckPayment.amount.amount, stuckPayment.amount.currency);
+
+  const handleConfirmRefund = () => {
+    toast.info('Refund initiation deferred to Phase 6', {
+      description:
+        'The Stuck refund endpoint is not in REQUIREMENTS v1; backend wiring will be added in Phase 6.',
+      duration: 8000,
+    });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button
+            data-testid="trigger-refund-button"
+            variant="destructive"
+            size="xs"
+          >
+            Trigger refund
+          </Button>
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Trigger refund?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This creates an irreversible refund initiation event for{' '}
+            {formattedAmount} to customer {stuckPayment.customer_id}. The refund
+            will be processed by the partner provider.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={handleConfirmRefund}>
+            Trigger refund
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/stuck/stuck-list.test.tsx
+++ b/apps/web/src/components/stuck/stuck-list.test.tsx
@@ -1,0 +1,202 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStuckPayment } from '~/test/fixtures/stuck';
+import { server } from '~/test/msw-server';
+import { render } from '~/test/render';
+import { StuckList } from './stuck-list';
+
+vi.mock('~/components/stuck/refund-confirmation-dialog', () => ({
+  RefundConfirmationDialog: ({ stuckPayment }: { stuckPayment: { transaction_ref: string } }) => (
+    <button data-testid={`refund-dialog-${stuckPayment.transaction_ref}`}>Trigger refund</button>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const now = new Date('2026-01-15T12:00:00Z');
+
+describe('StuckList', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now, shouldAdvanceTime: true });
+    server.resetHandlers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setupHandler(payments = [createStuckPayment()]) {
+    server.use(http.get('/api/v1/admin/stuck', () => HttpResponse.json(payments)));
+  }
+
+  it('renders page header', () => {
+    // arrange
+    setupHandler();
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    expect(screen.getByText('Stuck Payments')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('renders banner with total count', async () => {
+    // arrange
+    setupHandler([createStuckPayment(), createStuckPayment({ transaction_ref: 'TXN-STUCK-002' })]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    const banner = await screen.findByTestId('stuck-banner');
+    expect(banner).toHaveTextContent('2 stuck payments');
+  });
+
+  it('renders banner with critical threshold count for payments stuck >= 24h', async () => {
+    // arrange
+    setupHandler([
+      createStuckPayment({ stuck_since: '2026-01-14T08:00:00Z' }),
+      createStuckPayment({
+        transaction_ref: 'TXN-STUCK-RECENT',
+        stuck_since: '2026-01-15T11:00:00Z',
+      }),
+    ]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    const banner = await screen.findByTestId('stuck-banner');
+    expect(banner).toHaveTextContent('1 exceeds 24h threshold');
+  });
+
+  it('renders expandable cards for each stuck payment', async () => {
+    // arrange
+    setupHandler([
+      createStuckPayment({ transaction_ref: 'TXN-CARD-1' }),
+      createStuckPayment({ transaction_ref: 'TXN-CARD-2' }),
+    ]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    expect(await screen.findByTestId('stuck-card-TXN-CARD-1')).toBeInTheDocument();
+    expect(screen.getByTestId('stuck-card-TXN-CARD-2')).toBeInTheDocument();
+  });
+
+  it('expands card on click to reveal reason and actions', async () => {
+    // arrange
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    setupHandler([
+      createStuckPayment({
+        transaction_ref: 'TXN-EXPAND',
+        stuck_reason: 'Partner timeout after 24h',
+      }),
+    ]);
+    render(<StuckList />);
+
+    // act
+    const card = await screen.findByTestId('stuck-card-TXN-EXPAND');
+    await user.click(card);
+
+    // assert
+    const detail = screen.getByTestId('stuck-card-detail-TXN-EXPAND');
+    expect(detail).toHaveTextContent('Partner timeout after 24h');
+    expect(within(detail).getByTestId('view-transaction-link')).toBeInTheDocument();
+    expect(within(detail).getByTestId('refund-dialog-TXN-EXPAND')).toBeInTheDocument();
+  });
+
+  it('collapses card on second click', async () => {
+    // arrange
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    setupHandler([createStuckPayment({ transaction_ref: 'TXN-COLLAPSE' })]);
+    render(<StuckList />);
+
+    // act — expand then collapse
+    const card = await screen.findByTestId('stuck-card-TXN-COLLAPSE');
+    await user.click(card);
+    expect(screen.getByTestId('stuck-card-detail-TXN-COLLAPSE')).toBeInTheDocument();
+    await user.click(card);
+
+    // assert
+    expect(screen.queryByTestId('stuck-card-detail-TXN-COLLAPSE')).not.toBeInTheDocument();
+  });
+
+  it('shows critical badge for payments stuck >= 24h', async () => {
+    // arrange
+    setupHandler([createStuckPayment({ stuck_since: '2026-01-14T08:00:00Z' })]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    expect(await screen.findByTestId('critical-badge')).toBeInTheDocument();
+  });
+
+  it('does not show critical badge for payments stuck < 24h', async () => {
+    // arrange
+    setupHandler([createStuckPayment({ stuck_since: '2026-01-15T11:30:00Z' })]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    await screen.findByTestId('stuck-cards');
+    expect(screen.queryByTestId('critical-badge')).not.toBeInTheDocument();
+  });
+
+  it('does not render an Escalate button', async () => {
+    // arrange
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    setupHandler([createStuckPayment({ transaction_ref: 'TXN-NO-ESC' })]);
+    render(<StuckList />);
+
+    // act
+    const card = await screen.findByTestId('stuck-card-TXN-NO-ESC');
+    await user.click(card);
+
+    // assert
+    expect(screen.queryByText('Escalate')).not.toBeInTheDocument();
+  });
+
+  it('renders agg_stuck_withdrawals table with Trino eyebrow', async () => {
+    // arrange
+    setupHandler([createStuckPayment()]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    expect(await screen.findByText('Trino · iceberg catalog')).toBeInTheDocument();
+    expect(screen.getByText('agg_stuck_withdrawals')).toBeInTheDocument();
+  });
+
+  it('renders agg table with stuck payment data', async () => {
+    // arrange
+    setupHandler([createStuckPayment({ transaction_ref: 'TXN-AGG-001' })]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    const table = screen.getByTestId('data-table');
+    expect(await within(table).findByText('TXN-AGG-001')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no stuck payments', async () => {
+    // arrange
+    setupHandler([]);
+
+    // act
+    render(<StuckList />);
+
+    // assert
+    expect(await screen.findByText('No stuck payments')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/stuck/stuck-list.test.tsx
+++ b/apps/web/src/components/stuck/stuck-list.test.tsx
@@ -198,5 +198,6 @@ describe('StuckList', () => {
 
     // assert
     expect(await screen.findByText('No stuck payments')).toBeInTheDocument();
+    expect(screen.queryByTestId('stuck-banner')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/stuck/stuck-list.tsx
+++ b/apps/web/src/components/stuck/stuck-list.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import type { Route } from 'next';
+import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react';
+import type { ColumnConfig } from '~/components/data-table';
+import { DataTable } from '~/components/data-table';
+import { Amount } from '~/components/amount';
+import { StatusBadge } from '~/components/status-badge';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { RefundConfirmationDialog } from '~/components/stuck/refund-confirmation-dialog';
+import { useStuckList } from '~/lib/hooks/use-stuck-list';
+import type { StuckPaymentDto } from '~/types/api';
+import { cn } from '~/lib/utils';
+
+const CRITICAL_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+function isCritical(stuckSince: string): boolean {
+  return Date.now() - new Date(stuckSince).getTime() >= CRITICAL_THRESHOLD_MS;
+}
+
+type StuckRow = StuckPaymentDto & Record<string, unknown>;
+
+export function StuckList() {
+  const { data: stuckPayments, isLoading } = useStuckList();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const items = (stuckPayments ?? []) as StuckRow[];
+
+  const criticalCount = useMemo(
+    () => items.filter((p) => isCritical(p.stuck_since)).length,
+    [items],
+  );
+
+  const toggleExpanded = useCallback((ref: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(ref)) {
+        next.delete(ref);
+      } else {
+        next.add(ref);
+      }
+      return next;
+    });
+  }, []);
+
+  const tableColumns: ColumnConfig<StuckRow>[] = useMemo(
+    () => [
+      {
+        key: 'transaction_ref',
+        label: 'Transaction ref',
+        width: '22%',
+        tdClassName: 'font-mono text-[12px] text-fg-2',
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '14%',
+        render: (_: unknown, row: StuckRow) => <StatusBadge status={row.status} />,
+      },
+      {
+        key: 'amount',
+        label: 'Amount',
+        width: '16%',
+        render: (_: unknown, row: StuckRow) => (
+          <Amount value={row.amount.amount} currency={row.amount.currency} size="sm" />
+        ),
+      },
+      {
+        key: 'stuck_since',
+        label: 'Stuck since',
+        width: '20%',
+        render: (val: unknown) =>
+          new Date(val as string).toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          }),
+        tdClassName: 'text-[12px] text-fg-3',
+      },
+      {
+        key: 'stuck_reason',
+        label: 'Reason',
+        width: '28%',
+        tdClassName: 'text-[12px] text-fg-2 truncate',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="page" data-testid="stuck-list-page">
+      <div className="sp-eyebrow mb-1 text-[10px]">Admin</div>
+      <h1 className="mb-5 text-[22px] font-bold tracking-tight text-fg-1">Stuck Payments</h1>
+
+      {/* Banner */}
+      <div
+        data-testid="stuck-banner"
+        className={cn(
+          'mb-5 flex items-center gap-3 rounded-card border px-4 py-3',
+          criticalCount > 0
+            ? 'border-red-500/24 bg-red-500/10'
+            : 'border-amber-500/24 bg-amber-500/10',
+        )}
+      >
+        <AlertTriangle
+          size={16}
+          className={criticalCount > 0 ? 'text-red-400' : 'text-amber-400'}
+        />
+        <span className="text-[13px] font-medium text-fg-1">
+          {items.length} stuck payment{items.length !== 1 ? 's' : ''}
+          {criticalCount > 0 && (
+            <span className="text-red-400">
+              {' '}— {criticalCount} exceed{criticalCount === 1 ? 's' : ''} 24h threshold
+            </span>
+          )}
+        </span>
+      </div>
+
+      {/* Expandable cards */}
+      <div className="mb-6 space-y-2" data-testid="stuck-cards">
+        {items.map((payment) => {
+          const isOpen = expanded.has(payment.transaction_ref);
+          const critical = isCritical(payment.stuck_since);
+
+          return (
+            <div
+              key={payment.transaction_ref}
+              className="rounded-card border border-border-1 bg-surface-2"
+            >
+              <button
+                type="button"
+                data-testid={`stuck-card-${payment.transaction_ref}`}
+                className="flex w-full items-center justify-between px-4 py-3 text-left"
+                onClick={() => toggleExpanded(payment.transaction_ref)}
+                aria-expanded={isOpen}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-[12px] text-fg-2">
+                    {payment.transaction_ref}
+                  </span>
+                  <StatusBadge status={payment.status} />
+                  <Amount
+                    value={payment.amount.amount}
+                    currency={payment.amount.currency}
+                    size="sm"
+                  />
+                  {critical && (
+                    <Badge data-testid="critical-badge" variant="destructive">
+                      Critical
+                    </Badge>
+                  )}
+                </div>
+                {isOpen ? (
+                  <ChevronDown size={16} className="text-fg-3" />
+                ) : (
+                  <ChevronRight size={16} className="text-fg-3" />
+                )}
+              </button>
+
+              {isOpen && (
+                <div
+                  data-testid={`stuck-card-detail-${payment.transaction_ref}`}
+                  className="border-t border-border-1 px-4 py-3"
+                >
+                  <p className="mb-3 text-[12px] text-fg-3">{payment.stuck_reason}</p>
+                  <div className="flex items-center gap-2">
+                    <Link
+                      href={`/transactions/${encodeURIComponent(payment.transaction_ref)}` as Route}
+                    >
+                      <Button variant="outline" size="xs" data-testid="view-transaction-link">
+                        View transaction
+                      </Button>
+                    </Link>
+                    <RefundConfirmationDialog stuckPayment={payment} />
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {items.length === 0 && !isLoading && (
+          <div className="py-8 text-center text-[13px] text-fg-3">No stuck payments</div>
+        )}
+      </div>
+
+      {/* Agg stuck withdrawals table */}
+      <div className="sp-eyebrow mb-2 text-[10px]">Trino · iceberg catalog</div>
+      <h2 className="mb-3 text-[16px] font-semibold text-fg-1">agg_stuck_withdrawals</h2>
+      <div className="rounded-card border border-border-1 bg-surface-2">
+        <DataTable
+          columns={tableColumns}
+          rows={items}
+          emptyMessage="No stuck withdrawals"
+          loading={isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/stuck/stuck-list.tsx
+++ b/apps/web/src/components/stuck/stuck-list.tsx
@@ -97,28 +97,30 @@ export function StuckList() {
       <h1 className="mb-5 text-[22px] font-bold tracking-tight text-fg-1">Stuck Payments</h1>
 
       {/* Banner */}
-      <div
-        data-testid="stuck-banner"
-        className={cn(
-          'mb-5 flex items-center gap-3 rounded-card border px-4 py-3',
-          criticalCount > 0
-            ? 'border-red-500/24 bg-red-500/10'
-            : 'border-amber-500/24 bg-amber-500/10',
-        )}
-      >
-        <AlertTriangle
-          size={16}
-          className={criticalCount > 0 ? 'text-red-400' : 'text-amber-400'}
-        />
-        <span className="text-[13px] font-medium text-fg-1">
-          {items.length} stuck payment{items.length !== 1 ? 's' : ''}
-          {criticalCount > 0 && (
-            <span className="text-red-400">
-              {' '}— {criticalCount} exceed{criticalCount === 1 ? 's' : ''} 24h threshold
-            </span>
+      {items.length > 0 && (
+        <div
+          data-testid="stuck-banner"
+          className={cn(
+            'mb-5 flex items-center gap-3 rounded-card border px-4 py-3',
+            criticalCount > 0
+              ? 'border-red-500/24 bg-red-500/10'
+              : 'border-amber-500/24 bg-amber-500/10',
           )}
-        </span>
-      </div>
+        >
+          <AlertTriangle
+            size={16}
+            className={criticalCount > 0 ? 'text-red-400' : 'text-amber-400'}
+          />
+          <span className="text-[13px] font-medium text-fg-1">
+            {items.length} stuck payment{items.length !== 1 ? 's' : ''}
+            {criticalCount > 0 && (
+              <span className="text-red-400">
+                {' '}— {criticalCount} exceed{criticalCount === 1 ? 's' : ''} 24h threshold
+              </span>
+            )}
+          </span>
+        </div>
+      )}
 
       {/* Expandable cards */}
       <div className="mb-6 space-y-2" data-testid="stuck-cards">
@@ -137,6 +139,7 @@ export function StuckList() {
                 className="flex w-full items-center justify-between px-4 py-3 text-left"
                 onClick={() => toggleExpanded(payment.transaction_ref)}
                 aria-expanded={isOpen}
+                aria-controls={`stuck-detail-${payment.transaction_ref}`}
               >
                 <div className="flex items-center gap-3">
                   <span className="font-mono text-[12px] text-fg-2">
@@ -163,6 +166,7 @@ export function StuckList() {
 
               {isOpen && (
                 <div
+                  id={`stuck-detail-${payment.transaction_ref}`}
                   data-testid={`stuck-card-detail-${payment.transaction_ref}`}
                   className="border-t border-border-1 px-4 py-3"
                 >


### PR DESCRIPTION
## SPP Issue
Closes #123

## Changes
- Add `/admin/stuck` RSC page with prefetch + HydrationBoundary pattern (matches DLQ page)
- Add `StuckList` client component with summary banner showing total + 24h critical threshold count
- Add expandable cards per stuck payment with chevron toggle revealing reason text and action buttons
- Add critical badge (red destructive) for payments stuck >= 24h
- Add `RefundConfirmationDialog` using AlertDialog with destructive confirm flow — onConfirm stubs to `toast.info` (Phase 6 backend work)
- Add `agg_stuck_withdrawals` DataTable at bottom with "Trino · iceberg catalog" eyebrow
- No "Escalate" button rendered (out of v1 scope per UI-SPEC)
- Add skeleton loading state for stuck page
- Add 17 tests across 3 test files (page, component, dialog)

## Checklist
- [x] `vitest run` passes (391/391 tests, zero regressions)
- [x] Unit tests added (17 new tests)
- [x] Follows existing admin page patterns (DLQ page)
- [x] AlertDialog copy matches UI-SPEC Copywriting Contract
- [x] No Escalate button (v1 scope)
- [x] Refund onConfirm stubs to toast (Phase 6 deferral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)