### PR TITLE
SPP-118: add multi-tab session sync and theme toggle wiring

### DIFF
--- a/apps/web/src/app/(authed)/layout.tsx
+++ b/apps/web/src/app/(authed)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { AuthedShell } from '~/components/layout/authed-shell';
 import { LiveFeedConnector } from '~/components/layout/live-feed-connector';
+import { MultiTabSessionGuard } from '~/components/multi-tab-session-guard';
 import { QueryProvider } from '~/lib/query-client';
 import { auth } from '~/server/auth';
 
@@ -17,6 +18,7 @@ export default async function AuthedLayout({ children }: { children: React.React
 
   return (
     <QueryProvider>
+      <MultiTabSessionGuard />
       <LiveFeedConnector accessToken={session.accessToken} />
       <AuthedShell
         email={session.user.email ?? ''}

--- a/apps/web/src/components/layout/authed-shell.test.tsx
+++ b/apps/web/src/components/layout/authed-shell.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next-auth/react', () => ({
@@ -12,7 +13,11 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('~/components/layout/sidebar', () => ({
   Sidebar: (props: Record<string, unknown>) => (
-    <nav data-testid="sidebar" data-email={props.email} data-role={props.role} />
+    <nav data-testid="sidebar" data-email={props.email} data-role={props.role}>
+      <button data-testid="mock-signout" onClick={props.onSignOut as () => void} type="button">
+        Sign out
+      </button>
+    </nav>
   ),
 }));
 
@@ -22,6 +27,7 @@ vi.mock('~/components/live-feed', () => ({
   ),
 }));
 
+import { signOut } from 'next-auth/react';
 import { AuthedShell } from './authed-shell';
 
 describe('AuthedShell', () => {
@@ -85,5 +91,23 @@ describe('AuthedShell', () => {
 
     // assert
     expect(screen.getByTestId('live-feed')).toHaveAttribute('data-visible', 'true');
+  });
+
+  it('removes sp4_authed from localStorage and calls signOut on sign out', async () => {
+    // arrange
+    const user = userEvent.setup();
+    localStorage.setItem('sp4_authed', '1');
+    render(
+      <AuthedShell email="alice@stablepay.io" role="Admin" isAdmin>
+        <div>content</div>
+      </AuthedShell>,
+    );
+
+    // act
+    await user.click(screen.getByTestId('mock-signout'));
+
+    // assert
+    expect(localStorage.getItem('sp4_authed')).toBeNull();
+    expect(signOut).toHaveBeenCalledWith({ redirectTo: '/login' });
   });
 });

--- a/apps/web/src/components/layout/authed-shell.tsx
+++ b/apps/web/src/components/layout/authed-shell.tsx
@@ -52,6 +52,7 @@ export function AuthedShell({
   );
 
   const handleSignOut = useCallback(() => {
+    localStorage.removeItem('sp4_authed');
     void signOut({ redirectTo: '/login' });
   }, []);
 

--- a/apps/web/src/components/multi-tab-session-guard.test.tsx
+++ b/apps/web/src/components/multi-tab-session-guard.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockUseMultiTabSessionSync = vi.fn();
+
+vi.mock('~/lib/hooks/use-multi-tab-session-sync', () => ({
+  useMultiTabSessionSync: () => mockUseMultiTabSessionSync(),
+}));
+
+import { MultiTabSessionGuard } from './multi-tab-session-guard';
+
+describe('MultiTabSessionGuard', () => {
+  it('calls useMultiTabSessionSync and renders nothing', () => {
+    // act
+    const { container } = render(<MultiTabSessionGuard />);
+
+    // assert
+    expect(mockUseMultiTabSessionSync).toHaveBeenCalled();
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/web/src/components/multi-tab-session-guard.tsx
+++ b/apps/web/src/components/multi-tab-session-guard.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useMultiTabSessionSync } from '~/lib/hooks/use-multi-tab-session-sync';
+
+export function MultiTabSessionGuard() {
+  useMultiTabSessionSync();
+  return null;
+}

--- a/apps/web/src/lib/hooks/use-multi-tab-session-sync.test.ts
+++ b/apps/web/src/lib/hooks/use-multi-tab-session-sync.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const replaceFn = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceFn }),
+}));
+
+import { useMultiTabSessionSync } from './use-multi-tab-session-sync';
+
+describe('useMultiTabSessionSync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('sets sp4_authed flag in localStorage on mount', () => {
+    // act
+    renderHook(() => useMultiTabSessionSync());
+
+    // assert
+    expect(localStorage.getItem('sp4_authed')).toBe('1');
+  });
+
+  it('redirects to login when sp4_authed is removed via storage event', () => {
+    // arrange
+    renderHook(() => useMultiTabSessionSync());
+
+    // act
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'sp4_authed', newValue: null }),
+    );
+
+    // assert
+    expect(replaceFn).toHaveBeenCalledWith('/login?reason=signed-out-elsewhere');
+  });
+
+  it('ignores storage events for other keys', () => {
+    // arrange
+    renderHook(() => useMultiTabSessionSync());
+
+    // act
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'sp4_theme', newValue: 'light' }),
+    );
+
+    // assert
+    expect(replaceFn).not.toHaveBeenCalled();
+  });
+
+  it('ignores storage events where sp4_authed is set (not removed)', () => {
+    // arrange
+    renderHook(() => useMultiTabSessionSync());
+
+    // act
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'sp4_authed', newValue: '1' }),
+    );
+
+    // assert
+    expect(replaceFn).not.toHaveBeenCalled();
+  });
+
+  it('cleans up event listener on unmount', () => {
+    // arrange
+    const { unmount } = renderHook(() => useMultiTabSessionSync());
+
+    // act
+    unmount();
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'sp4_authed', newValue: null }),
+    );
+
+    // assert
+    expect(replaceFn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/hooks/use-multi-tab-session-sync.ts
+++ b/apps/web/src/lib/hooks/use-multi-tab-session-sync.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+const SESSION_FLAG = 'sp4_authed';
+
+export function useMultiTabSessionSync() {
+  const router = useRouter();
+
+  useEffect(() => {
+    localStorage.setItem(SESSION_FLAG, '1');
+
+    const handler = (e: StorageEvent) => {
+      if (e.key === SESSION_FLAG && e.newValue === null) {
+        router.replace('/login?reason=signed-out-elsewhere');
+      }
+    };
+
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [router]);
+}


### PR DESCRIPTION
## SPP Issue
Closes #124

## Changes
- Add `useMultiTabSessionSync` hook: sets `sp4_authed` localStorage flag on mount, listens for `storage` event removal to redirect other tabs to `/login?reason=signed-out-elsewhere`
- Add `<MultiTabSessionGuard>` client component to `(authed)/layout.tsx`
- Update `AuthedShell.handleSignOut` to call `localStorage.removeItem('sp4_authed')` before `signOut()`, triggering cross-tab redirect via the storage event
- Theme toggle already fully wired in `<ThemeSwitch>` (localStorage persistence, `prefers-color-scheme` fallback, `<html data-theme>` update) — no changes needed
- Login page already renders reason banner for `signed-out-elsewhere` — no changes needed

## Checklist
- [x] `vitest run` passes (399/399 tests, zero regressions)
- [x] Unit tests added (7 new tests across 3 files)
- [x] Follows existing (authed) layout patterns
- [x] Storage event listener cleaned up on unmount
- [x] Theme toggle verified working (existing 5 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)